### PR TITLE
security(config): enforce vault for prod jwt secret

### DIFF
--- a/koduck-backend/docs/ADR-0015-prod-jwt-secret-vault-enforcement.md
+++ b/koduck-backend/docs/ADR-0015-prod-jwt-secret-vault-enforcement.md
@@ -1,0 +1,45 @@
+# ADR-0015: 生产环境 JWT 密钥强制由 Vault 管理
+
+- Status: Accepted
+- Date: 2026-04-01
+- Issue: #320
+
+## Context
+
+虽然项目已引入 Spring Vault 基线，但生产配置未显式强制 Vault，仍存在“Vault 不可用时可能继续以环境变量方式运行”的风险。对于 JWT 签名密钥，此风险等级高。
+
+## Decision
+
+在生产环境 (`application-prod.yml`) 强制启用 Vault：
+
+- `spring.config.import=vault://`（非 optional）；
+- `spring.cloud.vault.enabled=true`；
+- `spring.cloud.vault.fail-fast=true`；
+- JWT 密钥 `JWT_SECRET` 在生产环境必须由 Vault 提供。
+
+## Consequences
+
+正向影响：
+
+- 消除生产环境对 JWT 密钥的“静默降级”路径；
+- 提升密钥治理一致性和可审计性；
+- 将 Vault 连通性与密钥可用性前置为启动前置条件。
+
+代价：
+
+- 生产环境启动对 Vault 可用性产生强依赖；
+- 发布前需提前验证 Vault 路径、策略与令牌配置。
+
+## Alternatives Considered
+
+1. 保持 optional:vault:// 并继续容许环境变量回退
+   - 拒绝：高价值密钥存在治理绕过风险。
+
+2. 仅通过流程约束，不做配置层强制
+   - 拒绝：执行一致性不可保证，审计成本高。
+
+## Verification
+
+- `application-prod.yml` 已显式配置 `vault://`、`enabled=true`、`fail-fast=true`；
+- `SECRET-MANAGEMENT.md` 已新增生产 JWT 强制策略说明；
+- 本地 `mvn -DskipTests compile` 验证通过。

--- a/koduck-backend/docs/README.md
+++ b/koduck-backend/docs/README.md
@@ -133,6 +133,7 @@ mvn spring-boot:run
 
 - 密钥管理文档：[`SECRET-MANAGEMENT.md`](SECRET-MANAGEMENT.md)
 - 密钥治理 ADR：`ADR-0013-spring-vault-secret-management-baseline.md`
+- 生产 JWT 强制 Vault ADR：`ADR-0015-prod-jwt-secret-vault-enforcement.md`
 
 ## Security 策略配置
 

--- a/koduck-backend/docs/SECRET-MANAGEMENT.md
+++ b/koduck-backend/docs/SECRET-MANAGEMENT.md
@@ -60,3 +60,13 @@ export VAULT_KV_CONTEXT=koduck-backend
 - 生产建议使用 TLS（`VAULT_SCHEME=https`）；
 - 建议通过短期令牌或 AppRole 等方式替代长期静态令牌；
 - 启用审计日志并按最小权限分配访问策略。
+
+## 生产环境强制要求（JWT）
+
+自 `ADR-0015` 起，生产环境执行以下强制策略：
+
+- `application-prod.yml` 使用 `spring.config.import=vault://`（非 optional）；
+- `spring.cloud.vault.enabled=true` 且 `fail-fast=true`；
+- 生产 JWT 密钥 `JWT_SECRET` 必须由 Vault 提供，不再接受“无 Vault 可启动”。
+
+建议在 Vault 中维护与运行时一致的键名，并通过最小权限策略限制读取范围。

--- a/koduck-backend/src/main/resources/application-prod.yml
+++ b/koduck-backend/src/main/resources/application-prod.yml
@@ -1,4 +1,10 @@
 spring:
+  config:
+    import: vault://
+  cloud:
+    vault:
+      enabled: true
+      fail-fast: true
   datasource:
     url: jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${DB_NAME:koduck}
     username: ${DB_USERNAME}


### PR DESCRIPTION
## Summary
- enforce Vault in production profile via spring.config.import=vault://
- enable spring.cloud.vault and fail-fast in application-prod.yml
- document production JWT secret policy under secret management doc
- add ADR-0015 for production JWT secret Vault enforcement

## Validation
- mvn -DskipTests compile -f koduck-backend/pom.xml

Closes #320