### PR TITLE
refactor(security): externalize permitAll endpoint patterns

### DIFF
--- a/koduck-backend/docs/ADR-0014-security-permitall-endpoint-externalization.md
+++ b/koduck-backend/docs/ADR-0014-security-permitall-endpoint-externalization.md
@@ -1,0 +1,52 @@
+# ADR-0014: Security permitAll 端点策略外置配置化
+
+- Status: Accepted
+- Date: 2026-04-01
+- Issue: #318
+
+## Context
+
+`SecurityConfig` 中存在多组 `permitAll` 端点路径硬编码。随着接口演进，该模式会带来：
+
+- 路径变更需要修改 Java 代码并重新发布；
+- 安全策略分散在代码实现中，审查与维护成本高；
+- 不利于不同环境基于配置快速调整公开端点策略。
+
+## Decision
+
+将 `permitAll` 策略迁移为配置驱动：
+
+- 新增 `SecurityEndpointProperties`（前缀 `koduck.security`）；
+- `SecurityConfig` 读取配置项动态装配 `requestMatchers`；
+- 提供两组策略：
+  - `permit-all-patterns`：全方法公开
+  - `permit-all-get-patterns`：仅 GET 公开
+- 默认配置保持与迁移前一致，确保行为不回归。
+
+## Consequences
+
+正向影响：
+
+- 公开路径维护从代码改动转为配置改动，降低变更成本；
+- 安全策略可读性与可审计性提升；
+- 为后续分环境安全策略差异化奠定基础。
+
+代价：
+
+- 配置错误可能导致暴露或误拦截，需要变更评审；
+- 策略分散到配置文件后，需要文档和发布流程约束。
+
+## Alternatives Considered
+
+1. 继续使用硬编码常量
+   - 拒绝：维护性问题持续存在。
+
+2. 将路径常量集中到单独 Java 常量类
+   - 未采用：虽然减少分散，但仍需代码发布，无法实现配置层运维弹性。
+
+## Verification
+
+- `SecurityConfig` 已移除多组硬编码 `permitAll` 路径；
+- 新增 `koduck.security` 配置并完成默认值对齐；
+- 新增文档：`koduck-backend/docs/SECURITY-ENDPOINTS.md`；
+- 本地 `mvn -DskipTests compile` 通过。

--- a/koduck-backend/docs/README.md
+++ b/koduck-backend/docs/README.md
@@ -134,6 +134,11 @@ mvn spring-boot:run
 - 密钥管理文档：[`SECRET-MANAGEMENT.md`](SECRET-MANAGEMENT.md)
 - 密钥治理 ADR：`ADR-0013-spring-vault-secret-management-baseline.md`
 
+## Security 策略配置
+
+- 公开端点配置文档：[`SECURITY-ENDPOINTS.md`](SECURITY-ENDPOINTS.md)
+- 配置化治理 ADR：`ADR-0014-security-permitall-endpoint-externalization.md`
+
 ## 测试
 
 ```bash

--- a/koduck-backend/docs/SECURITY-ENDPOINTS.md
+++ b/koduck-backend/docs/SECURITY-ENDPOINTS.md
@@ -1,0 +1,34 @@
+# Security 公开端点配置
+
+## 背景
+
+`SecurityConfig` 中公开端点（`permitAll`）策略已从硬编码迁移为配置外置，统一由 `koduck.security` 管理。
+
+## 配置项
+
+位于 `application.yml`：
+
+- `koduck.security.permit-all-patterns`：所有 HTTP 方法可匿名访问的路径
+- `koduck.security.permit-all-get-patterns`：仅 GET 可匿名访问的路径
+
+默认配置与迁移前保持一致：
+
+```yaml
+koduck:
+  security:
+    permit-all-patterns:
+      - /api/v1/auth/**
+      - /actuator/health
+      - /api/v1/health/**
+      - /api/v1/monitoring/**
+      - /ws/**
+      - /api/v1/a-share/**
+    permit-all-get-patterns:
+      - /api/v1/market/**
+```
+
+## 使用建议
+
+1. 新增公开接口时优先更新配置，不直接改 `SecurityConfig`。
+2. 仅在明确需要“只读公开”场景时放入 `permit-all-get-patterns`。
+3. 每次策略调整建议同步评审并更新 ADR/变更说明。

--- a/koduck-backend/src/main/java/com/koduck/config/SecurityConfig.java
+++ b/koduck-backend/src/main/java/com/koduck/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.koduck.config;
 
+import com.koduck.config.properties.SecurityEndpointProperties;
 import com.koduck.security.JwtAuthenticationFilter;
 import jakarta.servlet.DispatcherType;
 import jakarta.servlet.http.HttpServletResponse;
@@ -32,14 +33,6 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @EnableMethodSecurity(prePostEnabled = true)
 public class SecurityConfig {
 
-    private static final String AUTH_ENDPOINT_PATTERN = "/api/v1/auth/**";
-    private static final String ACTUATOR_HEALTH_ENDPOINT = "/actuator/health";
-    private static final String APP_HEALTH_ENDPOINT_PATTERN = "/api/v1/health/**";
-    private static final String MARKET_ENDPOINT_PATTERN = "/api/v1/market/**";
-    private static final String MONITORING_ENDPOINT_PATTERN = "/api/v1/monitoring/**";
-    private static final String WEBSOCKET_ENDPOINT = "/ws/**";
-    private static final String A_SHARE_ENDPOINT_PATTERN = "/api/v1/a-share/**";
-
     /**
      * Builds the security filter chain and configures endpoint authorization.
      *
@@ -52,7 +45,8 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(
             HttpSecurity http,
             JwtAuthenticationFilter jwtAuthenticationFilter,
-            UserDetailsService userDetailsService) throws Exception {
+            UserDetailsService userDetailsService,
+            SecurityEndpointProperties securityEndpointProperties) throws Exception {
         http
             .csrf(AbstractHttpConfigurer::disable)
             .sessionManagement(session ->
@@ -60,20 +54,24 @@ public class SecurityConfig {
             .exceptionHandling(exceptions ->
                 exceptions.authenticationEntryPoint((request, response, authException) ->
                     response.sendError(HttpServletResponse.SC_UNAUTHORIZED, authException.getMessage())))
-            .authorizeHttpRequests(auth -> auth
+            .authorizeHttpRequests(auth -> {
                 // Allow async/error dispatches (e.g. SSE) to continue after initial auth passes.
-                .dispatcherTypeMatchers(DispatcherType.ASYNC, DispatcherType.ERROR).permitAll()
-                .requestMatchers(
-                    AUTH_ENDPOINT_PATTERN,
-                    ACTUATOR_HEALTH_ENDPOINT,
-                    APP_HEALTH_ENDPOINT_PATTERN,
-                    MONITORING_ENDPOINT_PATTERN,
-                    WEBSOCKET_ENDPOINT,
-                    A_SHARE_ENDPOINT_PATTERN
-                ).permitAll()
-                .requestMatchers(HttpMethod.GET, MARKET_ENDPOINT_PATTERN).permitAll()
-                .anyRequest().authenticated()
-            )
+                auth.dispatcherTypeMatchers(DispatcherType.ASYNC, DispatcherType.ERROR).permitAll();
+
+                String[] permitAllPatterns =
+                        securityEndpointProperties.getPermitAllPatterns().toArray(String[]::new);
+                if (permitAllPatterns.length > 0) {
+                    auth.requestMatchers(permitAllPatterns).permitAll();
+                }
+
+                String[] permitAllGetPatterns =
+                        securityEndpointProperties.getPermitAllGetPatterns().toArray(String[]::new);
+                if (permitAllGetPatterns.length > 0) {
+                    auth.requestMatchers(HttpMethod.GET, permitAllGetPatterns).permitAll();
+                }
+
+                auth.anyRequest().authenticated();
+            })
             .authenticationProvider(authenticationProvider(userDetailsService))
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 

--- a/koduck-backend/src/main/java/com/koduck/config/properties/SecurityEndpointProperties.java
+++ b/koduck-backend/src/main/java/com/koduck/config/properties/SecurityEndpointProperties.java
@@ -1,0 +1,49 @@
+package com.koduck.config.properties;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Security endpoint authorization properties.
+ *
+ * <p>Defines endpoint patterns that can bypass authentication. The
+ * configuration is externalized under {@code koduck.security} so endpoint
+ * maintenance does not require Java code changes.</p>
+ */
+@Configuration
+@ConfigurationProperties(prefix = "koduck.security")
+public class SecurityEndpointProperties {
+
+    private static final List<String> DEFAULT_PERMIT_ALL_PATTERNS = List.of(
+            "/api/v1/auth/**",
+            "/actuator/health",
+            "/api/v1/health/**",
+            "/api/v1/monitoring/**",
+            "/ws/**",
+            "/api/v1/a-share/**"
+    );
+
+    private static final List<String> DEFAULT_PERMIT_ALL_GET_PATTERNS = List.of("/api/v1/market/**");
+
+    private List<String> permitAllPatterns = new ArrayList<>(DEFAULT_PERMIT_ALL_PATTERNS);
+
+    private List<String> permitAllGetPatterns = new ArrayList<>(DEFAULT_PERMIT_ALL_GET_PATTERNS);
+
+    public List<String> getPermitAllPatterns() {
+        return permitAllPatterns;
+    }
+
+    public void setPermitAllPatterns(List<String> permitAllPatterns) {
+        this.permitAllPatterns = permitAllPatterns;
+    }
+
+    public List<String> getPermitAllGetPatterns() {
+        return permitAllGetPatterns;
+    }
+
+    public void setPermitAllGetPatterns(List<String> permitAllGetPatterns) {
+        this.permitAllGetPatterns = permitAllGetPatterns;
+    }
+}

--- a/koduck-backend/src/main/resources/application.yml
+++ b/koduck-backend/src/main/resources/application.yml
@@ -111,6 +111,16 @@ koduck:
     max-page-size: 100
   agent:
     url: ${AGENT_URL:http://agent:8000}
+  security:
+    permit-all-patterns:
+      - /api/v1/auth/**
+      - /actuator/health
+      - /api/v1/health/**
+      - /api/v1/monitoring/**
+      - /ws/**
+      - /api/v1/a-share/**
+    permit-all-get-patterns:
+      - /api/v1/market/**
   mail:
     enabled: ${MAIL_ENABLED:false}
     from: ${MAIL_FROM:noreply@koduck.local}


### PR DESCRIPTION
## Summary
- move permitAll endpoint patterns from SecurityConfig hardcoded constants to configuration properties
- add SecurityEndpointProperties (koduck.security) to manage public endpoint strategy
- keep default behavior unchanged via application.yml defaults
- add security endpoint config document and ADR-0014

## Validation
- mvn -DskipTests compile -f koduck-backend/pom.xml

Closes #318