### PR TITLE
ci(quality-gate): remove data-service test job from core CI

### DIFF
--- a/.github/workflows/ci-quality-gate.yml
+++ b/.github/workflows/ci-quality-gate.yml
@@ -45,35 +45,3 @@ jobs:
           name: backend-surefire-reports-${{ github.run_id }}
           path: koduck-backend/target/surefire-reports/
           if-no-files-found: ignore
-
-  data-service-tests:
-    name: Data Service Tests (Python 3.13)
-    runs-on: ubuntu-latest
-    timeout-minutes: 25
-    defaults:
-      run:
-        working-directory: koduck-data-service
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Python 3.13
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.13"
-          cache: pip
-          cache-dependency-path: |
-            koduck-data-service/requirements.txt
-            koduck-data-service/pyproject.toml
-
-      - name: Install dependencies
-        run: |
-          set -euo pipefail
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-
-      - name: Run data service tests
-        run: |
-          set -euo pipefail
-          pytest -q tests
-


### PR DESCRIPTION
Remove Python data-service test job from CI Quality Gate to shorten critical-path CI duration.\n\n- keep backend unit tests\n- remove data-service job from core gate\n