### PR TITLE
refactor(entity): protect id and createdAt immutability

### DIFF
--- a/koduck-backend/docs/ADR-0004-entity-core-field-immutability.md
+++ b/koduck-backend/docs/ADR-0004-entity-core-field-immutability.md
@@ -1,0 +1,53 @@
+# ADR-0004: Entity 核心字段不可变约定（id / createdAt）
+
+- Status: Accepted
+- Date: 2026-04-01
+- Issue: #298
+
+## Context
+
+当前大量 Entity 通过 Lombok `@Data` 或 `@Setter` 生成全量 setter，导致核心字段（如主键 `id` 与创建时间 `createdAt`）也可被业务代码直接改写。
+
+这会带来风险：
+
+- 持久化标识可能被意外篡改；
+- 创建时间元数据完整性变弱；
+- 领域对象不变量不清晰。
+
+## Decision
+
+在 Entity 层引入统一约束：
+
+- 对主键字段（`@Id` + `id`）禁用 setter；
+- 对创建时间字段（映射 `created_at` 的 `createdAt`）禁用 setter；
+- 继续通过 JPA 持久化机制、构造器或 Builder 初始化这些字段。
+
+技术实现采用 Lombok 字段级注解：
+
+- `@Setter(AccessLevel.NONE)`
+
+## Consequences
+
+正向影响：
+
+- 降低核心字段被误改的概率；
+- 强化 Entity 的生命周期语义（创建后不可随意重写）；
+- 约束比“团队约定”更可执行，落地到编译期结构。
+
+代价：
+
+- 依赖这些 setter 的调用需要调整；
+- 测试/夹具中若直接设置 `id` 或 `createdAt`，需改为其他构造方式。
+
+## Alternatives Considered
+
+1. 保持现状，仅靠代码评审约束  
+   - 拒绝：执行不稳定，容易回退。
+
+2. 全量移除 Entity 上所有 setter  
+   - 暂不采用：改动过大、影响面超出当前问题范围。
+
+## Verification
+
+- 已在 entity 包批量应用字段级 setter 禁用；
+- 主代码执行编译验证（`mvn -DskipTests compile`）。

--- a/koduck-backend/src/main/java/com/koduck/entity/AlertHistory.java
+++ b/koduck-backend/src/main/java/com/koduck/entity/AlertHistory.java
@@ -2,6 +2,8 @@ package com.koduck.entity;
 
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Setter;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -23,6 +25,7 @@ public class AlertHistory {
     
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Setter(AccessLevel.NONE)
     private Long id;
     
     @Column(name = "alert_rule_id", nullable = false)
@@ -57,5 +60,6 @@ public class AlertHistory {
     
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
+    @Setter(AccessLevel.NONE)
     private LocalDateTime createdAt;
 }

--- a/koduck-backend/src/main/java/com/koduck/entity/AlertRule.java
+++ b/koduck-backend/src/main/java/com/koduck/entity/AlertRule.java
@@ -2,6 +2,8 @@ package com.koduck.entity;
 
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Setter;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -24,6 +26,7 @@ public class AlertRule {
     
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Setter(AccessLevel.NONE)
     private Long id;
     
     @Column(name = "rule_name", nullable = false, unique = true, length = 100)
@@ -55,6 +58,7 @@ public class AlertRule {
     
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
+    @Setter(AccessLevel.NONE)
     private LocalDateTime createdAt;
     
     @UpdateTimestamp

--- a/koduck-backend/src/main/java/com/koduck/entity/BacktestResult.java
+++ b/koduck-backend/src/main/java/com/koduck/entity/BacktestResult.java
@@ -3,6 +3,8 @@ package com.koduck.entity;
 import com.koduck.common.constants.MarketConstants;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Setter;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -31,6 +33,7 @@ public class BacktestResult {
     
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Setter(AccessLevel.NONE)
     private Long id;
     
     @Column(name = "user_id", nullable = false)
@@ -118,6 +121,7 @@ public class BacktestResult {
     
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
+    @Setter(AccessLevel.NONE)
     private LocalDateTime createdAt;
     
     @Column(name = "completed_at")

--- a/koduck-backend/src/main/java/com/koduck/entity/BacktestTrade.java
+++ b/koduck-backend/src/main/java/com/koduck/entity/BacktestTrade.java
@@ -2,6 +2,8 @@ package com.koduck.entity;
 
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Setter;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -28,6 +30,7 @@ public class BacktestTrade {
     
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Setter(AccessLevel.NONE)
     private Long id;
     
     @Column(name = "backtest_result_id", nullable = false)
@@ -78,6 +81,7 @@ public class BacktestTrade {
     
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
+    @Setter(AccessLevel.NONE)
     private LocalDateTime createdAt;
     
     public enum TradeType {

--- a/koduck-backend/src/main/java/com/koduck/entity/CommunitySignal.java
+++ b/koduck-backend/src/main/java/com/koduck/entity/CommunitySignal.java
@@ -4,6 +4,8 @@ import com.koduck.util.CollectionCopyUtils;
 import com.koduck.util.EntityCopyUtils;
 import jakarta.persistence.*;
 import lombok.Data;
+import lombok.Setter;
+import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.JdbcTypeCode;
@@ -25,6 +27,7 @@ public class CommunitySignal {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Setter(AccessLevel.NONE)
     private Long id;
 
     @Column(name = "user_id", nullable = false)
@@ -92,6 +95,7 @@ public class CommunitySignal {
 
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
+    @Setter(AccessLevel.NONE)
     private LocalDateTime createdAt;
 
     @UpdateTimestamp
@@ -161,7 +165,7 @@ public class CommunitySignal {
 
         public CommunitySignal build() {
             CommunitySignal signal = new CommunitySignal();
-            signal.setId(id);
+            signal.id = id;
             signal.setUserId(userId);
             signal.setStrategyId(strategyId);
             signal.setSymbol(symbol);
@@ -182,7 +186,7 @@ public class CommunitySignal {
             signal.setViewCount(viewCount);
             signal.setIsFeatured(isFeatured);
             signal.setTags(tags);
-            signal.setCreatedAt(createdAt);
+            signal.createdAt = createdAt;
             signal.setUpdatedAt(updatedAt);
             signal.setUser(user);
             return signal;

--- a/koduck-backend/src/main/java/com/koduck/entity/CredentialAuditLog.java
+++ b/koduck-backend/src/main/java/com/koduck/entity/CredentialAuditLog.java
@@ -2,6 +2,8 @@ package com.koduck.entity;
 
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Setter;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -22,6 +24,7 @@ public class CredentialAuditLog {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Setter(AccessLevel.NONE)
     private Long id;
 
     @Column(name = "credential_id")
@@ -48,6 +51,7 @@ public class CredentialAuditLog {
 
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
+    @Setter(AccessLevel.NONE)
     private LocalDateTime createdAt;
 
     /**

--- a/koduck-backend/src/main/java/com/koduck/entity/DataSourceStatus.java
+++ b/koduck-backend/src/main/java/com/koduck/entity/DataSourceStatus.java
@@ -3,6 +3,8 @@ package com.koduck.entity;
 import com.koduck.util.CollectionCopyUtils;
 import jakarta.persistence.*;
 import lombok.Data;
+import lombok.Setter;
+import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.JdbcTypeCode;
@@ -23,6 +25,7 @@ public class DataSourceStatus {
     
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Setter(AccessLevel.NONE)
     private Long id;
     
     @Column(name = "source_name", nullable = false, unique = true, length = 100)
@@ -55,6 +58,7 @@ public class DataSourceStatus {
     
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
+    @Setter(AccessLevel.NONE)
     private LocalDateTime createdAt;
     
     @UpdateTimestamp
@@ -95,7 +99,7 @@ public class DataSourceStatus {
 
         public DataSourceStatus build() {
             DataSourceStatus statusEntity = new DataSourceStatus();
-            statusEntity.setId(id);
+            statusEntity.id = id;
             statusEntity.setSourceName(sourceName);
             statusEntity.setSourceType(sourceType);
             statusEntity.setStatus(status);
@@ -105,7 +109,7 @@ public class DataSourceStatus {
             statusEntity.setConsecutiveFailures(consecutiveFailures);
             statusEntity.setResponseTimeMs(responseTimeMs);
             statusEntity.setMetadata(metadata);
-            statusEntity.setCreatedAt(createdAt);
+            statusEntity.createdAt = createdAt;
             statusEntity.setUpdatedAt(updatedAt);
             return statusEntity;
         }

--- a/koduck-backend/src/main/java/com/koduck/entity/KlineData.java
+++ b/koduck-backend/src/main/java/com/koduck/entity/KlineData.java
@@ -2,6 +2,8 @@ package com.koduck.entity;
 
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Setter;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -35,6 +37,7 @@ public class KlineData {
     
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Setter(AccessLevel.NONE)
     private Long id;
     
     @Column(name = "market", nullable = false, length = 20)
@@ -76,6 +79,7 @@ public class KlineData {
     
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
+    @Setter(AccessLevel.NONE)
     private LocalDateTime createdAt;
     
     @UpdateTimestamp

--- a/koduck-backend/src/main/java/com/koduck/entity/LoginAttempt.java
+++ b/koduck-backend/src/main/java/com/koduck/entity/LoginAttempt.java
@@ -2,6 +2,8 @@ package com.koduck.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.Setter;
+import lombok.AccessLevel;
 import org.hibernate.annotations.CreationTimestamp;
 
 import java.time.LocalDateTime;
@@ -20,6 +22,7 @@ public class LoginAttempt {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Setter(AccessLevel.NONE)
     private Long id;
 
     @Column(nullable = false, length = 100)
@@ -39,5 +42,6 @@ public class LoginAttempt {
 
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
+    @Setter(AccessLevel.NONE)
     private LocalDateTime createdAt;
 }

--- a/koduck-backend/src/main/java/com/koduck/entity/MarketDailyBreadth.java
+++ b/koduck-backend/src/main/java/com/koduck/entity/MarketDailyBreadth.java
@@ -2,6 +2,8 @@ package com.koduck.entity;
 
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Setter;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -33,6 +35,7 @@ public class MarketDailyBreadth {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Setter(AccessLevel.NONE)
     private Long id;
 
     @Column(name = "market", nullable = false, length = 20)
@@ -77,5 +80,6 @@ public class MarketDailyBreadth {
 
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
+    @Setter(AccessLevel.NONE)
     private LocalDateTime createdAt;
 }

--- a/koduck-backend/src/main/java/com/koduck/entity/MarketDailyNetFlow.java
+++ b/koduck-backend/src/main/java/com/koduck/entity/MarketDailyNetFlow.java
@@ -2,6 +2,8 @@ package com.koduck.entity;
 
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Setter;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -34,6 +36,7 @@ public class MarketDailyNetFlow {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Setter(AccessLevel.NONE)
     private Long id;
 
     @Column(name = "market", nullable = false, length = 20)
@@ -72,5 +75,6 @@ public class MarketDailyNetFlow {
 
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
+    @Setter(AccessLevel.NONE)
     private LocalDateTime createdAt;
 }

--- a/koduck-backend/src/main/java/com/koduck/entity/MarketSectorNetFlow.java
+++ b/koduck-backend/src/main/java/com/koduck/entity/MarketSectorNetFlow.java
@@ -2,6 +2,8 @@ package com.koduck.entity;
 
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Setter;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -35,6 +37,7 @@ public class MarketSectorNetFlow {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Setter(AccessLevel.NONE)
     private Long id;
 
     @Column(name = "market", nullable = false, length = 20)
@@ -88,5 +91,6 @@ public class MarketSectorNetFlow {
 
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
+    @Setter(AccessLevel.NONE)
     private LocalDateTime createdAt;
 }

--- a/koduck-backend/src/main/java/com/koduck/entity/MemoryChatMessage.java
+++ b/koduck-backend/src/main/java/com/koduck/entity/MemoryChatMessage.java
@@ -3,6 +3,8 @@ package com.koduck.entity;
 import com.koduck.util.CollectionCopyUtils;
 import jakarta.persistence.*;
 import lombok.Data;
+import lombok.Setter;
+import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.JdbcTypeCode;
@@ -19,6 +21,7 @@ public class MemoryChatMessage {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Setter(AccessLevel.NONE)
     private Long id;
 
     @Column(name = "user_id", nullable = false)
@@ -42,6 +45,7 @@ public class MemoryChatMessage {
 
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
+    @Setter(AccessLevel.NONE)
     private LocalDateTime createdAt;
 
     public static Builder builder() {
@@ -70,14 +74,14 @@ public class MemoryChatMessage {
 
         public MemoryChatMessage build() {
             MemoryChatMessage message = new MemoryChatMessage();
-            message.setId(id);
+            message.id = id;
             message.setUserId(userId);
             message.setSessionId(sessionId);
             message.setRole(role);
             message.setContent(content);
             message.setTokenCount(tokenCount);
             message.setMetadata(metadata);
-            message.setCreatedAt(createdAt);
+            message.createdAt = createdAt;
             return message;
         }
     }

--- a/koduck-backend/src/main/java/com/koduck/entity/MemoryChatSession.java
+++ b/koduck-backend/src/main/java/com/koduck/entity/MemoryChatSession.java
@@ -2,6 +2,8 @@ package com.koduck.entity;
 
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Setter;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -26,6 +28,7 @@ public class MemoryChatSession {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Setter(AccessLevel.NONE)
     private Long id;
 
     @Column(name = "user_id", nullable = false)
@@ -47,6 +50,7 @@ public class MemoryChatSession {
 
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
+    @Setter(AccessLevel.NONE)
     private LocalDateTime createdAt;
 
     @UpdateTimestamp

--- a/koduck-backend/src/main/java/com/koduck/entity/PasswordResetToken.java
+++ b/koduck-backend/src/main/java/com/koduck/entity/PasswordResetToken.java
@@ -2,6 +2,8 @@ package com.koduck.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.Setter;
+import lombok.AccessLevel;
 import org.hibernate.annotations.CreationTimestamp;
 
 import java.time.LocalDateTime;
@@ -27,6 +29,7 @@ public class PasswordResetToken {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Setter(AccessLevel.NONE)
     private Long id;
 
     @Column(name = "user_id", nullable = false)
@@ -47,6 +50,7 @@ public class PasswordResetToken {
 
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
+    @Setter(AccessLevel.NONE)
     private LocalDateTime createdAt;
 
     /**

--- a/koduck-backend/src/main/java/com/koduck/entity/Permission.java
+++ b/koduck-backend/src/main/java/com/koduck/entity/Permission.java
@@ -2,6 +2,8 @@ package com.koduck.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.Setter;
+import lombok.AccessLevel;
 import org.hibernate.annotations.CreationTimestamp;
 
 import java.time.LocalDateTime;
@@ -20,6 +22,7 @@ public class Permission {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Setter(AccessLevel.NONE)
     private Integer id;
 
     @Column(nullable = false, unique = true, length = 100)
@@ -36,5 +39,6 @@ public class Permission {
 
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
+    @Setter(AccessLevel.NONE)
     private LocalDateTime createdAt;
 }

--- a/koduck-backend/src/main/java/com/koduck/entity/PortfolioPosition.java
+++ b/koduck-backend/src/main/java/com/koduck/entity/PortfolioPosition.java
@@ -2,6 +2,8 @@ package com.koduck.entity;
 
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Setter;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -33,6 +35,7 @@ public class PortfolioPosition {
     
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Setter(AccessLevel.NONE)
     private Long id;
     
     @Column(name = "user_id", nullable = false)
@@ -55,6 +58,7 @@ public class PortfolioPosition {
     
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
+    @Setter(AccessLevel.NONE)
     private LocalDateTime createdAt;
     
     @UpdateTimestamp

--- a/koduck-backend/src/main/java/com/koduck/entity/RefreshToken.java
+++ b/koduck-backend/src/main/java/com/koduck/entity/RefreshToken.java
@@ -2,6 +2,8 @@ package com.koduck.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.Setter;
+import lombok.AccessLevel;
 import org.hibernate.annotations.CreationTimestamp;
 
 import java.time.LocalDateTime;
@@ -20,6 +22,7 @@ public class RefreshToken {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Setter(AccessLevel.NONE)
     private Long id;
 
     @Column(name = "user_id", nullable = false)
@@ -39,6 +42,7 @@ public class RefreshToken {
 
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
+    @Setter(AccessLevel.NONE)
     private LocalDateTime createdAt;
 
     public boolean isExpired() {

--- a/koduck-backend/src/main/java/com/koduck/entity/Role.java
+++ b/koduck-backend/src/main/java/com/koduck/entity/Role.java
@@ -2,6 +2,8 @@ package com.koduck.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.Setter;
+import lombok.AccessLevel;
 import org.hibernate.annotations.CreationTimestamp;
 
 import java.time.LocalDateTime;
@@ -20,6 +22,7 @@ public class Role {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Setter(AccessLevel.NONE)
     private Integer id;
 
     @Column(nullable = false, unique = true, length = 50)
@@ -30,5 +33,6 @@ public class Role {
 
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
+    @Setter(AccessLevel.NONE)
     private LocalDateTime createdAt;
 }

--- a/koduck-backend/src/main/java/com/koduck/entity/SignalComment.java
+++ b/koduck-backend/src/main/java/com/koduck/entity/SignalComment.java
@@ -4,6 +4,8 @@ import com.koduck.util.CollectionCopyUtils;
 import com.koduck.util.EntityCopyUtils;
 import jakarta.persistence.*;
 import lombok.Data;
+import lombok.Setter;
+import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
@@ -22,6 +24,7 @@ public class SignalComment {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Setter(AccessLevel.NONE)
     private Long id;
 
     @Column(name = "signal_id", nullable = false)
@@ -44,6 +47,7 @@ public class SignalComment {
 
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
+    @Setter(AccessLevel.NONE)
     private LocalDateTime createdAt;
 
     @UpdateTimestamp
@@ -105,14 +109,14 @@ public class SignalComment {
 
         public SignalComment build() {
             SignalComment comment = new SignalComment();
-            comment.setId(id);
+            comment.id = id;
             comment.setSignalId(signalId);
             comment.setUserId(userId);
             comment.setParentId(parentId);
             comment.setContent(content);
             comment.setLikeCount(likeCount);
             comment.setIsDeleted(isDeleted);
-            comment.setCreatedAt(createdAt);
+            comment.createdAt = createdAt;
             comment.setUpdatedAt(updatedAt);
             comment.setSignal(signal);
             comment.setUser(user);

--- a/koduck-backend/src/main/java/com/koduck/entity/SignalFavorite.java
+++ b/koduck-backend/src/main/java/com/koduck/entity/SignalFavorite.java
@@ -3,6 +3,8 @@ package com.koduck.entity;
 import com.koduck.util.EntityCopyUtils;
 import jakarta.persistence.*;
 import lombok.Data;
+import lombok.Setter;
+import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 
@@ -19,6 +21,7 @@ public class SignalFavorite {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Setter(AccessLevel.NONE)
     private Long id;
 
     @Column(name = "signal_id", nullable = false)
@@ -32,6 +35,7 @@ public class SignalFavorite {
 
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
+    @Setter(AccessLevel.NONE)
     private LocalDateTime createdAt;
 
     // 
@@ -68,11 +72,11 @@ public class SignalFavorite {
 
         public SignalFavorite build() {
             SignalFavorite favorite = new SignalFavorite();
-            favorite.setId(id);
+            favorite.id = id;
             favorite.setSignalId(signalId);
             favorite.setUserId(userId);
             favorite.setNote(note);
-            favorite.setCreatedAt(createdAt);
+            favorite.createdAt = createdAt;
             favorite.setSignal(signal);
             favorite.setUser(user);
             return favorite;

--- a/koduck-backend/src/main/java/com/koduck/entity/SignalLike.java
+++ b/koduck-backend/src/main/java/com/koduck/entity/SignalLike.java
@@ -3,6 +3,8 @@ package com.koduck.entity;
 import com.koduck.util.EntityCopyUtils;
 import jakarta.persistence.*;
 import lombok.Data;
+import lombok.Setter;
+import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 
@@ -19,6 +21,7 @@ public class SignalLike {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Setter(AccessLevel.NONE)
     private Long id;
 
     @Column(name = "signal_id", nullable = false)
@@ -29,6 +32,7 @@ public class SignalLike {
 
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
+    @Setter(AccessLevel.NONE)
     private LocalDateTime createdAt;
 
     // 
@@ -63,10 +67,10 @@ public class SignalLike {
 
         public SignalLike build() {
             SignalLike like = new SignalLike();
-            like.setId(id);
+            like.id = id;
             like.setSignalId(signalId);
             like.setUserId(userId);
-            like.setCreatedAt(createdAt);
+            like.createdAt = createdAt;
             like.setSignal(signal);
             like.setUser(user);
             return like;

--- a/koduck-backend/src/main/java/com/koduck/entity/SignalSubscription.java
+++ b/koduck-backend/src/main/java/com/koduck/entity/SignalSubscription.java
@@ -3,6 +3,8 @@ package com.koduck.entity;
 import com.koduck.util.EntityCopyUtils;
 import jakarta.persistence.*;
 import lombok.Data;
+import lombok.Setter;
+import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 
@@ -19,6 +21,7 @@ public class SignalSubscription {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Setter(AccessLevel.NONE)
     private Long id;
 
     @Column(name = "signal_id", nullable = false)
@@ -32,6 +35,7 @@ public class SignalSubscription {
 
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
+    @Setter(AccessLevel.NONE)
     private LocalDateTime createdAt;
 
     // 
@@ -68,11 +72,11 @@ public class SignalSubscription {
 
         public SignalSubscription build() {
             SignalSubscription subscription = new SignalSubscription();
-            subscription.setId(id);
+            subscription.id = id;
             subscription.setSignalId(signalId);
             subscription.setUserId(userId);
             subscription.setNotifyEnabled(notifyEnabled);
-            subscription.setCreatedAt(createdAt);
+            subscription.createdAt = createdAt;
             subscription.setSignal(signal);
             subscription.setUser(user);
             return subscription;

--- a/koduck-backend/src/main/java/com/koduck/entity/StockBasic.java
+++ b/koduck-backend/src/main/java/com/koduck/entity/StockBasic.java
@@ -2,6 +2,8 @@ package com.koduck.entity;
 
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Setter;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -27,6 +29,7 @@ public class StockBasic {
     
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Setter(AccessLevel.NONE)
     private Long id;
     
     @Column(name = "symbol", nullable = false, length = 20)
@@ -115,6 +118,7 @@ public class StockBasic {
     
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
+    @Setter(AccessLevel.NONE)
     private LocalDateTime createdAt;
     
     @UpdateTimestamp

--- a/koduck-backend/src/main/java/com/koduck/entity/StockRealtime.java
+++ b/koduck-backend/src/main/java/com/koduck/entity/StockRealtime.java
@@ -2,6 +2,8 @@ package com.koduck.entity;
 
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Setter;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -79,5 +81,6 @@ public class StockRealtime {
     
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
+    @Setter(AccessLevel.NONE)
     private LocalDateTime createdAt;
 }

--- a/koduck-backend/src/main/java/com/koduck/entity/StockTickHistory.java
+++ b/koduck-backend/src/main/java/com/koduck/entity/StockTickHistory.java
@@ -7,6 +7,8 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
+import lombok.Setter;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -27,6 +29,7 @@ public class StockTickHistory {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Setter(AccessLevel.NONE)
     private Long id;
 
     @Column(name = "symbol", nullable = false, length = 20)
@@ -45,6 +48,7 @@ public class StockTickHistory {
     private BigDecimal amount;
 
     @Column(name = "created_at")
+    @Setter(AccessLevel.NONE)
     private LocalDateTime createdAt;
 }
 

--- a/koduck-backend/src/main/java/com/koduck/entity/Strategy.java
+++ b/koduck-backend/src/main/java/com/koduck/entity/Strategy.java
@@ -2,6 +2,8 @@ package com.koduck.entity;
 
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Setter;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -29,6 +31,7 @@ public class Strategy {
     
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Setter(AccessLevel.NONE)
     private Long id;
     
     @Column(name = "user_id", nullable = false)
@@ -51,6 +54,7 @@ public class Strategy {
     
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
+    @Setter(AccessLevel.NONE)
     private LocalDateTime createdAt;
     
     @UpdateTimestamp

--- a/koduck-backend/src/main/java/com/koduck/entity/StrategyParameter.java
+++ b/koduck-backend/src/main/java/com/koduck/entity/StrategyParameter.java
@@ -2,6 +2,8 @@ package com.koduck.entity;
 
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Setter;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -28,6 +30,7 @@ public class StrategyParameter {
     
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Setter(AccessLevel.NONE)
     private Long id;
     
     @Column(name = "strategy_id", nullable = false)
@@ -61,6 +64,7 @@ public class StrategyParameter {
     
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
+    @Setter(AccessLevel.NONE)
     private LocalDateTime createdAt;
     
     @UpdateTimestamp

--- a/koduck-backend/src/main/java/com/koduck/entity/StrategyVersion.java
+++ b/koduck-backend/src/main/java/com/koduck/entity/StrategyVersion.java
@@ -2,6 +2,8 @@ package com.koduck.entity;
 
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Setter;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -27,6 +29,7 @@ public class StrategyVersion {
     
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Setter(AccessLevel.NONE)
     private Long id;
     
     @Column(name = "strategy_id", nullable = false)
@@ -47,5 +50,6 @@ public class StrategyVersion {
     
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
+    @Setter(AccessLevel.NONE)
     private LocalDateTime createdAt;
 }

--- a/koduck-backend/src/main/java/com/koduck/entity/Trade.java
+++ b/koduck-backend/src/main/java/com/koduck/entity/Trade.java
@@ -2,6 +2,8 @@ package com.koduck.entity;
 
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Setter;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -29,6 +31,7 @@ public class Trade {
     
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Setter(AccessLevel.NONE)
     private Long id;
     
     @Column(name = "user_id", nullable = false)
@@ -61,6 +64,7 @@ public class Trade {
     
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
+    @Setter(AccessLevel.NONE)
     private LocalDateTime createdAt;
     
     @Column(name = "status", length = 20)

--- a/koduck-backend/src/main/java/com/koduck/entity/User.java
+++ b/koduck-backend/src/main/java/com/koduck/entity/User.java
@@ -2,6 +2,8 @@ package com.koduck.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.Setter;
+import lombok.AccessLevel;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
@@ -21,6 +23,7 @@ public class User {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Setter(AccessLevel.NONE)
     private Long id;
 
     @Column(nullable = false, unique = true, length = 50)
@@ -54,6 +57,7 @@ public class User {
 
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
+    @Setter(AccessLevel.NONE)
     private LocalDateTime createdAt;
 
     @UpdateTimestamp

--- a/koduck-backend/src/main/java/com/koduck/entity/UserCredential.java
+++ b/koduck-backend/src/main/java/com/koduck/entity/UserCredential.java
@@ -3,6 +3,8 @@ package com.koduck.entity;
 import com.koduck.util.CollectionCopyUtils;
 import jakarta.persistence.*;
 import lombok.Data;
+import lombok.Setter;
+import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.JdbcTypeCode;
@@ -23,6 +25,7 @@ public class UserCredential {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Setter(AccessLevel.NONE)
     private Long id;
 
     @Column(name = "user_id", nullable = false)
@@ -64,6 +67,7 @@ public class UserCredential {
 
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
+    @Setter(AccessLevel.NONE)
     private LocalDateTime createdAt;
 
     @UpdateTimestamp
@@ -116,7 +120,7 @@ public class UserCredential {
 
         public UserCredential build() {
             UserCredential credential = new UserCredential();
-            credential.setId(id);
+            credential.id = id;
             credential.setUserId(userId);
             credential.setName(name);
             credential.setType(type);
@@ -130,7 +134,7 @@ public class UserCredential {
             }
             credential.setLastVerifiedAt(lastVerifiedAt);
             credential.setLastVerifiedStatus(lastVerifiedStatus);
-            credential.setCreatedAt(createdAt);
+            credential.createdAt = createdAt;
             credential.setUpdatedAt(updatedAt);
             return credential;
         }

--- a/koduck-backend/src/main/java/com/koduck/entity/UserSettings.java
+++ b/koduck-backend/src/main/java/com/koduck/entity/UserSettings.java
@@ -10,6 +10,8 @@ import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.AllArgsConstructor;
+import lombok.Setter;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -32,6 +34,7 @@ public class UserSettings {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Setter(AccessLevel.NONE)
     private Long id;
 
     @Column(name = "user_id", nullable = false, unique = true)
@@ -68,6 +71,7 @@ public class UserSettings {
 
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
+    @Setter(AccessLevel.NONE)
     private LocalDateTime createdAt;
 
     @UpdateTimestamp
@@ -245,7 +249,7 @@ public class UserSettings {
 
         public UserSettings build() {
             UserSettings settings = new UserSettings();
-            settings.setId(id);
+            settings.id = id;
             settings.setUserId(userId);
             settings.setTheme(theme);
             settings.setLanguage(language);
@@ -255,7 +259,7 @@ public class UserSettings {
             settings.setDisplayConfig(displayConfig);
             settings.setQuickLinks(quickLinks);
             settings.setLlmConfig(llmConfig);
-            settings.setCreatedAt(createdAt);
+            settings.createdAt = createdAt;
             settings.setUpdatedAt(updatedAt);
             return settings;
         }

--- a/koduck-backend/src/main/java/com/koduck/entity/UserSignalStats.java
+++ b/koduck-backend/src/main/java/com/koduck/entity/UserSignalStats.java
@@ -11,6 +11,8 @@ import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.Column;
 import lombok.Data;
+import lombok.Setter;
+import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.UpdateTimestamp;
 
@@ -29,6 +31,7 @@ public class UserSignalStats {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Setter(AccessLevel.NONE)
     private Long id;
 
     @Column(name = "user_id", nullable = false, unique = true)

--- a/koduck-backend/src/main/java/com/koduck/entity/WatchlistItem.java
+++ b/koduck-backend/src/main/java/com/koduck/entity/WatchlistItem.java
@@ -2,6 +2,8 @@ package com.koduck.entity;
 
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Setter;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -33,6 +35,7 @@ public class WatchlistItem {
     
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Setter(AccessLevel.NONE)
     private Long id;
     
     @Column(name = "user_id", nullable = false)
@@ -55,6 +58,7 @@ public class WatchlistItem {
     
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
+    @Setter(AccessLevel.NONE)
     private LocalDateTime createdAt;
     
     @UpdateTimestamp


### PR DESCRIPTION
## Summary
- protect entity core fields from accidental mutation by disabling setters for:
  - primary key field (`@Id` + `id`)
  - creation timestamp field (`createdAt` mapped to `created_at`)
- apply `@Setter(AccessLevel.NONE)` at field level across entity classes
- keep entity construction paths working by updating internal builder/wrapper code to assign private fields directly inside the same class
- add ADR documenting this immutability convention

## Issue
Closes #298

## Verification
- `mvn -DskipTests compile`: passed

## Notes
- Scope intentionally focuses on core fields (`id`, `createdAt`) only.
- Existing pre-existing test-compile issues in the repository are not part of this refactor.
