### PR TITLE
ci(workflow): add backend integration and flaky tracker workflows

### DIFF
--- a/.github/workflows/ci-backend-integration.yml
+++ b/.github/workflows/ci-backend-integration.yml
@@ -1,0 +1,96 @@
+name: Backend Integration Tests
+
+on:
+  schedule:
+    # Run nightly at 2 AM UTC
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'koduck-backend/**'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'koduck-backend/**'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: backend-integration-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  integration-tests:
+    name: Integration Tests (Java 23)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: koduck
+          POSTGRES_PASSWORD: koduck_test
+          POSTGRES_DB: koduck_test
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+      redis:
+        image: redis:7-alpine
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 6379:6379
+      rabbitmq:
+        image: rabbitmq:3-alpine
+        options: >-
+          --health-cmd "rabbitmq-diagnostics -q ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5672:5672
+    env:
+      DB_HOST: localhost
+      DB_PORT: 5432
+      DB_NAME: koduck_test
+      DB_USERNAME: koduck
+      DB_PASSWORD: koduck_test
+      REDIS_HOST: localhost
+      REDIS_PORT: 6379
+      RABBITMQ_HOST: localhost
+      RABBITMQ_PORT: 5672
+      RABBITMQ_USERNAME: guest
+      RABBITMQ_PASSWORD: guest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 23
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '23'
+          cache: maven
+
+      - name: Run Integration Tests
+        working-directory: koduck-backend
+        run: mvn -B clean verify -Pwith-integration-tests
+
+      - name: Upload Integration Test Reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-test-reports-${{ github.run_id }}
+          path: |
+            koduck-backend/target/surefire-reports/
+            koduck-backend/target/failsafe-reports/
+          retention-days: 7

--- a/.github/workflows/flaky-tracker.yml
+++ b/.github/workflows/flaky-tracker.yml
@@ -1,0 +1,61 @@
+name: Flaky Tracker
+
+on:
+  schedule:
+    - cron: "0 2 * * 1"
+  workflow_dispatch:
+    inputs:
+      test_class:
+        description: "Optional test class name (e.g. UserServiceTest). Leave empty to run all."
+        required: false
+        type: string
+      runs:
+        description: "Repeat count"
+        required: false
+        default: "5"
+        type: string
+      rerun_count:
+        description: "Surefire rerunFailingTestsCount"
+        required: false
+        default: "2"
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  flaky-detection:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    defaults:
+      run:
+        working-directory: koduck-backend
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 23
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "23"
+          cache: maven
+
+      - name: Run flaky detection
+        run: |
+          set -euo pipefail
+          TEST_CLASS="${{ inputs.test_class }}"
+          RUNS="${{ inputs.runs }}"
+          RERUN="${{ inputs.rerun_count }}"
+          if [ -z "$RUNS" ]; then RUNS=5; fi
+          if [ -z "$RERUN" ]; then RERUN=2; fi
+          ./scripts/detect-flaky.sh "$TEST_CLASS" "$RUNS" "$RERUN"
+
+      - name: Upload surefire reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: flaky-tracker-surefire-${{ github.run_id }}
+          path: koduck-backend/target/surefire-reports/
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary\n- add \n- add \n\n## Why\n- unblock Phase 3 #253 evidence collection by enabling integration workflow on default branch\n- align flaky tracking workflow with #252 documentation\n\n## Validation\n- workflow files are committed and pushed on this branch