### PR TITLE
docs(exception): standardize Javadoc for core exception classes

### DIFF
--- a/koduck-backend/docs/ADR-0008-exception-javadoc-standardization.md
+++ b/koduck-backend/docs/ADR-0008-exception-javadoc-standardization.md
@@ -1,0 +1,60 @@
+# ADR-0008: Exception 层 Javadoc 规范化
+
+- Status: Accepted
+- Date: 2026-04-01
+- Issue: #306
+
+## Context
+
+`com.koduck.exception` 包中部分异常类存在注释空白、语义不完整或风格不一致的问题，导致：
+
+- 新成员理解异常语义成本上升；
+- 构造器与工厂方法用途不清晰；
+- 文档质量与代码规范不一致。
+
+本次问题属于“文档可维护性治理”，不涉及业务逻辑调整。
+
+## Decision
+
+对核心异常类进行 Javadoc 标准化，统一描述：
+
+- 类级职责（何时抛出）；
+- 构造器参数语义；
+- 工厂方法用途和返回值；
+- 关键字段含义。
+
+本次覆盖：
+
+- `BusinessException`
+- `AuthenticationException`
+- `AuthorizationException`
+- `ValidationException`
+- `ResourceNotFoundException`
+- `DuplicateException`
+- `StateException`
+
+## Consequences
+
+正向影响：
+
+- 异常语义更清晰，提升可维护性和可读性；
+- 统一注释风格，降低协作沟通成本；
+- 无行为改动，风险低。
+
+代价：
+
+- 文档维护工作量上升，需要在后续新增异常时持续遵循规范。
+
+## Alternatives Considered
+
+1. 保持现状，仅靠口头约定  
+   - 拒绝：信息不可执行，规范易漂移。
+
+2. 仅修复单个类注释  
+   - 暂不采用：无法形成一致风格，治理收益有限。
+
+## Verification
+
+- 目标异常类 Javadoc 已统一补全；
+- 未修改异常行为与对外契约；
+- 编译验证通过：`mvn -DskipTests compile -f koduck-backend/pom.xml`。

--- a/koduck-backend/src/main/java/com/koduck/exception/AuthenticationException.java
+++ b/koduck-backend/src/main/java/com/koduck/exception/AuthenticationException.java
@@ -3,9 +3,10 @@ package com.koduck.exception;
 import java.io.Serial;
 
 /**
- * 
+ * Exception for authentication failures.
  *
- * <p>，</p>
+ * <p>Used for identity verification errors such as invalid credentials,
+ * token issues, or disabled/locked account states.</p>
  *
  * @author Koduck Team
  */
@@ -15,73 +16,73 @@ public class AuthenticationException extends BusinessException {
     private static final long serialVersionUID = 1L;
 
     /**
-     * 
+     * Creates an authentication exception with custom message.
      *
-     * @param message 
+     * @param message error message
      */
     public AuthenticationException(String message) {
         super(ErrorCode.AUTH_ERROR.getCode(), message);
     }
 
     /**
-     * 
+     * Creates an authentication exception from predefined error code.
      *
-     * @param errorCode 
+     * @param errorCode authentication-related error code
      */
     public AuthenticationException(ErrorCode errorCode) {
         super(errorCode.getCode(), errorCode.getDefaultMessage());
     }
 
     /**
-     * 
+     * Creates an authentication exception from error code and custom message.
      *
-     * @param errorCode 
-     * @param message   
+     * @param errorCode authentication-related error code
+     * @param message custom error message
      */
     public AuthenticationException(ErrorCode errorCode, String message) {
         super(errorCode.getCode(), message);
     }
 
     /**
-     * 
+     * Factory method for invalid credential errors.
      *
-     * @return AuthenticationException
+     * @return exception instance
      */
     public static AuthenticationException invalidCredentials() {
         return new AuthenticationException(ErrorCode.AUTH_INVALID_CREDENTIALS);
     }
 
     /**
-     * 
+     * Factory method for expired token errors.
      *
-     * @return AuthenticationException
+     * @return exception instance
      */
     public static AuthenticationException tokenExpired() {
         return new AuthenticationException(ErrorCode.AUTH_TOKEN_EXPIRED);
     }
 
     /**
-     * 
+     * Factory method for invalid token errors.
      *
-     * @return AuthenticationException
+     * @return exception instance
      */
     public static AuthenticationException tokenInvalid() {
         return new AuthenticationException(ErrorCode.AUTH_TOKEN_INVALID);
     }
 
     /**
-     * 
+     * Factory method for disabled account errors.
      *
-     * @return AuthenticationException
+     * @return exception instance
      */
     public static AuthenticationException accountDisabled() {
         return new AuthenticationException(ErrorCode.AUTH_ACCOUNT_DISABLED);
     }
 
     /**
-     * 
+     * Factory method for locked account errors.
      *
-     * @return AuthenticationException
+     * @return exception instance
      */
     public static AuthenticationException accountLocked() {
         return new AuthenticationException(ErrorCode.AUTH_ACCOUNT_LOCKED);

--- a/koduck-backend/src/main/java/com/koduck/exception/AuthorizationException.java
+++ b/koduck-backend/src/main/java/com/koduck/exception/AuthorizationException.java
@@ -3,9 +3,10 @@ package com.koduck.exception;
 import java.io.Serial;
 
 /**
- * 
+ * Exception for authorization and permission failures.
  *
- * <p></p>
+ * <p>Used when an authenticated user attempts operations without enough
+ * privileges.</p>
  *
  * @author Koduck Team
  */
@@ -15,47 +16,47 @@ public class AuthorizationException extends BusinessException {
     private static final long serialVersionUID = 1L;
 
     /**
-     * 
+     * Creates an authorization exception with custom message.
      *
-     * @param message 
+     * @param message error message
      */
     public AuthorizationException(String message) {
         super(ErrorCode.FORBIDDEN.getCode(), message);
     }
 
     /**
-     * 
+     * Creates an authorization exception from predefined error code.
      *
-     * @param errorCode 
+     * @param errorCode authorization-related error code
      */
     public AuthorizationException(ErrorCode errorCode) {
         super(errorCode.getCode(), errorCode.getDefaultMessage());
     }
 
     /**
-     * 
+     * Creates an authorization exception from error code and custom message.
      *
-     * @param errorCode 
-     * @param message   
+     * @param errorCode authorization-related error code
+     * @param message custom error message
      */
     public AuthorizationException(ErrorCode errorCode, String message) {
         super(errorCode.getCode(), message);
     }
 
     /**
-     * 
+     * Factory method for access denied errors.
      *
-     * @return AuthorizationException
+     * @return exception instance
      */
     public static AuthorizationException accessDenied() {
         return new AuthorizationException(ErrorCode.AUTH_ACCESS_DENIED);
     }
 
     /**
-     * 
+     * Factory method for generic operation-not-allowed errors.
      *
-     * @param message 
-     * @return AuthorizationException
+     * @param message custom error message
+     * @return exception instance
      */
     public static AuthorizationException operationNotAllowed(String message) {
         return new AuthorizationException(ErrorCode.OPERATION_NOT_ALLOWED, message);

--- a/koduck-backend/src/main/java/com/koduck/exception/BusinessException.java
+++ b/koduck-backend/src/main/java/com/koduck/exception/BusinessException.java
@@ -5,9 +5,10 @@ import lombok.Getter;
 import java.io.Serial;
 
 /**
- * 
+ * Base class for domain/business exceptions.
  *
- * <p>，</p>
+ * <p>It carries a stable business error code used by API responses and
+ * monitoring pipelines.</p>
  *
  * @author Koduck Team
  */
@@ -18,15 +19,15 @@ public class BusinessException extends RuntimeException {
     private static final long serialVersionUID = 1L;
 
     /**
-     * 
+     * Business error code defined by {@link ErrorCode}.
      */
     private final int code;
 
     /**
-     * 
+     * Creates an exception with explicit business code and message.
      *
-     * @param code    
-     * @param message 
+     * @param code business error code
+     * @param message error message
      */
     public BusinessException(int code, String message) {
         super(message);
@@ -34,18 +35,18 @@ public class BusinessException extends RuntimeException {
     }
 
     /**
-     * （）
+     * Creates an exception with default {@link ErrorCode#BUSINESS_ERROR} code.
      *
-     * @param message 
+     * @param message error message
      */
     public BusinessException(String message) {
         this(ErrorCode.BUSINESS_ERROR.getCode(), message);
     }
 
     /**
-     * 
+     * Creates an exception from a predefined {@link ErrorCode}.
      *
-     * @param errorCode 
+     * @param errorCode predefined business error code
      */
     public BusinessException(ErrorCode errorCode) {
         super(errorCode.getDefaultMessage());
@@ -53,10 +54,10 @@ public class BusinessException extends RuntimeException {
     }
 
     /**
-     * 
+     * Creates an exception from a predefined {@link ErrorCode} with custom message.
      *
-     * @param errorCode 
-     * @param message   
+     * @param errorCode predefined business error code
+     * @param message custom error message
      */
     public BusinessException(ErrorCode errorCode, String message) {
         super(message);
@@ -64,11 +65,11 @@ public class BusinessException extends RuntimeException {
     }
 
     /**
-     * 
+     * Creates an exception with explicit code, message and root cause.
      *
-     * @param code    
-     * @param message 
-     * @param cause   
+     * @param code business error code
+     * @param message error message
+     * @param cause root cause
      */
     public BusinessException(int code, String message, Throwable cause) {
         super(message, cause);
@@ -76,10 +77,10 @@ public class BusinessException extends RuntimeException {
     }
 
     /**
-     * 
+     * Creates an exception from {@link ErrorCode} and root cause.
      *
-     * @param errorCode 
-     * @param cause     
+     * @param errorCode predefined business error code
+     * @param cause root cause
      */
     public BusinessException(ErrorCode errorCode, Throwable cause) {
         super(errorCode.getDefaultMessage(), cause);
@@ -87,9 +88,9 @@ public class BusinessException extends RuntimeException {
     }
 
     /**
-     *  HTTP 
+     * Resolves mapped HTTP status code from current business code.
      *
-     * @return HTTP 
+     * @return HTTP status code value
      */
     public int getHttpStatus() {
         ErrorCode errorCode = ErrorCode.fromCode(code);

--- a/koduck-backend/src/main/java/com/koduck/exception/DuplicateException.java
+++ b/koduck-backend/src/main/java/com/koduck/exception/DuplicateException.java
@@ -5,9 +5,9 @@ import lombok.Getter;
 import java.io.Serial;
 
 /**
- * 
+ * Exception for duplicate resource or unique-constraint conflicts.
  *
- * <p></p>
+ * <p>Typically used when creating/updating data violates uniqueness rules.</p>
  *
  * @author Koduck Team
  */
@@ -18,19 +18,19 @@ public class DuplicateException extends BusinessException {
     private static final long serialVersionUID = 1L;
 
     /**
-     * 
+     * Name of the duplicate field.
      */
     private final String field;
 
     /**
-     * 
+     * Duplicate field value.
      */
     private final transient Object value;
 
     /**
-     * 
+     * Creates an exception with custom message.
      *
-     * @param message 
+     * @param message error message
      */
     public DuplicateException(String message) {
         super(ErrorCode.DUPLICATE_ERROR.getCode(), message);
@@ -39,9 +39,9 @@ public class DuplicateException extends BusinessException {
     }
 
     /**
-     * 
+     * Creates an exception from predefined error code.
      *
-     * @param errorCode 
+     * @param errorCode duplicate-related error code
      */
     public DuplicateException(ErrorCode errorCode) {
         super(errorCode.getCode(), errorCode.getDefaultMessage());
@@ -50,11 +50,11 @@ public class DuplicateException extends BusinessException {
     }
 
     /**
-     * 
+     * Creates an exception from duplicate field/value and custom message.
      *
-     * @param field   
-     * @param value   
-     * @param message 
+     * @param field duplicate field name
+     * @param value duplicate value
+     * @param message custom error message
      */
     public DuplicateException(String field, Object value, String message) {
         super(ErrorCode.DUPLICATE_ERROR.getCode(), message);
@@ -63,33 +63,33 @@ public class DuplicateException extends BusinessException {
     }
 
     /**
-     * （）
+     * Creates an exception from duplicate field/value with default message.
      *
-     * @param field 
-     * @param value 
+     * @param field duplicate field name
+     * @param value duplicate value
      */
     public DuplicateException(String field, Object value) {
         this(field, value, field + " 已存在: " + value);
     }
 
     /**
-     * 
+     * Factory method for duplicate exception with custom message.
      *
-     * @param field   
-     * @param value   
-     * @param message 
-     * @return DuplicateException
+     * @param field duplicate field name
+     * @param value duplicate value
+     * @param message custom error message
+     * @return exception instance
      */
     public static DuplicateException of(String field, Object value, String message) {
         return new DuplicateException(field, value, message);
     }
 
     /**
-     * （）
+     * Factory method for duplicate exception with default message.
      *
-     * @param field 
-     * @param value 
-     * @return DuplicateException
+     * @param field duplicate field name
+     * @param value duplicate value
+     * @return exception instance
      */
     public static DuplicateException of(String field, Object value) {
         return new DuplicateException(field, value);

--- a/koduck-backend/src/main/java/com/koduck/exception/ResourceNotFoundException.java
+++ b/koduck-backend/src/main/java/com/koduck/exception/ResourceNotFoundException.java
@@ -5,9 +5,9 @@ import lombok.Getter;
 import java.io.Serial;
 
 /**
- * 
+ * Exception for missing resources.
  *
- * <p>，</p>
+ * <p>Used when required domain entities cannot be found by ID or by business key.</p>
  *
  * @author Koduck Team
  */
@@ -18,19 +18,19 @@ public class ResourceNotFoundException extends BusinessException {
     private static final long serialVersionUID = 1L;
 
     /**
-     * 
+     * Resource type, for example "user" or "strategy".
      */
     private final String resourceType;
 
     /**
-     *  ID
+     * Missing resource identifier.
      */
     private final transient Object resourceId;
 
     /**
-     * 
+     * Creates an exception with custom message.
      *
-     * @param message 
+     * @param message error message
      */
     public ResourceNotFoundException(String message) {
         super(ErrorCode.RESOURCE_NOT_FOUND.getCode(), message);
@@ -39,9 +39,9 @@ public class ResourceNotFoundException extends BusinessException {
     }
 
     /**
-     * 
+     * Creates an exception from predefined error code.
      *
-     * @param errorCode 
+     * @param errorCode resource-not-found related error code
      */
     public ResourceNotFoundException(ErrorCode errorCode) {
         super(errorCode.getCode(), errorCode.getDefaultMessage());
@@ -50,10 +50,10 @@ public class ResourceNotFoundException extends BusinessException {
     }
 
     /**
-     * 
+     * Creates an exception from resource type and identifier.
      *
-     * @param resourceType （ "", ""）
-     * @param resourceId    ID
+     * @param resourceType resource type (for example "user", "signal")
+     * @param resourceId resource identifier
      */
     public ResourceNotFoundException(String resourceType, Object resourceId) {
         super(ErrorCode.RESOURCE_NOT_FOUND.getCode(), resourceType + "不存在: " + resourceId);
@@ -62,11 +62,11 @@ public class ResourceNotFoundException extends BusinessException {
     }
 
     /**
-     * 
+     * Creates an exception from explicit error code plus resource identity.
      *
-     * @param errorCode    
-     * @param resourceType 
-     * @param resourceId    ID
+     * @param errorCode resource-not-found related error code
+     * @param resourceType resource type
+     * @param resourceId resource identifier
      */
     public ResourceNotFoundException(ErrorCode errorCode, String resourceType, Object resourceId) {
         super(errorCode.getCode(), errorCode.getDefaultMessage());
@@ -75,11 +75,11 @@ public class ResourceNotFoundException extends BusinessException {
     }
 
     /**
-     * 
+     * Factory method for common resource-not-found case.
      *
-     * @param resourceType 
-     * @param resourceId    ID
-     * @return ResourceNotFoundException
+     * @param resourceType resource type
+     * @param resourceId resource identifier
+     * @return exception instance
      */
     public static ResourceNotFoundException of(String resourceType, Object resourceId) {
         return new ResourceNotFoundException(resourceType, resourceId);

--- a/koduck-backend/src/main/java/com/koduck/exception/StateException.java
+++ b/koduck-backend/src/main/java/com/koduck/exception/StateException.java
@@ -5,9 +5,9 @@ import java.io.Serial;
 import lombok.Getter;
 
 /**
- * 
+ * Exception for invalid state transitions.
  *
- * <p></p>
+ * <p>Used when current entity/process state does not match expected state.</p>
  *
  * @author Koduck Team
  */
@@ -18,19 +18,19 @@ public class StateException extends BusinessException {
     private static final long serialVersionUID = 1L;
 
     /**
-     * 
+     * Current state value.
      */
     private final String currentState;
 
     /**
-     * 
+     * Expected state value.
      */
     private final String expectedState;
 
     /**
-     * 
+     * Creates a state exception with custom message.
      *
-     * @param message 
+     * @param message error message
      */
     public StateException(String message) {
         super(ErrorCode.INVALID_STATE.getCode(), message);
@@ -39,9 +39,9 @@ public class StateException extends BusinessException {
     }
 
     /**
-     * 
+     * Creates a state exception from predefined error code.
      *
-     * @param errorCode 
+     * @param errorCode state-related error code
      */
     public StateException(ErrorCode errorCode) {
         super(errorCode.getCode(), errorCode.getDefaultMessage());
@@ -50,10 +50,10 @@ public class StateException extends BusinessException {
     }
 
     /**
-     * 
+     * Creates a state exception from current/expected states.
      *
-     * @param currentState  
-     * @param expectedState 
+     * @param currentState current state
+     * @param expectedState expected state
      */
     public StateException(String currentState, String expectedState) {
         super(ErrorCode.INVALID_STATE.getCode(),
@@ -63,11 +63,11 @@ public class StateException extends BusinessException {
     }
 
     /**
-     * 
+     * Creates a state exception with explicit state values and custom message.
      *
-     * @param currentState  
-     * @param expectedState 
-     * @param message       
+     * @param currentState current state
+     * @param expectedState expected state
+     * @param message custom error message
      */
     public StateException(String currentState, String expectedState, String message) {
         super(ErrorCode.INVALID_STATE.getCode(), message);

--- a/koduck-backend/src/main/java/com/koduck/exception/ValidationException.java
+++ b/koduck-backend/src/main/java/com/koduck/exception/ValidationException.java
@@ -6,9 +6,9 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * 
+ * Exception for request or business validation failures.
  *
- * <p>，</p>
+ * <p>Besides the main message, it can carry field-level validation errors.</p>
  *
  * @author Koduck Team
  */
@@ -18,14 +18,14 @@ public class ValidationException extends BusinessException {
     private static final long serialVersionUID = 1L;
 
     /**
-     * ，key ，value 
+     * Field-level validation errors. Key is field name, value is error message.
      */
     private final Map<String, String> fieldErrors;
 
     /**
-     * 
+     * Creates a validation exception with message only.
      *
-     * @param message 
+     * @param message validation error message
      */
     public ValidationException(String message) {
         super(ErrorCode.VALIDATION_ERROR.getCode(), message);
@@ -33,9 +33,9 @@ public class ValidationException extends BusinessException {
     }
 
     /**
-     * 
+     * Creates a validation exception from predefined error code.
      *
-     * @param errorCode 
+     * @param errorCode validation-related error code
      */
     public ValidationException(ErrorCode errorCode) {
         super(errorCode.getCode(), errorCode.getDefaultMessage());
@@ -43,16 +43,21 @@ public class ValidationException extends BusinessException {
     }
 
     /**
-     * （）
+     * Creates a validation exception with field-level error details.
      *
-     * @param message     
-     * @param fieldErrors 
+     * @param message validation error message
+     * @param fieldErrors field-level errors
      */
     public ValidationException(String message, Map<String, String> fieldErrors) {
         super(ErrorCode.VALIDATION_ERROR.getCode(), message);
         this.fieldErrors = fieldErrors != null ? Map.copyOf(fieldErrors) : Collections.emptyMap();
     }
-    
+
+    /**
+     * Returns immutable copy of field-level errors.
+     *
+     * @return field-level errors
+     */
     public Map<String, String> getFieldErrors() {
         return fieldErrors == null || fieldErrors.isEmpty()
                 ? Collections.emptyMap()
@@ -60,11 +65,11 @@ public class ValidationException extends BusinessException {
     }
 
     /**
-     * （）
+     * Creates a single-field validation exception.
      *
-     * @param field   
-     * @param message 
-     * @return ValidationException
+     * @param field field name
+     * @param message validation message
+     * @return exception instance
      */
     public static ValidationException forField(String field, String message) {
         return new ValidationException(message, Map.of(field, message));


### PR DESCRIPTION
## Summary
- standardize and complete Javadoc for core exception classes in exception package
- clarify class responsibilities, constructor parameter semantics, and factory method intents
- keep runtime behavior unchanged (documentation-only refactor)
- add ADR-0008 under koduck-backend/docs

## Verification
- mvn -DskipTests compile -f koduck-backend/pom.xml

Issue: #306