### PR TITLE
perf(jpa): mitigate community signal N+1 query risk

### DIFF
--- a/koduck-backend/docs/ADR-0006-community-signal-n-plus-one-mitigation.md
+++ b/koduck-backend/docs/ADR-0006-community-signal-n-plus-one-mitigation.md
@@ -1,0 +1,55 @@
+# ADR-0006: 社区信号查询链路 N+1 风险治理（EntityGraph 预加载）
+
+- Status: Accepted
+- Date: 2026-04-01
+- Issue: #302
+
+## Context
+
+社区信号列表/详情读取路径中，`CommunitySignalResponseAssembler` 在组装 DTO 时对每条
+`CommunitySignal` 执行一次 `userRepository.findById(...)`。当返回 N 条信号时，会出现
+“1 次主查询 + N 次用户查询”的访问模式，存在典型 N+1 查询风险。
+
+该问题在如下读取场景最明显：
+
+- 信号列表：按状态、热门、symbol/type 过滤查询；
+- 精选信号列表；
+- 用户发布信号列表；
+- 信号详情。
+
+## Decision
+
+采用 JPA `@EntityGraph(attributePaths = "user")` 在 `CommunitySignalRepository` 的关键读取方法中预加载 `user` 关联，并在组装器中优先使用 `signal.getUser()`。
+
+具体执行：
+
+- 为 `CommunitySignalRepository` 的核心读方法添加 `@EntityGraph(attributePaths = "user")`；
+- 覆盖 `findById` 并加 `@EntityGraph(attributePaths = "user")`；
+- 在 `CommunitySignalResponseAssembler.toSignalResponse` 中优先读取已加载的 `signal.user`，仅在缺失时兜底查询。
+
+## Consequences
+
+正向影响：
+
+- 列表读取场景显著降低额外用户查询次数；
+- 在保持 API 行为不变前提下提升查询效率；
+- 方案局部、低风险，便于快速落地。
+
+代价：
+
+- Repository 查询声明增加，维护时需注意 EntityGraph 覆盖范围；
+- 仍存在非 signal 路径的潜在 N+1（例如评论/订阅组装）需后续分批治理。
+
+## Alternatives Considered
+
+1. 在 Service 层批量预查询用户并手工映射  
+   - 暂不采用：实现分散，重复逻辑较多。
+
+2. 保持现状，仅依赖缓存缓解  
+   - 拒绝：不能从查询结构上根治 N+1。
+
+## Verification
+
+- `CommunitySignalRepository` 关键读取方法已添加 `@EntityGraph(attributePaths = "user")`；
+- `CommunitySignalResponseAssembler` 已优先使用 `signal.getUser()`；
+- 编译验证通过：`mvn -DskipTests compile -f koduck-backend/pom.xml`。

--- a/koduck-backend/src/main/java/com/koduck/repository/CommunitySignalRepository.java
+++ b/koduck-backend/src/main/java/com/koduck/repository/CommunitySignalRepository.java
@@ -4,6 +4,7 @@ import com.koduck.entity.CommunitySignal;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -21,38 +22,52 @@ public interface CommunitySignalRepository extends JpaRepository<CommunitySignal
     /**
      *  ID 
      */
+    @EntityGraph(attributePaths = "user")
     Page<CommunitySignal> findByUserId(Long userId, Pageable pageable);
 
     /**
      * 
      */
+    @EntityGraph(attributePaths = "user")
     Page<CommunitySignal> findByStatus(CommunitySignal.Status status, Pageable pageable);
 
     /**
      * 
      */
+    @EntityGraph(attributePaths = "user")
     Page<CommunitySignal> findByIsFeaturedTrueAndStatus(Pageable pageable, CommunitySignal.Status status);
 
     /**
      * 
      */
+    @EntityGraph(attributePaths = "user")
     Page<CommunitySignal> findBySymbolContainingAndStatus(String symbol, CommunitySignal.Status status, Pageable pageable);
 
     /**
      * 
      */
+    @EntityGraph(attributePaths = "user")
     Page<CommunitySignal> findBySignalTypeAndStatus(CommunitySignal.SignalType signalType, CommunitySignal.Status status, Pageable pageable);
 
     /**
      * （）
      */
+    @EntityGraph(attributePaths = "user")
     @Query("SELECT s FROM CommunitySignal s WHERE s.status = :status ORDER BY (s.likeCount + s.subscribeCount * 2 + s.commentCount * 3) DESC")
     Page<CommunitySignal> findHotSignals(@Param("status") CommunitySignal.Status status, Pageable pageable);
 
     /**
      * 
      */
+    @EntityGraph(attributePaths = "user")
     List<CommunitySignal> findByUserIdOrderByCreatedAtDesc(Long userId);
+
+    /**
+     * 详情查询预加载 user，避免组装阶段触发额外查询。
+     */
+    @Override
+    @EntityGraph(attributePaths = "user")
+    java.util.Optional<CommunitySignal> findById(Long id);
 
     /**
      * 

--- a/koduck-backend/src/main/java/com/koduck/service/support/CommunitySignalResponseAssembler.java
+++ b/koduck-backend/src/main/java/com/koduck/service/support/CommunitySignalResponseAssembler.java
@@ -31,8 +31,7 @@ public class CommunitySignalResponseAssembler {
             Set<Long> likedSignalIds,
             Set<Long> favoritedSignalIds,
             Set<Long> subscribedSignalIds) {
-        User user = userRepository.findById(Objects.requireNonNull(signal.getUserId(), "signal userId must not be null"))
-            .orElse(null);
+        User user = resolveSignalUser(signal);
         return SignalResponse.builder()
             .id(signal.getId())
             .userId(signal.getUserId())
@@ -63,6 +62,16 @@ public class CommunitySignalResponseAssembler {
             .createdAt(signal.getCreatedAt())
             .updatedAt(signal.getUpdatedAt())
             .build();
+    }
+
+    private User resolveSignalUser(CommunitySignal signal) {
+        Objects.requireNonNull(signal, "signal must not be null");
+        User user = signal.getUser();
+        if (user != null) {
+            return user;
+        }
+        Long userId = Objects.requireNonNull(signal.getUserId(), "signal userId must not be null");
+        return userRepository.findById(userId).orElse(null);
     }
 
     public SignalSubscriptionResponse toSubscriptionResponse(SignalSubscription subscription, CommunitySignal signal) {


### PR DESCRIPTION
## Summary
- add EntityGraph(user) to key CommunitySignalRepository read methods to avoid per-row lazy user fetch
- override findById with EntityGraph(user) for detail path consistency
- update CommunitySignalResponseAssembler to prefer signal.user and only fallback query when missing
- add ADR-0006 under koduck-backend/docs

## Verification
- mvn -DskipTests compile -f koduck-backend/pom.xml

Issue: #302