### PR TITLE
ci(integration): sync backend integration workflow key to main

### DIFF
--- a/.github/workflows/ci-backend-integration.yml
+++ b/.github/workflows/ci-backend-integration.yml
@@ -64,6 +64,7 @@ jobs:
       DB_NAME: koduck_test
       DB_USERNAME: koduck
       DB_PASSWORD: koduck_test
+      CREDENTIAL_ENCRYPTION_KEY: ci-test-credential-encryption-key-32chars
       REDIS_HOST: localhost
       REDIS_PORT: 6379
       RABBITMQ_HOST: localhost


### PR DESCRIPTION
## Summary
- sync  from dev to main
- add  for integration test context bootstrap

## Why
- unblock Issue #253 evidence collection (3 consecutive passing integration runs)
