### PR TITLE
test(integration): stabilize db connection in CI integration runs

### DIFF
--- a/koduck-backend/src/test/java/com/koduck/AbstractIntegrationTest.java
+++ b/koduck-backend/src/test/java/com/koduck/AbstractIntegrationTest.java
@@ -4,35 +4,35 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
-import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 /**
- * （ TestContainers PostgreSQL）
+ * 共享集成测试基类：统一使用 PostgreSQL 连接配置。
  */
 @SpringBootTest
-@Testcontainers
-@ActiveProfiles("test")
+@ActiveProfiles("integration-test")
 public abstract class AbstractIntegrationTest {
-
-    @Container
-    static final PostgreSQLContainer<?> postgres = createPostgresContainer();
-
-    private static PostgreSQLContainer<?> createPostgresContainer() {
-        PostgreSQLContainer<?> container = new PostgreSQLContainer<>("postgres:15-alpine");
-        container.withDatabaseName("koduck_test");
-        container.withUsername("test");
-        container.withPassword("test");
-        return container;
-    }
 
     @DynamicPropertySource
     static void configureProperties(DynamicPropertyRegistry registry) {
-        registry.add("spring.datasource.url", postgres::getJdbcUrl);
-        registry.add("spring.datasource.username", postgres::getUsername);
-        registry.add("spring.datasource.password", postgres::getPassword);
-        registry.add("spring.datasource.driver-class-name", postgres::getDriverClassName);
+        registry.add(
+                "spring.datasource.url",
+                () ->
+                        String.format(
+                                "jdbc:postgresql://%s:%s/%s",
+                                envOrDefault("DB_HOST", "localhost"),
+                                envOrDefault("DB_PORT", "5432"),
+                                envOrDefault("DB_NAME", "koduck_test")));
+        registry.add("spring.datasource.username", () -> envOrDefault("DB_USERNAME", "koduck"));
+        registry.add("spring.datasource.password", () -> envOrDefault("DB_PASSWORD", "koduck_test"));
+        registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
         registry.add("spring.flyway.enabled", () -> "true");
+    }
+
+    private static String envOrDefault(String key, String defaultValue) {
+        String value = System.getenv(key);
+        if (value == null || value.isBlank()) {
+            return defaultValue;
+        }
+        return value;
     }
 }

--- a/koduck-backend/src/test/resources/application-integration-test.yml
+++ b/koduck-backend/src/test/resources/application-integration-test.yml
@@ -1,0 +1,35 @@
+spring:
+  datasource:
+    url: jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${DB_NAME:koduck_test}
+    username: ${DB_USERNAME:koduck}
+    password: ${DB_PASSWORD:koduck_test}
+    driver-class-name: org.postgresql.Driver
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: false
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
+    baseline-on-migrate: true
+  rabbitmq:
+    listener:
+      simple:
+        auto-startup: false
+
+jwt:
+  secret: test-secret-key-for-jwt-signing-must-be-at-least-32-characters-long
+  access-token-expiration: 3600000
+  refresh-token-expiration: 86400000
+
+credential:
+  encryption:
+    key: ${CREDENTIAL_ENCRYPTION_KEY:test-credential-encryption-key}
+
+logging:
+  level:
+    root: WARN
+    com.koduck: INFO


### PR DESCRIPTION
Summary:\n- remove Testcontainers dependency from shared integration base class\n- switch integration tests to dedicated integration-test profile using fixed PostgreSQL service env\n- add application-integration-test.yml\n\nWhy:\n- fix intermittent localhost mapped-port connection refused in CI\n- unblock Issue #253 requirement for 3 consecutive passing integration runs\n