### PR TITLE
refactor(cache): unify cache strategy via cache layer abstraction

### DIFF
--- a/koduck-backend/docs/ADR-0007-cache-layer-abstraction.md
+++ b/koduck-backend/docs/ADR-0007-cache-layer-abstraction.md
@@ -1,0 +1,57 @@
+# ADR-0007: 统一缓存访问抽象层（CacheLayer）
+
+- Status: Accepted
+- Date: 2026-04-01
+- Issue: #304
+
+## Context
+
+当前缓存策略在多个服务实现中分散：
+
+- `UserCacheServiceImpl` 与 `StockCacheServiceImpl` 都直接依赖 `RedisTemplate`
+- key 删除、集合替换、列表替换、TTL 设置等底层模式重复出现
+- 异常处理和参数校验逻辑分散，维护时容易产生不一致
+
+在不改变业务接口的前提下，需要建立统一缓存访问层来收敛实现细节。
+
+## Decision
+
+引入统一缓存抽象 `CacheLayer`，并提供 Redis 实现 `RedisCacheLayer`，统一承载：
+
+- value 读写（含 TTL）
+- key 删除与存在性判断
+- set/list 的替换和读取操作
+
+然后将以下服务迁移为依赖 `CacheLayer`：
+
+- `UserCacheServiceImpl`
+- `StockCacheServiceImpl`
+
+保留现有服务接口和 key 规则，确保上层调用无感知。
+
+## Consequences
+
+正向影响：
+
+- 缓存底层操作集中，减少重复代码；
+- 缓存策略更一致，后续维护成本下降；
+- 后续若切换缓存实现或统一监控/熔断策略，改动面更小。
+
+代价：
+
+- 增加一层抽象，初期阅读链路略变长；
+- 需要在新增缓存场景中遵循抽象层而非直接注入 `RedisTemplate`。
+
+## Alternatives Considered
+
+1. 保持现状，分别维护多个 CacheService 实现  
+   - 拒绝：重复逻辑持续增长，策略一致性难保障。
+
+2. 全量切换到 Spring Cache 注解统一管理  
+   - 暂不采用：当前存在集合结构与细粒度 key 操作，迁移成本和风险较高。
+
+## Verification
+
+- 新增 `CacheLayer` 与 `RedisCacheLayer`；
+- `UserCacheServiceImpl` 与 `StockCacheServiceImpl` 已迁移到抽象层；
+- 编译验证通过：`mvn -DskipTests compile -f koduck-backend/pom.xml`。

--- a/koduck-backend/src/main/java/com/koduck/service/cache/CacheLayer.java
+++ b/koduck-backend/src/main/java/com/koduck/service/cache/CacheLayer.java
@@ -1,0 +1,31 @@
+package com.koduck.service.cache;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Unified cache abstraction for low-level key/value and collection operations.
+ */
+public interface CacheLayer {
+
+    void setValue(String key, Object value, long ttlSeconds);
+
+    Object getValue(String key);
+
+    void delete(String key);
+
+    boolean hasKey(String key);
+
+    void addSetMember(String key, Object member);
+
+    void removeSetMember(String key, Object member);
+
+    Set<Object> getSetMembers(String key);
+
+    void replaceSet(String key, Collection<?> members);
+
+    void replaceList(String key, Collection<?> values, long ttlSeconds);
+
+    List<Object> getListRange(String key, long start, long end);
+}

--- a/koduck-backend/src/main/java/com/koduck/service/cache/RedisCacheLayer.java
+++ b/koduck-backend/src/main/java/com/koduck/service/cache/RedisCacheLayer.java
@@ -1,0 +1,107 @@
+package com.koduck.service.cache;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * Redis-backed implementation of {@link CacheLayer}.
+ */
+@Component
+public class RedisCacheLayer implements CacheLayer {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public RedisCacheLayer(RedisTemplate<String, Object> redisTemplate) {
+        this.redisTemplate = Objects.requireNonNull(redisTemplate, "redisTemplate must not be null");
+    }
+
+    @Override
+    public void setValue(String key, Object value, long ttlSeconds) {
+        redisTemplate.opsForValue().set(
+                Objects.requireNonNull(key, "key must not be null"),
+                Objects.requireNonNull(value, "value must not be null"),
+                ttlSeconds,
+                TimeUnit.SECONDS
+        );
+    }
+
+    @Override
+    public Object getValue(String key) {
+        return redisTemplate.opsForValue().get(Objects.requireNonNull(key, "key must not be null"));
+    }
+
+    @Override
+    public void delete(String key) {
+        redisTemplate.delete(Objects.requireNonNull(key, "key must not be null"));
+    }
+
+    @Override
+    public boolean hasKey(String key) {
+        Boolean exists = redisTemplate.hasKey(Objects.requireNonNull(key, "key must not be null"));
+        return Boolean.TRUE.equals(exists);
+    }
+
+    @Override
+    public void addSetMember(String key, Object member) {
+        redisTemplate.opsForSet().add(
+                Objects.requireNonNull(key, "key must not be null"),
+                Objects.requireNonNull(member, "member must not be null")
+        );
+    }
+
+    @Override
+    public void removeSetMember(String key, Object member) {
+        redisTemplate.opsForSet().remove(
+                Objects.requireNonNull(key, "key must not be null"),
+                Objects.requireNonNull(member, "member must not be null")
+        );
+    }
+
+    @Override
+    public Set<Object> getSetMembers(String key) {
+        return redisTemplate.opsForSet().members(Objects.requireNonNull(key, "key must not be null"));
+    }
+
+    @Override
+    public void replaceSet(String key, Collection<?> members) {
+        String nonNullKey = Objects.requireNonNull(key, "key must not be null");
+        redisTemplate.delete(nonNullKey);
+        if (members == null || members.isEmpty()) {
+            return;
+        }
+        for (Object member : members) {
+            if (member != null) {
+                redisTemplate.opsForSet().add(nonNullKey, member);
+            }
+        }
+    }
+
+    @Override
+    public void replaceList(String key, Collection<?> values, long ttlSeconds) {
+        String nonNullKey = Objects.requireNonNull(key, "key must not be null");
+        redisTemplate.delete(nonNullKey);
+        if (values == null || values.isEmpty()) {
+            return;
+        }
+        Object[] valueArray = values.stream().filter(Objects::nonNull).toArray();
+        if (valueArray.length == 0) {
+            return;
+        }
+        redisTemplate.opsForList().rightPushAll(nonNullKey, valueArray);
+        redisTemplate.expire(nonNullKey, ttlSeconds, TimeUnit.SECONDS);
+    }
+
+    @Override
+    public List<Object> getListRange(String key, long start, long end) {
+        return redisTemplate.opsForList().range(
+                Objects.requireNonNull(key, "key must not be null"),
+                start,
+                end
+        );
+    }
+}

--- a/koduck-backend/src/main/java/com/koduck/service/impl/StockCacheServiceImpl.java
+++ b/koduck-backend/src/main/java/com/koduck/service/impl/StockCacheServiceImpl.java
@@ -2,10 +2,9 @@ package com.koduck.service.impl;
 
 import com.koduck.common.constants.RedisKeyConstants;
 import com.koduck.dto.market.PriceQuoteDto;
+import com.koduck.service.cache.CacheLayer;
 import com.koduck.service.StockCacheService;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.lang.NonNull;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
@@ -14,7 +13,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 /**
@@ -30,10 +28,10 @@ public class StockCacheServiceImpl implements StockCacheService {
     private static final String KEY_TYPE = "type";
     private static final String KEY_PRICE = "price";
     private static final String KEY_CHANGE_PERCENT = "changePercent";
-    private final RedisTemplate<String, Object> redisTemplate;
+    private final CacheLayer cacheLayer;
 
-    public StockCacheServiceImpl(RedisTemplate<String, Object> redisTemplate) {
-        this.redisTemplate = Objects.requireNonNull(redisTemplate, "redisTemplate must not be null");
+    public StockCacheServiceImpl(CacheLayer cacheLayer) {
+        this.cacheLayer = Objects.requireNonNull(cacheLayer, "cacheLayer must not be null");
     }
 
     // ==================== Stock Tracking () ====================
@@ -45,11 +43,11 @@ public class StockCacheServiceImpl implements StockCacheService {
         }
         String key = RedisKeyConstants.stockTrackKey(symbol);
         try {
-            redisTemplate.opsForValue().set(
+            cacheLayer.setValue(
                     requireNonNullString(key, KEY_NULL_MESSAGE),
                     requireNonNullObject(quote, "quote must not be null"),
-                    RedisKeyConstants.TTL_STOCK_TRACK,
-                    TimeUnit.SECONDS);
+                    RedisKeyConstants.TTL_STOCK_TRACK
+            );
             log.debug("Cached stock track: symbol={}", symbol);
         } catch (Exception e) {
             log.warn("Failed to cache stock track: symbol={}, error={}", symbol, e.getMessage());
@@ -60,7 +58,7 @@ public class StockCacheServiceImpl implements StockCacheService {
     public PriceQuoteDto getCachedStockTrack(String symbol) {
         String key = RedisKeyConstants.stockTrackKey(symbol);
         try {
-            Object cached = redisTemplate.opsForValue().get(requireNonNullObject(key, KEY_NULL_MESSAGE));
+            Object cached = cacheLayer.getValue(requireNonNullString(key, KEY_NULL_MESSAGE));
             if (cached instanceof PriceQuoteDto priceQuoteDto) {
                 log.debug("Cache hit: stock track {}", symbol);
                 return priceQuoteDto;
@@ -97,12 +95,7 @@ public class StockCacheServiceImpl implements StockCacheService {
         String key = RedisKeyConstants.hotStocksKey(type);
         try {
             String nonNullKey = requireNonNullString(key, KEY_NULL_MESSAGE);
-            redisTemplate.delete(nonNullKey);
-            if (symbols != null && !symbols.isEmpty()) {
-                Object[] symbolArray = requireNonNullObjectArray(symbols.toArray(), "symbolArray must not be null");
-                redisTemplate.opsForList().rightPushAll(nonNullKey, symbolArray);
-                redisTemplate.expire(nonNullKey, RedisKeyConstants.TTL_HOT_STOCKS, TimeUnit.SECONDS);
-            }
+            cacheLayer.replaceList(nonNullKey, symbols, RedisKeyConstants.TTL_HOT_STOCKS);
             log.debug("Cached hot stocks: type={}, count={}", type, symbols != null ? symbols.size() : 0);
         } catch (Exception e) {
             log.warn("Failed to cache hot stocks: type={}, error={}", type, e.getMessage());
@@ -113,8 +106,7 @@ public class StockCacheServiceImpl implements StockCacheService {
     public List<String> getCachedHotStocks(String type) {
         String key = RedisKeyConstants.hotStocksKey(type);
         try {
-            List<Object> cached = redisTemplate.opsForList().range(
-                    requireNonNullString(key, KEY_NULL_MESSAGE), 0, -1);
+            List<Object> cached = cacheLayer.getListRange(requireNonNullString(key, KEY_NULL_MESSAGE), 0, -1);
             if (cached != null && !cached.isEmpty()) {
                 log.debug("Cache hit: hot stocks type={}", type);
                 return cached.stream()
@@ -147,8 +139,7 @@ public class StockCacheServiceImpl implements StockCacheService {
     public boolean isStockTrackCached(String symbol) {
         String key = RedisKeyConstants.stockTrackKey(symbol);
         try {
-            Boolean exists = redisTemplate.hasKey(requireNonNullString(key, KEY_NULL_MESSAGE));
-            return Boolean.TRUE.equals(exists);
+            return cacheLayer.hasKey(requireNonNullString(key, KEY_NULL_MESSAGE));
         } catch (Exception e) {
             log.warn("Failed to check stock track cache: symbol={}, error={}", symbol, e.getMessage());
             return false;
@@ -225,8 +216,4 @@ public class StockCacheServiceImpl implements StockCacheService {
         return Objects.requireNonNull(value, message);
     }
 
-    
-    private static Object[] requireNonNullObjectArray(Object[] value, String message) {
-        return Objects.requireNonNull(value, message);
-    }
 }

--- a/koduck-backend/src/main/java/com/koduck/service/impl/UserCacheServiceImpl.java
+++ b/koduck-backend/src/main/java/com/koduck/service/impl/UserCacheServiceImpl.java
@@ -1,9 +1,9 @@
 package com.koduck.service.impl;
 
 import com.koduck.common.constants.RedisKeyConstants;
+import com.koduck.service.cache.CacheLayer;
 import com.koduck.service.UserCacheService;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.lang.NonNull;
 
@@ -18,10 +18,10 @@ import java.util.stream.Collectors;
 @Service
 @Slf4j
 public class UserCacheServiceImpl implements UserCacheService {
-    private final RedisTemplate<String, Object> redisTemplate;
+    private final CacheLayer cacheLayer;
 
-    public UserCacheServiceImpl(RedisTemplate<String, Object> redisTemplate) {
-        this.redisTemplate = Objects.requireNonNull(redisTemplate, "redisTemplate must not be null");
+    public UserCacheServiceImpl(CacheLayer cacheLayer) {
+        this.cacheLayer = Objects.requireNonNull(cacheLayer, "cacheLayer must not be null");
     }
 
     // ==================== User Tracking List () ====================
@@ -30,7 +30,7 @@ public class UserCacheServiceImpl implements UserCacheService {
     public void addToUserTrackList(@NonNull Long userId, @NonNull String symbol) {
         String key = RedisKeyConstants.userTrackKey(userId);
         try {
-            redisTemplate.opsForSet().add(key, symbol);
+            cacheLayer.addSetMember(key, symbol);
             log.debug("Added to user track list: userId={}, symbol={}", userId, symbol);
         } catch (Exception e) {
             log.warn("Failed to add to user track list: userId={}, symbol={}, error={}", 
@@ -42,7 +42,7 @@ public class UserCacheServiceImpl implements UserCacheService {
     public void removeFromUserTrackList(@NonNull Long userId, @NonNull String symbol) {
         String key = RedisKeyConstants.userTrackKey(userId);
         try {
-            redisTemplate.opsForSet().remove(key, symbol);
+            cacheLayer.removeSetMember(key, symbol);
             log.debug("Removed from user track list: userId={}, symbol={}", userId, symbol);
         } catch (Exception e) {
             log.warn("Failed to remove from user track list: userId={}, symbol={}, error={}", 
@@ -54,7 +54,7 @@ public class UserCacheServiceImpl implements UserCacheService {
     public Set<String> getUserTrackList(@NonNull Long userId) {
         String key = RedisKeyConstants.userTrackKey(userId);
         try {
-            Set<Object> members = redisTemplate.opsForSet().members(key);
+            Set<Object> members = cacheLayer.getSetMembers(key);
             if (members != null && !members.isEmpty()) {
                 log.debug("Cache hit: user track list userId={}", userId);
                 return members.stream()
@@ -71,8 +71,8 @@ public class UserCacheServiceImpl implements UserCacheService {
     public boolean isInUserTrackList(@NonNull Long userId, @NonNull String symbol) {
         String key = RedisKeyConstants.userTrackKey(userId);
         try {
-            Boolean isMember = redisTemplate.opsForSet().isMember(key, symbol);
-            return Boolean.TRUE.equals(isMember);
+            Set<Object> members = cacheLayer.getSetMembers(key);
+            return members != null && members.contains(symbol);
         } catch (Exception e) {
             log.warn("Failed to check user track list: userId={}, symbol={}, error={}", 
                     userId, symbol, e.getMessage());
@@ -86,7 +86,7 @@ public class UserCacheServiceImpl implements UserCacheService {
     public void addToUserWatchList(@NonNull Long userId, @NonNull String symbol) {
         String key = RedisKeyConstants.userWatchKey(userId);
         try {
-            redisTemplate.opsForSet().add(key, symbol);
+            cacheLayer.addSetMember(key, symbol);
             log.debug("Added to user watch list: userId={}, symbol={}", userId, symbol);
         } catch (Exception e) {
             log.warn("Failed to add to user watch list: userId={}, symbol={}, error={}", 
@@ -98,7 +98,7 @@ public class UserCacheServiceImpl implements UserCacheService {
     public void removeFromUserWatchList(@NonNull Long userId, @NonNull String symbol) {
         String key = RedisKeyConstants.userWatchKey(userId);
         try {
-            redisTemplate.opsForSet().remove(key, symbol);
+            cacheLayer.removeSetMember(key, symbol);
             log.debug("Removed from user watch list: userId={}, symbol={}", userId, symbol);
         } catch (Exception e) {
             log.warn("Failed to remove from user watch list: userId={}, symbol={}, error={}", 
@@ -110,7 +110,7 @@ public class UserCacheServiceImpl implements UserCacheService {
     public Set<String> getUserWatchList(@NonNull Long userId) {
         String key = RedisKeyConstants.userWatchKey(userId);
         try {
-            Set<Object> members = redisTemplate.opsForSet().members(key);
+            Set<Object> members = cacheLayer.getSetMembers(key);
             if (members != null && !members.isEmpty()) {
                 log.debug("Cache hit: user watch list userId={}", userId);
                 return members.stream()
@@ -129,12 +129,7 @@ public class UserCacheServiceImpl implements UserCacheService {
     public void cacheUserTrackList(@NonNull Long userId, Set<String> symbols) {
         String key = RedisKeyConstants.userTrackKey(userId);
         try {
-            redisTemplate.delete(key);
-            if (symbols != null && !symbols.isEmpty()) {
-                for (String item : symbols) {
-                    redisTemplate.opsForSet().add(key, item);
-                }
-            }
+            cacheLayer.replaceSet(key, symbols);
             log.debug("Cached user track list: userId={}, count={}", userId, symbols != null ? symbols.size() : 0);
         } catch (Exception e) {
             log.warn("Failed to cache user track list: userId={}, error={}", userId, e.getMessage());
@@ -145,12 +140,7 @@ public class UserCacheServiceImpl implements UserCacheService {
     public void cacheUserWatchList(@NonNull Long userId, Set<String> symbols) {
         String key = RedisKeyConstants.userWatchKey(userId);
         try {
-            redisTemplate.delete(key);
-            if (symbols != null && !symbols.isEmpty()) {
-                for (String item : symbols) {
-                    redisTemplate.opsForSet().add(key, item);
-                }
-            }
+            cacheLayer.replaceSet(key, symbols);
             log.debug("Cached user watch list: userId={}, count={}", userId, symbols != null ? symbols.size() : 0);
         } catch (Exception e) {
             log.warn("Failed to cache user watch list: userId={}, error={}", userId, e.getMessage());
@@ -162,8 +152,8 @@ public class UserCacheServiceImpl implements UserCacheService {
         try {
             String trackKey = RedisKeyConstants.userTrackKey(userId);
             String watchKey = RedisKeyConstants.userWatchKey(userId);
-            redisTemplate.delete(trackKey);
-            redisTemplate.delete(watchKey);
+            cacheLayer.delete(trackKey);
+            cacheLayer.delete(watchKey);
             log.debug("Invalidated user cache: userId={}", userId);
         } catch (Exception e) {
             log.warn("Failed to invalidate user cache: userId={}, error={}", userId, e.getMessage());


### PR DESCRIPTION
## Summary
- add a unified CacheLayer abstraction and RedisCacheLayer implementation for low-level cache operations
- migrate UserCacheServiceImpl and StockCacheServiceImpl to depend on CacheLayer instead of RedisTemplate directly
- keep existing key patterns and cache behavior unchanged while centralizing cache access strategy
- add ADR-0007 in koduck-backend/docs

## Verification
- mvn -DskipTests compile -f koduck-backend/pom.xml

Issue: #304