### PR TITLE
feat(resilience): add circuit breaker for data-service client

### DIFF
--- a/koduck-backend/docs/ADR-0011-data-service-circuit-breaker.md
+++ b/koduck-backend/docs/ADR-0011-data-service-circuit-breaker.md
@@ -1,0 +1,52 @@
+# ADR-0011: 外部数据服务调用引入 Circuit Breaker（Resilience4j）
+
+- Status: Accepted
+- Date: 2026-04-01
+- Issue: #312
+
+## Context
+
+`DataServiceClient` 负责触发 data-service 的实时更新调用。当前链路在下游持续失败时缺少熔断机制，可能导致：
+
+- 持续重试/调用放大下游故障；
+- 上游线程和连接资源被无效调用占用；
+- 故障恢复前系统稳定性下降。
+
+需要在不改变既有业务接口的前提下，引入可配置、可观测的熔断保护。
+
+## Decision
+
+采用 Resilience4j Circuit Breaker，并首批落地到 `DataServiceClient` 外部调用：
+
+- 引入 `resilience4j-spring-boot3` 依赖；
+- 在 `DataServiceClient#triggerRealtimeUpdate(List<String>)` 增加 `@CircuitBreaker`；
+- 配置 `dataServiceClient` 熔断实例（窗口、失败率阈值、Open 等待时长、Half-Open 探测量）；
+- 增加 fallback：熔断打开或调用异常时记录告警日志并快速返回。
+
+## Consequences
+
+正向影响：
+
+- 连续失败场景下快速失败，避免故障扩散；
+- 调用方行为保持兼容（失败时仍以“记录并返回”为主）；
+- 熔断参数可通过配置和环境变量调整。
+
+代价：
+
+- 新增运行时依赖与配置维护成本；
+- 首批仅覆盖 `DataServiceClient`，其他外部调用链路需后续分批纳入。
+
+## Alternatives Considered
+
+1. 仅使用重试（无熔断）  
+   - 拒绝：下游故障持续时会增加压力，无法快速止损。
+
+2. 自研熔断逻辑  
+   - 暂不采用：成熟度与可观测性不如 Resilience4j，维护成本高。
+
+## Verification
+
+- `pom.xml` 已引入 Resilience4j 依赖；
+- `DataServiceClient` 已接入 `@CircuitBreaker` 与 fallback；
+- `application.yml` 已新增 `resilience4j.circuitbreaker.instances.dataServiceClient` 配置；
+- 编译验证通过：`mvn -DskipTests compile -f koduck-backend/pom.xml`。

--- a/koduck-backend/pom.xml
+++ b/koduck-backend/pom.xml
@@ -29,6 +29,7 @@
         <mapstruct.version>1.6.3</mapstruct.version>
         <ta4j.version>0.16</ta4j.version>
         <springdoc.version>2.8.5</springdoc.version>
+        <resilience4j.version>2.2.0</resilience4j.version>
 
         <!-- Plugin Versions -->
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
@@ -210,6 +211,13 @@
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
             <version>${springdoc.version}</version>
+        </dependency>
+
+        <!-- Resilience4j Circuit Breaker -->
+        <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-spring-boot3</artifactId>
+            <version>${resilience4j.version}</version>
         </dependency>
 
         <!-- WebSocket -->

--- a/koduck-backend/src/main/java/com/koduck/client/DataServiceClient.java
+++ b/koduck-backend/src/main/java/com/koduck/client/DataServiceClient.java
@@ -1,6 +1,7 @@
 package com.koduck.client;
 
 import com.koduck.config.properties.DataServiceProperties;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -28,6 +29,7 @@ public class DataServiceClient {
      * Request body key for stock symbol collections.
      */
     private static final String KEY_SYMBOLS = "symbols";
+    private static final String CB_DATA_SERVICE_CLIENT = "dataServiceClient";
 
     /**
      * Data-service feature flags and endpoint settings.
@@ -75,6 +77,7 @@ public class DataServiceClient {
      *
      * @param symbols list of stock symbols to update
      */
+    @CircuitBreaker(name = CB_DATA_SERVICE_CLIENT, fallbackMethod = "triggerRealtimeUpdateFallback")
     public void triggerRealtimeUpdate(final List<String> symbols) {
         final boolean shouldTrigger;
         final List<String> requestedSymbols;
@@ -92,25 +95,43 @@ public class DataServiceClient {
         }
 
         if (shouldTrigger) {
-            final String url = dataSvcProps.getBaseUrl() + dataSvcProps.getRealtimeUpdatePath();
-            try {
-                final HttpHeaders headers = new HttpHeaders();
-                headers.setContentType(MediaType.APPLICATION_JSON);
-
-                final Map<String, Object> requestBody = Map.of(KEY_SYMBOLS, requestedSymbols);
-                final HttpEntity<Map<String, Object>> request = new HttpEntity<>(requestBody, headers);
-                dataSvcRestTemplate.postForObject(url, request, Void.class);
-
-                if (log.isInfoEnabled()) {
-                    log.info("realtime_update_triggered symbolsCount={} symbols={}",
-                            requestedSymbols.size(), requestedSymbols);
-                }
-            } catch (RestClientException ex) {
-                if (log.isWarnEnabled()) {
-                    log.warn("realtime_update_trigger_failed symbols={} error={}",
-                            requestedSymbols, ex.getMessage());
-                }
-            }
+            invokeRealtimeUpdate(requestedSymbols);
         }
+    }
+
+    /**
+     * Invokes data-service realtime update endpoint with circuit breaker protection.
+     *
+     * @param requestedSymbols symbols to trigger refresh
+     */
+    void invokeRealtimeUpdate(final List<String> requestedSymbols) {
+        final String url = dataSvcProps.getBaseUrl() + dataSvcProps.getRealtimeUpdatePath();
+        final HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        final Map<String, Object> requestBody = Map.of(KEY_SYMBOLS, requestedSymbols);
+        final HttpEntity<Map<String, Object>> request = new HttpEntity<>(requestBody, headers);
+        dataSvcRestTemplate.postForObject(url, request, Void.class);
+
+        if (log.isInfoEnabled()) {
+            log.info("realtime_update_triggered symbolsCount={} symbols={}",
+                    requestedSymbols.size(), requestedSymbols);
+        }
+    }
+
+    /**
+     * Circuit-breaker fallback for realtime update invocation failures.
+     *
+     * @param requestedSymbols symbols to trigger refresh
+     * @param throwable root cause
+     */
+    void triggerRealtimeUpdateFallback(final List<String> requestedSymbols, final Throwable throwable) {
+        if (throwable instanceof RestClientException restClientException) {
+            log.warn("realtime_update_trigger_failed symbols={} error={}",
+                    requestedSymbols, restClientException.getMessage());
+            return;
+        }
+        log.warn("realtime_update_trigger_failed symbols={} errorType={} error={}",
+                requestedSymbols, throwable.getClass().getSimpleName(), throwable.getMessage());
     }
 }

--- a/koduck-backend/src/main/resources/application.yml
+++ b/koduck-backend/src/main/resources/application.yml
@@ -137,6 +137,23 @@ app:
     username: ${APP_DEMO_USERNAME:demo}
     password: ${APP_DEMO_PASSWORD:demo123}
 
+# Resilience4j 熔断配置
+resilience4j:
+  circuitbreaker:
+    instances:
+      dataServiceClient:
+        registerHealthIndicator: true
+        slidingWindowType: COUNT_BASED
+        slidingWindowSize: ${DATA_SERVICE_CB_WINDOW_SIZE:20}
+        minimumNumberOfCalls: ${DATA_SERVICE_CB_MIN_CALLS:10}
+        failureRateThreshold: ${DATA_SERVICE_CB_FAILURE_RATE:50}
+        waitDurationInOpenState: ${DATA_SERVICE_CB_OPEN_WAIT:30s}
+        permittedNumberOfCallsInHalfOpenState: ${DATA_SERVICE_CB_HALF_OPEN_CALLS:3}
+        automaticTransitionFromOpenToHalfOpenEnabled: true
+        recordExceptions:
+          - org.springframework.web.client.RestClientException
+          - java.lang.RuntimeException
+
 # SpringDoc OpenAPI 配置
 springdoc:
   api-docs:


### PR DESCRIPTION
## Summary
- introduce Resilience4j dependency for circuit breaker support
- add circuit breaker configuration for dataServiceClient in application.yml
- apply @CircuitBreaker with fallback in DataServiceClient external realtime update call path
- add ADR-0011 under koduck-backend/docs

## Verification
- mvn -DskipTests compile -f koduck-backend/pom.xml

Issue: #312