### PR TITLE
fix(market): make provider registry thread-safe

### DIFF
--- a/koduck-backend/docs/ADR-0002-providerfactory-thread-safety.md
+++ b/koduck-backend/docs/ADR-0002-providerfactory-thread-safety.md
@@ -1,0 +1,49 @@
+# ADR-0002: ProviderFactory 注册表线程安全策略
+
+- Status: Accepted
+- Date: 2026-04-01
+- Issue: #294
+
+## Context
+
+`ProviderFactory` 使用 `ConcurrentHashMap<MarketType, List<MarketDataProvider>>` 管理市场与 provider 列表映射。
+原实现中，列表值为 `ArrayList`，并在 `registerProvider()` 中通过 `computeIfAbsent(...).add(...)` 进行写入。
+
+该结构在并发注册、反注册与读取（如 `getAvailableProvider()` 的遍历）并发发生时，存在可见性与迭代安全风险，可能导致：
+- 列表并发修改异常；
+- 读写竞态下状态不一致；
+- 回退选择逻辑行为不稳定。
+
+## Decision
+
+对 `providersByMarket` 的值类型改为 `CopyOnWriteArrayList`，并在对外 `getProviders()` 返回时使用只读快照（`List.copyOf`）。
+
+具体策略：
+- `registerProvider()`：`computeIfAbsent(..., k -> new CopyOnWriteArrayList<>()).add(provider)`。
+- `getProviders()`：返回不可变快照，避免外部代码直接修改内部状态。
+
+## Consequences
+
+正向影响：
+- 并发迭代与写入不再共享可变游标，降低 `ConcurrentModificationException` 风险。
+- provider 注册表语义更稳定，读操作不受并发写入影响。
+- 通过只读快照保护内部结构，减少外部误用。
+
+代价与权衡：
+- `CopyOnWriteArrayList` 写时复制带来写放大开销。
+- 适用于“读多写少”场景；若将来 provider 动态变更频繁，需要重新评估数据结构（如锁分段或无锁队列方案）。
+
+## Alternatives Considered
+
+1. `Collections.synchronizedList(new ArrayList<>())`
+- 未采用：仍需要调用方手动在遍历时加锁，易误用。
+
+2. 使用显式 `ReentrantReadWriteLock`
+- 未采用：复杂度更高，不符合本次缺陷修复的最小改动目标。
+
+3. 保持现状
+- 拒绝：无法满足并发安全要求。
+
+## Verification
+
+- 新增并发测试：在多线程下并发执行 register/unregister/read 路径，验证无异常抛出。

--- a/koduck-backend/src/main/java/com/koduck/market/provider/ProviderFactory.java
+++ b/koduck-backend/src/main/java/com/koduck/market/provider/ProviderFactory.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * Factory for managing and retrieving market data providers.
@@ -30,7 +31,7 @@ public class ProviderFactory {
         providersByName.put(providerName, provider);
         
         // Add to market map
-        providersByMarket.computeIfAbsent(marketType, k -> new ArrayList<>())
+        providersByMarket.computeIfAbsent(marketType, k -> new CopyOnWriteArrayList<>())
                         .add(provider);
         
         // Set as primary if no primary exists for this market
@@ -93,7 +94,11 @@ public class ProviderFactory {
      * @return list of providers (may be empty)
      */
     public List<MarketDataProvider> getProviders(MarketType marketType) {
-        return providersByMarket.getOrDefault(marketType, Collections.emptyList());
+        List<MarketDataProvider> providers = providersByMarket.get(marketType);
+        if (providers == null || providers.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return List.copyOf(providers);
     }
     
     /**

--- a/koduck-backend/src/test/java/com/koduck/market/provider/ProviderFactoryTest.java
+++ b/koduck-backend/src/test/java/com/koduck/market/provider/ProviderFactoryTest.java
@@ -7,6 +7,11 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -157,6 +162,50 @@ class ProviderFactoryTest {
         assertNotNull(health);
         assertEquals(MarketType.A_SHARE, health.marketType());
         assertTrue(health.isPrimary());
+    }
+
+    @Test
+    void testConcurrentRegisterUnregisterAndReadShouldNotThrow() throws InterruptedException {
+        int workers = 12;
+        int iterations = 150;
+        ExecutorService executorService = Executors.newFixedThreadPool(workers);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(workers);
+        ConcurrentLinkedQueue<Throwable> errors = new ConcurrentLinkedQueue<>();
+
+        for (int i = 0; i < workers; i++) {
+            int workerIndex = i;
+            executorService.submit(() -> {
+                try {
+                    startLatch.await();
+                    for (int round = 0; round < iterations; round++) {
+                        String providerName = "concurrent-" + workerIndex + "-" + round;
+                        MarketDataProvider provider = createMockProvider(providerName, MarketType.A_SHARE);
+                        factory.registerProvider(provider);
+
+                        // Exercise concurrent iteration paths while mutation is happening.
+                        factory.getAvailableProvider(MarketType.A_SHARE);
+                        factory.getProviders(MarketType.A_SHARE);
+                        factory.getProviderHealthSummary();
+
+                        factory.unregisterProvider(providerName);
+                    }
+                } catch (Throwable throwable) {
+                    errors.add(throwable);
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+        }
+
+        startLatch.countDown();
+        assertTrue(doneLatch.await(20, TimeUnit.SECONDS), "Concurrent tasks did not finish in time");
+        executorService.shutdownNow();
+
+        if (!errors.isEmpty()) {
+            Throwable firstError = errors.peek();
+            fail("Concurrent provider operations should not throw, but got: " + firstError, firstError);
+        }
     }
     
     /**


### PR DESCRIPTION
## Summary
- make `ProviderFactory` market-provider registry list thread-safe using `CopyOnWriteArrayList`
- keep concurrent map structure but remove unsafe `ArrayList` mutation path in `registerProvider`
- return immutable snapshot in `getProviders()` via `List.copyOf(...)` to prevent external mutation of internal state
- add concurrent unit test covering register/unregister/read interleaving
- add ADR documenting thread-safety decision and trade-offs

## Issue
Closes #294

## Key Change
- `providersByMarket.computeIfAbsent(marketType, k -> new CopyOnWriteArrayList<>()).add(provider)`

## Tests
- Added concurrency test in `ProviderFactoryTest`:
  - `testConcurrentRegisterUnregisterAndReadShouldNotThrow`

## Verification Notes
- `mvn -DskipTests compile`: passed
- `mvn -Dtest=ProviderFactoryTest test`: blocked by unrelated pre-existing test compile errors in `src/test/java/com/koduck/fixtures/StockFixtures.java` (builder methods `highPrice`/`exchange` not found)

## Risks
- `CopyOnWriteArrayList` has write amplification cost; acceptable for current read-heavy/rare-registration usage.
