### PR TITLE
ci(integration): skip jacoco gate for smoke workflow

### DIFF
--- a/.github/workflows/ci-backend-integration.yml
+++ b/.github/workflows/ci-backend-integration.yml
@@ -86,7 +86,8 @@ jobs:
         run: |
           set -euo pipefail
           mvn -B -f koduck-backend/pom.xml clean test \
-            -Dtest=com.koduck.integration.IntegrationSmokeTest
+            -Dtest=com.koduck.integration.IntegrationSmokeTest \
+            -Djacoco.skip=true
 
       - name: Upload Integration Test Reports
         if: always()


### PR DESCRIPTION
Summary:\n- skip jacoco check in backend integration smoke workflow\n- keep coverage gate responsibility in quality workflows\n\nWhy:\n- avoid false-negative failures in #253 smoke-evidence runs\n