### PR TITLE
refactor(market): unify data-service provider abstraction

### DIFF
--- a/koduck-backend/docs/ADR-0016-market-provider-abstraction-unification.md
+++ b/koduck-backend/docs/ADR-0016-market-provider-abstraction-unification.md
@@ -1,0 +1,54 @@
+# ADR-0016: 统一 DataService MarketProvider 抽象与错误处理
+
+- Status: Accepted
+- Date: 2026-04-01
+- Issue: #322
+
+## Context
+
+`ForexProvider`、`HKStockProvider`、`FuturesProvider` 过去各自实现了大量重复逻辑：
+
+- DataService URL 组装与 HTTP 调用流程重复；
+- `RestClientException` 处理分散，日志与回退策略不一致；
+- `subscribe/search/tick/kline` 的通用行为在多个类中重复维护。
+
+项目中已有 `AbstractDataServiceMarketProvider`，但上述 Provider 未完全收敛到该抽象层。
+
+## Decision
+
+将 `ForexProvider`、`HKStockProvider`、`FuturesProvider` 统一迁移为继承
+`AbstractDataServiceMarketProvider`：
+
+- 公共调用链（kline/tick/search/subscribe）由基类统一实现；
+- 公共异常处理（`RestClientException`）在基类统一兜底；
+- 子类仅保留市场差异化能力：
+  - symbol 规范化；
+  - mock 数据生成；
+  - DTO/Map 到领域对象转换；
+  - 市场状态判定。
+
+## Consequences
+
+正向影响：
+
+- Provider 接口行为更加一致；
+- 错误处理统一，降低维护与排障成本；
+- 重复代码显著减少，后续新增 DataService Provider 更可复用。
+
+代价：
+
+- 抽象基类职责增大，需要保持稳定性；
+- 子类需要遵循基类约定，定制点需在抽象层扩展。
+
+## Alternatives Considered
+
+1. 保持现状，各 Provider 独立实现
+   - 拒绝：重复逻辑持续扩散，错误处理难以统一。
+
+2. 仅提炼工具类，不统一继承关系
+   - 未采用：仍无法彻底统一调用链与异常处理语义。
+
+## Verification
+
+- `ForexProvider/HKStockProvider/FuturesProvider` 已统一继承抽象基类；
+- 编译验证通过：`mvn -DskipTests compile -f koduck-backend/pom.xml`。

--- a/koduck-backend/docs/README.md
+++ b/koduck-backend/docs/README.md
@@ -140,6 +140,10 @@ mvn spring-boot:run
 - 公开端点配置文档：[`SECURITY-ENDPOINTS.md`](SECURITY-ENDPOINTS.md)
 - 配置化治理 ADR：`ADR-0014-security-permitall-endpoint-externalization.md`
 
+## Market Provider 抽象治理
+
+- Provider 抽象统一 ADR：`ADR-0016-market-provider-abstraction-unification.md`
+
 ## 测试
 
 ```bash

--- a/koduck-backend/src/main/java/com/koduck/service/market/ForexProvider.java
+++ b/koduck-backend/src/main/java/com/koduck/service/market/ForexProvider.java
@@ -4,368 +4,197 @@ import com.koduck.config.properties.DataServiceProperties;
 import com.koduck.market.MarketType;
 import com.koduck.market.model.KlineData;
 import com.koduck.market.model.TickData;
-import com.koduck.market.provider.MarketDataProvider;
 import com.koduck.market.util.DataConverter;
 import com.koduck.service.market.support.MarketDataMapReader;
 import com.koduck.service.market.support.MarketTimeframeParser;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.DayOfWeek;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ThreadLocalRandom;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.core.ParameterizedTypeReference;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
-import org.springframework.lang.NonNull;
-import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
-import org.springframework.web.util.UriComponentsBuilder;
-
-import java.math.BigDecimal;
-import java.math.RoundingMode;
-import java.time.*;
-import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ThreadLocalRandom;
-import java.util.Objects;
 
 /**
  * Forex (Foreign Exchange) market data provider.
- * Fetches forex data from Python Data Service.
- * 
- * Market Characteristics:
- * - 24-hour market (5 days a week)
- * - Trading hours: Sunday 17:00 ET to Friday 17:00 ET
- * - Major pairs: EUR/USD, USD/JPY, GBP/USD, USD/CHF, AUD/USD, USD/CAD
- * - Cross pairs: EUR/GBP, EUR/JPY, GBP/JPY
- * - Asian pairs: USD/CNH, USD/SGD, USD/HKD
- * 
- * Symbol format: BASE/QUOTE (e.g., EUR/USD, USD/CNH)
+ *
+ * <p>Data-service based implementation with unified retrieval and error handling inherited from
+ * {@link AbstractDataServiceMarketProvider}.</p>
  */
 @Component
-public class ForexProvider implements MarketDataProvider {
-    
+public class ForexProvider extends AbstractDataServiceMarketProvider {
+
     private static final Logger LOG = LoggerFactory.getLogger(ForexProvider.class);
     private static final ZoneId NEW_YORK_ZONE = ZoneId.of("America/New_York");
     private static final String FOREX_BASE_PATH = "/forex";
     private static final String PROVIDER_NAME = "akshare-forex";
-    private static final String RESPONSE_TYPE_MESSAGE = "responseType must not be null";
-    private static final ParameterizedTypeReference<List<Map<String, Object>>> LIST_MAP_RESPONSE_TYPE =
-            new ParameterizedTypeReference<List<Map<String, Object>>>() {
-            };
-    private static final ParameterizedTypeReference<Map<String, Object>> MAP_RESPONSE_TYPE =
-            new ParameterizedTypeReference<Map<String, Object>>() {
-            };
-    
-    private final DataServiceProperties properties;
-    private final RestTemplate restTemplate;
-    private final Set<String> subscribedSymbols = ConcurrentHashMap.newKeySet();
-    
+
     // Base rates for major currency pairs (mock data fallback)
-    private final Map<String, BigDecimal> baseRates = new HashMap<>();
-    
+    private final Map<String, BigDecimal> baseRates = new LinkedHashMap<>();
+
     public ForexProvider(
             DataServiceProperties properties,
             @Qualifier("dataServiceRestTemplate") RestTemplate restTemplate) {
-        this.properties = Objects.requireNonNull(properties, "properties must not be null");
-        this.restTemplate = Objects.requireNonNull(restTemplate, "restTemplate must not be null");
-        // Initialize base rates for major pairs
-        baseRates.put("EUR/USD", new BigDecimal("1.0850"));
-        baseRates.put("USD/JPY", new BigDecimal("149.50"));
-        baseRates.put("GBP/USD", new BigDecimal("1.2650"));
-        baseRates.put("USD/CHF", new BigDecimal("0.8820"));
-        baseRates.put("AUD/USD", new BigDecimal("0.6550"));
-        baseRates.put("USD/CAD", new BigDecimal("1.3520"));
-        baseRates.put("EUR/GBP", new BigDecimal("0.8570"));
-        baseRates.put("EUR/JPY", new BigDecimal("162.20"));
-        baseRates.put("GBP/JPY", new BigDecimal("189.20"));
-        baseRates.put("USD/CNH", new BigDecimal("7.2150"));
-        baseRates.put("USD/SGD", new BigDecimal("1.3450"));
-        baseRates.put("USD/HKD", new BigDecimal("7.8230"));
-        baseRates.put("XAU/USD", new BigDecimal("2150.00")); // Gold
-        baseRates.put("XAG/USD", new BigDecimal("24.50"));   // Silver
+        super(properties, restTemplate);
+        initBaseRates();
     }
-    
+
     @Override
     public String getProviderName() {
         return PROVIDER_NAME;
     }
-    
+
     @Override
     public MarketType getMarketType() {
         return MarketType.FOREX;
     }
-    
-    @Override
-    public boolean isAvailable() {
-        return properties.isEnabled();
-    }
-    
-    @Override
-    public int getHealthScore() {
-        if (!properties.isEnabled()) {
-            return 0;
-        }
-        return 100;
-    }
-    
-    @Override
-    public List<KlineData> getKlineData(String symbol, String timeframe, int limit,
-                                         Instant startTime, Instant endTime) 
-            throws MarketDataException {
-        
-        if (!isAvailable()) {
-            LOG.debug("Data service not available, using mock data for forex kline");
-            return generateMockKlineData(symbol, timeframe, limit, startTime, endTime);
-        }
-        
-        String normalizedSymbol = normalizeSymbol(symbol);
-        
-        try {
-            UriComponentsBuilder builder = UriComponentsBuilder
-                    .fromUriString(properties.getBaseUrl() + FOREX_BASE_PATH + "/kline/{symbol}")
-                    .queryParam("timeframe", timeframe)
-                    .queryParam("limit", limit);
-            
-            if (startTime != null) {
-                builder.queryParam("startTime", startTime.toEpochMilli());
-            }
-            if (endTime != null) {
-                builder.queryParam("endTime", endTime.toEpochMilli());
-            }
-            
-            String url = builder.buildAndExpand(normalizedSymbol).toUriString();
-            
-            LOG.debug("Fetching forex kline from data service: symbol={}, timeframe={}", 
-                    normalizedSymbol, timeframe);
-            
-                ResponseEntity<List<Map<String, Object>>> response = restTemplate.exchange(
-                    url,
-                    getHttpGet(),
-                    null,
-                    Objects.requireNonNull(LIST_MAP_RESPONSE_TYPE, RESPONSE_TYPE_MESSAGE)
-                );
-            
-            List<Map<String, Object>> data = response.getBody();
-            if (data == null || data.isEmpty()) {
-                return generateMockKlineData(symbol, timeframe, limit, startTime, endTime);
-            }
-            
-            return convertToKlineData(data, normalizedSymbol, timeframe);
-            
-        } catch (RestClientException e) {
-            LOG.error("Failed to fetch forex kline from data service: {}", e.getMessage());
-            return generateMockKlineData(symbol, timeframe, limit, startTime, endTime);
-        }
-    }
-    
-    @Override
-    public Optional<TickData> getRealTimeTick(String symbol) throws MarketDataException {
-        if (!isAvailable()) {
-            LOG.debug("Data service not available, using mock data for forex tick");
-            return generateMockTickData(symbol);
-        }
-        
-        String normalizedSymbol = normalizeSymbol(symbol);
-        
-        try {
-            String url = UriComponentsBuilder
-                    .fromUriString(properties.getBaseUrl() + FOREX_BASE_PATH + "/price/{symbol}")
-                    .buildAndExpand(normalizedSymbol)
-                    .toUriString();
-            
-            LOG.debug("Fetching forex price from data service: symbol={}", normalizedSymbol);
-            
-                ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
-                    url,
-                    getHttpGet(),
-                    null,
-                    Objects.requireNonNull(MAP_RESPONSE_TYPE, RESPONSE_TYPE_MESSAGE)
-                );
-            
-            Map<String, Object> data = response.getBody();
-            if (data == null || data.isEmpty()) {
-                return generateMockTickData(symbol);
-            }
-            
-            return Optional.of(convertToTickData(data, normalizedSymbol));
-            
-        } catch (RestClientException e) {
-            LOG.error("Failed to fetch forex price from data service: {}", e.getMessage());
-            return generateMockTickData(symbol);
-        }
-    }
-    
-    @Override
-    public void subscribeRealTime(List<String> symbols, RealTimeDataCallback callback) 
-            throws MarketDataException {
-        
-        if (!isAvailable()) {
-            throw new MarketDataException("Provider is not available");
-        }
-        
-        symbols.forEach(sym -> subscribedSymbols.add(normalizeSymbol(sym)));
-        LOG.info("Subscribed to {} forex pairs for real-time data", symbols.size());
-    }
-    
-    @Override
-    public void unsubscribeRealTime(List<String> symbols) {
-        symbols.forEach(sym -> subscribedSymbols.remove(normalizeSymbol(sym)));
-        LOG.info("Unsubscribed from {} forex pairs", symbols.size());
-    }
-    
+
     @Override
     public MarketStatus getMarketStatus() {
         ZonedDateTime now = ZonedDateTime.now(NEW_YORK_ZONE);
         DayOfWeek dayOfWeek = now.getDayOfWeek();
         LocalTime time = now.toLocalTime();
-        
+
         // Forex trades 24 hours from Sunday 17:00 ET to Friday 17:00 ET
-        boolean isWeekend = dayOfWeek == DayOfWeek.SATURDAY ||
-                           (dayOfWeek == DayOfWeek.SUNDAY && time.isBefore(LocalTime.of(17, 0))) ||
-                           (dayOfWeek == DayOfWeek.FRIDAY && time.isAfter(LocalTime.of(17, 0)));
-        
+        boolean isWeekend = dayOfWeek == DayOfWeek.SATURDAY
+                || (dayOfWeek == DayOfWeek.SUNDAY && time.isBefore(LocalTime.of(17, 0)))
+                || (dayOfWeek == DayOfWeek.FRIDAY && time.isAfter(LocalTime.of(17, 0)));
+
         if (isWeekend) {
             return MarketStatus.CLOSED;
         }
-        
+
         return MarketStatus.OPEN;
     }
-    
+
     @Override
-    public List<SymbolInfo> searchSymbols(String keyword, int limit) {
-        if (!isAvailable()) {
-            return generateMockSearchResults(keyword, limit);
-        }
-        
-        try {
-            String url = UriComponentsBuilder
-                    .fromUriString(properties.getBaseUrl() + FOREX_BASE_PATH + "/search")
-                    .queryParam("keyword", keyword)
-                    .queryParam("limit", limit)
-                    .toUriString();
-            
-                ResponseEntity<List<Map<String, Object>>> response = restTemplate.exchange(
-                    url,
-                    getHttpGet(),
-                    null,
-                    Objects.requireNonNull(LIST_MAP_RESPONSE_TYPE, RESPONSE_TYPE_MESSAGE)
-                );
-            
-            List<Map<String, Object>> data = response.getBody();
-            if (data == null || data.isEmpty()) {
-                return generateMockSearchResults(keyword, limit);
-            }
-            
-            return data.stream()
-                    .map(this::convertToSymbolInfo)
-                    .limit(limit)
-                    .toList();
-                    
-        } catch (RestClientException e) {
-            LOG.error("Failed to search forex pairs: {}", e.getMessage());
-            return generateMockSearchResults(keyword, limit);
-        }
+    protected Logger logger() {
+        return LOG;
     }
-    
-    // Helper methods
-    
-    private String normalizeSymbol(String symbol) {
+
+    @Override
+    protected String getDataServiceBasePath() {
+        return FOREX_BASE_PATH;
+    }
+
+    @Override
+    protected String getLogMarketName() {
+        return "forex";
+    }
+
+    @Override
+    protected String getSubscriptionLabel() {
+        return "forex pairs";
+    }
+
+    @Override
+    protected String normalizeSymbol(String symbol) {
         if (symbol == null || symbol.trim().isEmpty()) {
             return "";
         }
-        
+
         String normalized = symbol.trim().toUpperCase(Locale.ROOT);
-        
+
         // Handle different formats: EURUSD, EUR-USD, EUR_USD -> EUR/USD
         normalized = normalized.replace("-", "/").replace("_", "/");
-        
+
         // If no separator and 6 chars, insert / in middle (e.g., EURUSD -> EUR/USD)
-        if (!normalized.contains("/") && normalized.length() == 6 && 
-            normalized.matches("[A-Z]{6}")) {
+        if (!normalized.contains("/") && normalized.length() == 6
+                && normalized.matches("[A-Z]{6}")) {
             normalized = normalized.substring(0, 3) + "/" + normalized.substring(3);
         }
-        
-        // Handle XAUUSD format (Gold)
-        if (!normalized.contains("/") && normalized.startsWith("XAU") && 
-            normalized.length() == 6) {
+
+        // Handle XAUUSD/XAGUSD format
+        if (!normalized.contains("/") && normalized.length() == 6
+                && (normalized.startsWith("XAU") || normalized.startsWith("XAG"))) {
             normalized = normalized.substring(0, 3) + "/" + normalized.substring(3);
         }
-        
-        // Handle XAGUSD format (Silver)
-        if (!normalized.contains("/") && normalized.startsWith("XAG") && 
-            normalized.length() == 6) {
-            normalized = normalized.substring(0, 3) + "/" + normalized.substring(3);
-        }
-        
+
         return normalized;
     }
-    
-    private List<KlineData> generateMockKlineData(String symbol, String timeframe, int limit,
-                                                   Instant startTime, Instant endTime) {
+
+    @Override
+    protected List<KlineData> generateMockKlineData(String symbol, String timeframe, int limit,
+                                                    Instant startTime, Instant endTime) {
         List<KlineData> klines = new ArrayList<>();
         String normalizedSymbol = normalizeSymbol(symbol);
         BigDecimal baseRate = baseRates.getOrDefault(normalizedSymbol, new BigDecimal("1.0000"));
-        
+
         Instant currentTime = endTime != null ? endTime : Instant.now();
         if (endTime == null && startTime != null) {
             currentTime = startTime;
         }
         Duration interval = MarketTimeframeParser.parseWithFourHour(timeframe);
-        
-        // Adjust volatility based on pair (precious metals more volatile)
+
+        // Precious metals are more volatile than major forex pairs
         double volatility = normalizedSymbol.startsWith("XAU") || normalizedSymbol.startsWith("XAG")
-            ? 0.008 : 0.0015;
-        
+                ? 0.008 : 0.0015;
+
         BigDecimal currentRate = baseRate;
         for (int i = 0; i < limit; i++) {
             double changePercent = (ThreadLocalRandom.current().nextDouble() - 0.5) * volatility * 2;
             BigDecimal change = currentRate.multiply(BigDecimal.valueOf(changePercent));
             BigDecimal close = currentRate.add(change);
-            
-            BigDecimal high = close.multiply(BigDecimal.valueOf(1 + ThreadLocalRandom.current().nextDouble() * volatility));
-            BigDecimal low = close.multiply(BigDecimal.valueOf(1 - ThreadLocalRandom.current().nextDouble() * volatility));
+
+            BigDecimal high = close.multiply(
+                    BigDecimal.valueOf(1 + ThreadLocalRandom.current().nextDouble() * volatility));
+            BigDecimal low = close.multiply(
+                    BigDecimal.valueOf(1 - ThreadLocalRandom.current().nextDouble() * volatility));
             BigDecimal open = currentRate;
-            
+
             long volume = ThreadLocalRandom.current().nextLong(10_000L, 1_000_000L);
-            
+
             klines.add(KlineData.builder()
-                .symbol(normalizedSymbol)
-                .market(MarketType.FOREX.getCode())
-                .timestamp(currentTime)
-                .open(open)
-                .high(high)
-                .low(low)
-                .close(close)
-                .volume(volume)
-                .amount(close.multiply(BigDecimal.valueOf(volume)))
-                .timeframe(timeframe)
-                .build());
-            
+                    .symbol(normalizedSymbol)
+                    .market(MarketType.FOREX.getCode())
+                    .timestamp(currentTime)
+                    .open(open)
+                    .high(high)
+                    .low(low)
+                    .close(close)
+                    .volume(volume)
+                    .amount(close.multiply(BigDecimal.valueOf(volume)))
+                    .timeframe(timeframe)
+                    .build());
+
             currentRate = close;
             currentTime = currentTime.minus(interval);
         }
-        
+
         Collections.reverse(klines);
         return klines;
     }
-    
-    private Optional<TickData> generateMockTickData(String symbol) {
+
+    @Override
+    protected Optional<TickData> generateMockTickData(String symbol) {
         String normalizedSymbol = normalizeSymbol(symbol);
         BigDecimal baseRate = baseRates.getOrDefault(normalizedSymbol, new BigDecimal("1.0000"));
-        
-        // Adjust volatility based on pair
+
         double volatility = normalizedSymbol.startsWith("XAU") || normalizedSymbol.startsWith("XAG")
                 ? 0.005 : 0.001;
-        
+
         double changePercent = (ThreadLocalRandom.current().nextDouble() - 0.5) * volatility * 2;
         BigDecimal price = baseRate.multiply(BigDecimal.valueOf(1 + changePercent));
         BigDecimal change = price.subtract(baseRate);
         BigDecimal changePercentValue = change.divide(baseRate, 4, RoundingMode.HALF_UP)
-                                              .multiply(BigDecimal.valueOf(100));
-        
+                .multiply(BigDecimal.valueOf(100));
+
         long volume = ThreadLocalRandom.current().nextLong(100_000L, 5_000_000L);
-        
-        // Calculate pip size based on pair
+
         int pipDigits = 4;
         if (normalizedSymbol.startsWith("XAU")) {
             pipDigits = 2;
@@ -373,93 +202,93 @@ public class ForexProvider implements MarketDataProvider {
             pipDigits = 3;
         }
         BigDecimal pipSize = BigDecimal.valueOf(Math.pow(10, -pipDigits));
-        
+
         TickData tickData = TickData.builder()
-            .symbol(normalizedSymbol)
-            .market(MarketType.FOREX.getCode())
-            .timestamp(Instant.now())
-            .price(price)
-            .change(change)
-            .changePercent(changePercentValue)
-            .volume(volume)
-            .amount(price.multiply(BigDecimal.valueOf(volume)))
-            .bidPrice(price.subtract(pipSize.multiply(BigDecimal.valueOf(2))))
-            .bidVolume(ThreadLocalRandom.current().nextLong(100L, 10_000L))
-            .askPrice(price.add(pipSize.multiply(BigDecimal.valueOf(2))))
-            .askVolume(ThreadLocalRandom.current().nextLong(100L, 10_000L))
-            .dayHigh(price.multiply(BigDecimal.valueOf(1.01)))
-            .dayLow(price.multiply(BigDecimal.valueOf(0.99)))
-            .open(baseRate)
-            .prevClose(baseRate)
-            .build();
-        
+                .symbol(normalizedSymbol)
+                .market(MarketType.FOREX.getCode())
+                .timestamp(Instant.now())
+                .price(price)
+                .change(change)
+                .changePercent(changePercentValue)
+                .volume(volume)
+                .amount(price.multiply(BigDecimal.valueOf(volume)))
+                .bidPrice(price.subtract(pipSize.multiply(BigDecimal.valueOf(2))))
+                .bidVolume(ThreadLocalRandom.current().nextLong(100L, 10_000L))
+                .askPrice(price.add(pipSize.multiply(BigDecimal.valueOf(2))))
+                .askVolume(ThreadLocalRandom.current().nextLong(100L, 10_000L))
+                .dayHigh(price.multiply(BigDecimal.valueOf(1.01)))
+                .dayLow(price.multiply(BigDecimal.valueOf(0.99)))
+                .open(baseRate)
+                .prevClose(baseRate)
+                .build();
+
         return Optional.of(tickData);
     }
-    
-    private List<SymbolInfo> generateMockSearchResults(String keyword, int limit) {
+
+    @Override
+    protected List<SymbolInfo> generateMockSearchResults(String keyword, int limit) {
         List<SymbolInfo> results = new ArrayList<>();
         String upperKeyword = keyword.toUpperCase(Locale.ROOT);
-        
+
         Map<String, String> forexPairs = new LinkedHashMap<>();
-        // Major pairs
         forexPairs.put("EUR/USD", "Euro / US Dollar");
         forexPairs.put("USD/JPY", "US Dollar / Japanese Yen");
         forexPairs.put("GBP/USD", "British Pound / US Dollar");
         forexPairs.put("USD/CHF", "US Dollar / Swiss Franc");
         forexPairs.put("AUD/USD", "Australian Dollar / US Dollar");
         forexPairs.put("USD/CAD", "US Dollar / Canadian Dollar");
-        // Cross pairs
         forexPairs.put("EUR/GBP", "Euro / British Pound");
         forexPairs.put("EUR/JPY", "Euro / Japanese Yen");
         forexPairs.put("GBP/JPY", "British Pound / Japanese Yen");
-        // Asian pairs
         forexPairs.put("USD/CNH", "US Dollar / Chinese Yuan (Offshore)");
         forexPairs.put("USD/SGD", "US Dollar / Singapore Dollar");
         forexPairs.put("USD/HKD", "US Dollar / Hong Kong Dollar");
-        // Precious metals
         forexPairs.put("XAU/USD", "Gold / US Dollar");
         forexPairs.put("XAG/USD", "Silver / US Dollar");
-        
+
         forexPairs.entrySet().stream()
-            .filter(e -> e.getKey().contains(upperKeyword) || 
-                        e.getValue().toUpperCase(Locale.ROOT).contains(upperKeyword))
-            .limit(limit)
-            .forEach(e -> results.add(new SymbolInfo(
-                e.getKey(),
-                e.getValue(),
-                MarketType.FOREX.getCode(),
-                "FOREX",
-                "forex"
-            )));
-        
+                .filter(e -> e.getKey().contains(upperKeyword)
+                        || e.getValue().toUpperCase(Locale.ROOT).contains(upperKeyword))
+                .limit(limit)
+                .forEach(e -> results.add(new SymbolInfo(
+                        e.getKey(),
+                        e.getValue(),
+                        MarketType.FOREX.getCode(),
+                        "FOREX",
+                        "forex"
+                )));
+
         return results;
     }
-    
-    private List<KlineData> convertToKlineData(List<Map<String, Object>> data, String symbol, String timeframe) {
+
+    @Override
+    protected List<KlineData> convertToKlineData(List<Map<String, Object>> data, String symbol,
+                                                 String timeframe) {
         List<KlineData> klines = new ArrayList<>();
-        
+
         for (Map<String, Object> item : data) {
             klines.add(KlineData.builder()
-                .symbol(symbol)
-                .market(MarketType.FOREX.getCode())
-                .timestamp(DataConverter.toInstantFromMillis(MarketDataMapReader.getLong(item, "timestamp")))
-                .open(DataConverter.toBigDecimal(MarketDataMapReader.getString(item, "open")))
-                .high(DataConverter.toBigDecimal(MarketDataMapReader.getString(item, "high")))
-                .low(DataConverter.toBigDecimal(MarketDataMapReader.getString(item, "low")))
-                .close(DataConverter.toBigDecimal(MarketDataMapReader.getString(item, "close")))
-                .volume(MarketDataMapReader.getLong(item, "volume"))
-                .amount(DataConverter.toBigDecimal(MarketDataMapReader.getString(item, "amount")))
-                .timeframe(timeframe)
-                .build());
+                    .symbol(symbol)
+                    .market(MarketType.FOREX.getCode())
+                    .timestamp(DataConverter.toInstantFromMillis(MarketDataMapReader.getLong(item, "timestamp")))
+                    .open(DataConverter.toBigDecimal(MarketDataMapReader.getString(item, "open")))
+                    .high(DataConverter.toBigDecimal(MarketDataMapReader.getString(item, "high")))
+                    .low(DataConverter.toBigDecimal(MarketDataMapReader.getString(item, "low")))
+                    .close(DataConverter.toBigDecimal(MarketDataMapReader.getString(item, "close")))
+                    .volume(MarketDataMapReader.getLong(item, "volume"))
+                    .amount(DataConverter.toBigDecimal(MarketDataMapReader.getString(item, "amount")))
+                    .timeframe(timeframe)
+                    .build());
         }
-        
+
         return klines;
     }
-    
-    private TickData convertToTickData(Map<String, Object> data, String symbol) {
+
+    @Override
+    protected TickData convertToTickData(Map<String, Object> data, String symbol) {
         return TickData.builder()
-            .symbol(symbol)
-            .market(MarketType.FOREX.getCode())
+                .symbol(symbol)
+                .market(MarketType.FOREX.getCode())
                 .timestamp(DataConverter.toInstantFromMillis(MarketDataMapReader.getLong(data, "timestamp")))
                 .price(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "price")))
                 .change(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "change")))
@@ -474,22 +303,34 @@ public class ForexProvider implements MarketDataProvider {
                 .dayLow(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "low")))
                 .open(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "open")))
                 .prevClose(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "prevClose")))
-            .build();
+                .build();
     }
-    
-    private SymbolInfo convertToSymbolInfo(Map<String, Object> data) {
+
+    @Override
+    protected SymbolInfo convertToSymbolInfo(Map<String, Object> data) {
         return new SymbolInfo(
-            MarketDataMapReader.getString(data, "symbol"),
-            MarketDataMapReader.getString(data, "name"),
-            MarketType.FOREX.getCode(),
-            "FOREX",
-            "forex"
+                MarketDataMapReader.getString(data, "symbol"),
+                MarketDataMapReader.getString(data, "name"),
+                MarketType.FOREX.getCode(),
+                "FOREX",
+                "forex"
         );
     }
 
-    
-    private static HttpMethod getHttpGet() {
-        return Objects.requireNonNull(HttpMethod.GET, "HTTP GET must not be null");
+    private void initBaseRates() {
+        baseRates.put("EUR/USD", new BigDecimal("1.0850"));
+        baseRates.put("USD/JPY", new BigDecimal("149.50"));
+        baseRates.put("GBP/USD", new BigDecimal("1.2650"));
+        baseRates.put("USD/CHF", new BigDecimal("0.8820"));
+        baseRates.put("AUD/USD", new BigDecimal("0.6550"));
+        baseRates.put("USD/CAD", new BigDecimal("1.3520"));
+        baseRates.put("EUR/GBP", new BigDecimal("0.8570"));
+        baseRates.put("EUR/JPY", new BigDecimal("162.20"));
+        baseRates.put("GBP/JPY", new BigDecimal("189.20"));
+        baseRates.put("USD/CNH", new BigDecimal("7.2150"));
+        baseRates.put("USD/SGD", new BigDecimal("1.3450"));
+        baseRates.put("USD/HKD", new BigDecimal("7.8230"));
+        baseRates.put("XAU/USD", new BigDecimal("2150.00"));
+        baseRates.put("XAG/USD", new BigDecimal("24.50"));
     }
-    
 }

--- a/koduck-backend/src/main/java/com/koduck/service/market/FuturesProvider.java
+++ b/koduck-backend/src/main/java/com/koduck/service/market/FuturesProvider.java
@@ -4,22 +4,9 @@ import com.koduck.config.properties.DataServiceProperties;
 import com.koduck.market.MarketType;
 import com.koduck.market.model.KlineData;
 import com.koduck.market.model.TickData;
-import com.koduck.market.provider.MarketDataProvider;
 import com.koduck.market.util.DataConverter;
 import com.koduck.service.market.support.FuturesMockDataSupport;
 import com.koduck.service.market.support.MarketDataMapReader;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.core.ParameterizedTypeReference;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.ResponseEntity;
-import org.springframework.lang.NonNull;
-import org.springframework.stereotype.Component;
-import org.springframework.web.client.RestClientException;
-import org.springframework.web.client.RestTemplate;
-import org.springframework.web.util.UriComponentsBuilder;
-
 import java.math.BigDecimal;
 import java.time.DayOfWeek;
 import java.time.Instant;
@@ -30,200 +17,53 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
 
 /**
  * Futures market data provider.
- * Fetches futures data from Python Data Service.
- * 
- * Market Characteristics:
- * - Commodity Futures: Gold, Silver, Copper, Crude Oil, etc.
- * - Financial Futures: Index futures, Bond futures
- * - Trading hours vary by exchange and product
- * - Contract codes include delivery month (e.g., AU2412 = Gold Dec 2024)
- * 
- * Chinese Futures (主要上海、大连、郑州、中金所):
- * - 上期所 (SHFE): Gold (AU), Silver (AG), Copper (CU), etc.
- * - 大商所 (DCE): Iron Ore (I), Soybean (A), etc.
- * - 郑商所 (ZCE): PTA, etc.
- * - 中金所 (CFFEX): CSI300 (IF), SSE50 (IH), etc.
- * 
- * Symbol format varies:
- * - Chinese: AU2412, AG2406, CU2403
- * - International: GC (Gold), CL (Crude Oil), ES (E-mini S&P 500)
+ *
+ * <p>Data-service based implementation with unified retrieval and error handling inherited from
+ * {@link AbstractDataServiceMarketProvider}.</p>
  */
 @Component
-public class FuturesProvider implements MarketDataProvider {
-    
+public class FuturesProvider extends AbstractDataServiceMarketProvider {
+
     private static final Logger LOG = LoggerFactory.getLogger(FuturesProvider.class);
     private static final ZoneId BEIJING_ZONE = ZoneId.of("Asia/Shanghai");
     private static final String FUTURES_BASE_PATH = "/futures";
     private static final String PROVIDER_NAME = "akshare-futures";
-    private static final String HTTP_GET_MESSAGE = "HTTP GET must not be null";
-    private static final String RESPONSE_TYPE_MESSAGE = "responseType must not be null";
-    private static final HttpMethod HTTP_GET = HttpMethod.GET;
-    private static final ParameterizedTypeReference<List<Map<String, Object>>> LIST_MAP_RESPONSE_TYPE =
-        new ParameterizedTypeReference<List<Map<String, Object>>>() {
-        };
-    private static final ParameterizedTypeReference<Map<String, Object>> MAP_RESPONSE_TYPE =
-        new ParameterizedTypeReference<Map<String, Object>>() {
-        };
-    
-    private final DataServiceProperties properties;
-    private final RestTemplate restTemplate;
-    private final Set<String> subscribedSymbols = ConcurrentHashMap.newKeySet();
-    
+
     // Base prices for popular futures (mock data fallback)
     private final Map<String, BigDecimal> basePrices;
-    
+
     public FuturesProvider(
             DataServiceProperties properties,
             @Qualifier("dataServiceRestTemplate") RestTemplate restTemplate) {
-        this.properties = Objects.requireNonNull(properties, "properties must not be null");
-        this.restTemplate = Objects.requireNonNull(restTemplate, "restTemplate must not be null");
+        super(properties, restTemplate);
         this.basePrices = FuturesMockDataSupport.defaultBasePrices();
     }
-    
+
     @Override
     public String getProviderName() {
         return PROVIDER_NAME;
     }
-    
+
     @Override
     public MarketType getMarketType() {
         return MarketType.FUTURES;
     }
-    
-    @Override
-    public boolean isAvailable() {
-        return properties.isEnabled();
-    }
-    
-    @Override
-    public int getHealthScore() {
-        if (!properties.isEnabled()) {
-            return 0;
-        }
-        return 100;
-    }
-    
-    @Override
-    public List<KlineData> getKlineData(String symbol, String timeframe, int limit,
-                                         Instant startTime, Instant endTime) 
-            throws MarketDataException {
-        
-        if (!isAvailable()) {
-            LOG.debug("Data service not available, using mock data for futures kline");
-            return FuturesMockDataSupport.generateMockKlineData(
-                normalizeSymbol(symbol), timeframe, limit, endTime, basePrices);
-        }
-        
-        String normalizedSymbol = normalizeSymbol(symbol);
-        
-        try {
-            UriComponentsBuilder builder = UriComponentsBuilder
-                    .fromUriString(properties.getBaseUrl() + FUTURES_BASE_PATH + "/kline/{symbol}")
-                    .queryParam("timeframe", timeframe)
-                    .queryParam("limit", limit);
-            
-            if (startTime != null) {
-                builder.queryParam("startTime", startTime.toEpochMilli());
-            }
-            if (endTime != null) {
-                builder.queryParam("endTime", endTime.toEpochMilli());
-            }
-            
-            String url = builder.buildAndExpand(normalizedSymbol).toUriString();
-            
-            LOG.debug("Fetching futures kline from data service: symbol={}, timeframe={}", 
-                    normalizedSymbol, timeframe);
-            
-            ResponseEntity<List<Map<String, Object>>> response = restTemplate.exchange(
-                    url,
-                    getHttpGet(),
-                    null,
-                    getListMapResponseType()
-            );
-            
-            List<Map<String, Object>> data = response.getBody();
-            if (data == null || data.isEmpty()) {
-                return FuturesMockDataSupport.generateMockKlineData(
-                    normalizedSymbol, timeframe, limit, endTime, basePrices);
-            }
-            
-            return convertToKlineData(data, normalizedSymbol, timeframe);
-            
-        } catch (RestClientException e) {
-            LOG.error("Failed to fetch futures kline from data service: {}", e.getMessage());
-            return FuturesMockDataSupport.generateMockKlineData(
-                normalizeSymbol(symbol), timeframe, limit, endTime, basePrices);
-        }
-    }
-    
-    @Override
-    public Optional<TickData> getRealTimeTick(String symbol) throws MarketDataException {
-        if (!isAvailable()) {
-            LOG.debug("Data service not available, using mock data for futures tick");
-            return Optional.of(FuturesMockDataSupport.generateMockTickData(normalizeSymbol(symbol), basePrices));
-        }
-        
-        String normalizedSymbol = normalizeSymbol(symbol);
-        
-        try {
-            String url = UriComponentsBuilder
-                    .fromUriString(properties.getBaseUrl() + FUTURES_BASE_PATH + "/price/{symbol}")
-                    .buildAndExpand(normalizedSymbol)
-                    .toUriString();
-            
-            LOG.debug("Fetching futures price from data service: symbol={}", normalizedSymbol);
-            
-            ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
-                    url,
-                    getHttpGet(),
-                    null,
-                    getMapResponseType()
-            );
-            
-            Map<String, Object> data = response.getBody();
-            if (data == null || data.isEmpty()) {
-                return Optional.of(FuturesMockDataSupport.generateMockTickData(normalizedSymbol, basePrices));
-            }
-            
-            return Optional.of(convertToTickData(data, normalizedSymbol));
-            
-        } catch (RestClientException e) {
-            LOG.error("Failed to fetch futures price from data service: {}", e.getMessage());
-            return Optional.of(FuturesMockDataSupport.generateMockTickData(normalizeSymbol(symbol), basePrices));
-        }
-    }
-    
-    @Override
-    public void subscribeRealTime(List<String> symbols, RealTimeDataCallback callback) 
-            throws MarketDataException {
-        
-        if (!isAvailable()) {
-            throw new MarketDataException("Provider is not available");
-        }
-        
-        symbols.forEach(sym -> subscribedSymbols.add(normalizeSymbol(sym)));
-        LOG.info("Subscribed to {} futures contracts for real-time data", symbols.size());
-    }
-    
-    @Override
-    public void unsubscribeRealTime(List<String> symbols) {
-        symbols.forEach(sym -> subscribedSymbols.remove(normalizeSymbol(sym)));
-        LOG.info("Unsubscribed from {} futures contracts", symbols.size());
-    }
-    
+
     @Override
     public MarketStatus getMarketStatus() {
         ZonedDateTime now = ZonedDateTime.now(BEIJING_ZONE);
         LocalTime time = now.toLocalTime();
         DayOfWeek dayOfWeek = now.getDayOfWeek();
-        
+
         if (FuturesMockDataSupport.isWeekend(dayOfWeek)) {
             return MarketStatus.CLOSED;
         }
@@ -242,124 +82,113 @@ public class FuturesProvider implements MarketDataProvider {
 
         return MarketStatus.CLOSED;
     }
-    
+
     @Override
-    public List<SymbolInfo> searchSymbols(String keyword, int limit) {
-        if (!isAvailable()) {
-            return FuturesMockDataSupport.generateMockSearchResults(keyword, limit);
-        }
-        
-        try {
-            String url = UriComponentsBuilder
-                    .fromUriString(properties.getBaseUrl() + FUTURES_BASE_PATH + "/search")
-                    .queryParam("keyword", keyword)
-                    .queryParam("limit", limit)
-                    .toUriString();
-            
-            ResponseEntity<List<Map<String, Object>>> response = restTemplate.exchange(
-                    url,
-                    getHttpGet(),
-                    null,
-                    getListMapResponseType()
-            );
-            
-            List<Map<String, Object>> data = response.getBody();
-            if (data == null || data.isEmpty()) {
-                return FuturesMockDataSupport.generateMockSearchResults(keyword, limit);
-            }
-            
-            return data.stream()
-                    .map(this::convertToSymbolInfo)
-                    .limit(limit)
-                    .toList();
-                    
-        } catch (RestClientException e) {
-            LOG.error("Failed to search futures: {}", e.getMessage());
-            return FuturesMockDataSupport.generateMockSearchResults(keyword, limit);
-        }
+    protected Logger logger() {
+        return LOG;
     }
-    
-    // Helper methods
-    
-    private String normalizeSymbol(String symbol) {
+
+    @Override
+    protected String getDataServiceBasePath() {
+        return FUTURES_BASE_PATH;
+    }
+
+    @Override
+    protected String getLogMarketName() {
+        return "futures";
+    }
+
+    @Override
+    protected String getSubscriptionLabel() {
+        return "futures contracts";
+    }
+
+    @Override
+    protected String normalizeSymbol(String symbol) {
         if (symbol == null || symbol.trim().isEmpty()) {
             return "";
         }
-        
+
         String normalized = symbol.trim().toUpperCase(Locale.ROOT);
-        
-        // Remove any exchange suffix if present
+
+        // Remove exchange suffix if present.
         if (normalized.contains(".")) {
-            normalized = normalized.substring(0, normalized.indexOf("."));
+            normalized = normalized.substring(0, normalized.indexOf('.'));
         }
-        
+
         return normalized;
     }
 
-    
-    private static HttpMethod getHttpGet() {
-        return Objects.requireNonNull(HTTP_GET, HTTP_GET_MESSAGE);
+    @Override
+    protected List<KlineData> generateMockKlineData(String symbol, String timeframe, int limit,
+                                                    Instant startTime, Instant endTime) {
+        return FuturesMockDataSupport.generateMockKlineData(
+                normalizeSymbol(symbol), timeframe, limit, endTime, basePrices);
     }
 
-    
-    private static ParameterizedTypeReference<List<Map<String, Object>>> getListMapResponseType() {
-        return Objects.requireNonNull(LIST_MAP_RESPONSE_TYPE, RESPONSE_TYPE_MESSAGE);
+    @Override
+    protected Optional<TickData> generateMockTickData(String symbol) {
+        return Optional.of(FuturesMockDataSupport.generateMockTickData(normalizeSymbol(symbol), basePrices));
     }
 
-    
-    private static ParameterizedTypeReference<Map<String, Object>> getMapResponseType() {
-        return Objects.requireNonNull(MAP_RESPONSE_TYPE, RESPONSE_TYPE_MESSAGE);
+    @Override
+    protected List<SymbolInfo> generateMockSearchResults(String keyword, int limit) {
+        return FuturesMockDataSupport.generateMockSearchResults(keyword, limit);
     }
-    
-    private List<KlineData> convertToKlineData(List<Map<String, Object>> data, String symbol, String timeframe) {
+
+    @Override
+    protected List<KlineData> convertToKlineData(List<Map<String, Object>> data, String symbol,
+                                                 String timeframe) {
         List<KlineData> klines = new ArrayList<>();
-        
+
         for (Map<String, Object> item : data) {
             klines.add(KlineData.builder()
-                .symbol(symbol)
-                .market(MarketType.FUTURES.getCode())
-                .timestamp(DataConverter.toInstantFromMillis(MarketDataMapReader.getLong(item, "timestamp")))
-                .open(DataConverter.toBigDecimal(MarketDataMapReader.getString(item, "open")))
-                .high(DataConverter.toBigDecimal(MarketDataMapReader.getString(item, "high")))
-                .low(DataConverter.toBigDecimal(MarketDataMapReader.getString(item, "low")))
-                .close(DataConverter.toBigDecimal(MarketDataMapReader.getString(item, "close")))
-                .volume(MarketDataMapReader.getLong(item, "volume"))
-                .amount(DataConverter.toBigDecimal(MarketDataMapReader.getString(item, "amount")))
-                .timeframe(timeframe)
-                .build());
+                    .symbol(symbol)
+                    .market(MarketType.FUTURES.getCode())
+                    .timestamp(DataConverter.toInstantFromMillis(MarketDataMapReader.getLong(item, "timestamp")))
+                    .open(DataConverter.toBigDecimal(MarketDataMapReader.getString(item, "open")))
+                    .high(DataConverter.toBigDecimal(MarketDataMapReader.getString(item, "high")))
+                    .low(DataConverter.toBigDecimal(MarketDataMapReader.getString(item, "low")))
+                    .close(DataConverter.toBigDecimal(MarketDataMapReader.getString(item, "close")))
+                    .volume(MarketDataMapReader.getLong(item, "volume"))
+                    .amount(DataConverter.toBigDecimal(MarketDataMapReader.getString(item, "amount")))
+                    .timeframe(timeframe)
+                    .build());
         }
-        
+
         return klines;
     }
-    
-    private TickData convertToTickData(Map<String, Object> data, String symbol) {
+
+    @Override
+    protected TickData convertToTickData(Map<String, Object> data, String symbol) {
         return TickData.builder()
-            .symbol(symbol)
-            .market(MarketType.FUTURES.getCode())
-            .timestamp(DataConverter.toInstantFromMillis(MarketDataMapReader.getLong(data, "timestamp")))
-            .price(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "price")))
-            .change(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "change")))
-            .changePercent(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "changePercent")))
-            .volume(MarketDataMapReader.getLong(data, "volume"))
-            .amount(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "amount")))
-            .bidPrice(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "bidPrice")))
-            .bidVolume(MarketDataMapReader.getLong(data, "bidVolume"))
-            .askPrice(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "askPrice")))
-            .askVolume(MarketDataMapReader.getLong(data, "askVolume"))
-            .dayHigh(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "high")))
-            .dayLow(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "low")))
-            .open(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "open")))
-            .prevClose(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "prevClose")))
-            .build();
+                .symbol(symbol)
+                .market(MarketType.FUTURES.getCode())
+                .timestamp(DataConverter.toInstantFromMillis(MarketDataMapReader.getLong(data, "timestamp")))
+                .price(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "price")))
+                .change(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "change")))
+                .changePercent(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "changePercent")))
+                .volume(MarketDataMapReader.getLong(data, "volume"))
+                .amount(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "amount")))
+                .bidPrice(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "bidPrice")))
+                .bidVolume(MarketDataMapReader.getLong(data, "bidVolume"))
+                .askPrice(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "askPrice")))
+                .askVolume(MarketDataMapReader.getLong(data, "askVolume"))
+                .dayHigh(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "high")))
+                .dayLow(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "low")))
+                .open(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "open")))
+                .prevClose(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "prevClose")))
+                .build();
     }
-    
-    private SymbolInfo convertToSymbolInfo(Map<String, Object> data) {
+
+    @Override
+    protected SymbolInfo convertToSymbolInfo(Map<String, Object> data) {
         return new SymbolInfo(
-            MarketDataMapReader.getString(data, "symbol"),
-            MarketDataMapReader.getString(data, "name"),
-            MarketType.FUTURES.getCode(),
-            FuturesMockDataSupport.resolveExchangeOrDefault(MarketDataMapReader.getString(data, "exchange")),
-            "futures"
+                MarketDataMapReader.getString(data, "symbol"),
+                MarketDataMapReader.getString(data, "name"),
+                MarketType.FUTURES.getCode(),
+                FuturesMockDataSupport.resolveExchangeOrDefault(MarketDataMapReader.getString(data, "exchange")),
+                "futures"
         );
     }
 }

--- a/koduck-backend/src/main/java/com/koduck/service/market/HKStockProvider.java
+++ b/koduck-backend/src/main/java/com/koduck/service/market/HKStockProvider.java
@@ -4,23 +4,10 @@ import com.koduck.config.properties.DataServiceProperties;
 import com.koduck.market.MarketType;
 import com.koduck.market.model.KlineData;
 import com.koduck.market.model.TickData;
-import com.koduck.market.provider.MarketDataProvider;
 import com.koduck.market.util.DataConverter;
 import com.koduck.service.market.support.HKStockMarketCalendar;
 import com.koduck.service.market.support.MarketDataMapReader;
 import com.koduck.service.market.support.MarketTimeframeParser;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.core.ParameterizedTypeReference;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.ResponseEntity;
-import org.springframework.lang.NonNull;
-import org.springframework.stereotype.Component;
-import org.springframework.web.client.RestClientException;
-import org.springframework.web.client.RestTemplate;
-import org.springframework.web.util.UriComponentsBuilder;
-
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.DayOfWeek;
@@ -31,204 +18,58 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ThreadLocalRandom;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
 
 /**
- * Hong Kong Stock market data provider.
- * Fetches HK stock data from Python Data Service.
- * 
- * Trading Hours (Hong Kong Time):
- * - Pre-market: 09:00 - 09:30 (opening auction)
- * - Morning: 09:30 - 12:00
- * - Lunch: 12:00 - 13:00
- * - Afternoon: 13:00 - 16:00
- * - Closing auction: 16:00 - 16:10
- * 
- * Stock codes: 5-digit numbers (e.g., 00700 for Tencent, 09988 for Alibaba Health)
+ * Hong Kong stock market data provider.
+ *
+ * <p>Data-service based implementation with unified retrieval and error handling inherited from
+ * {@link AbstractDataServiceMarketProvider}.</p>
  */
 @Component
-public class HKStockProvider implements MarketDataProvider {
-    
+public class HKStockProvider extends AbstractDataServiceMarketProvider {
+
     private static final Logger LOG = LoggerFactory.getLogger(HKStockProvider.class);
     private static final ZoneId HONG_KONG_ZONE = ZoneId.of("Asia/Hong_Kong");
     private static final String HK_STOCK_BASE_PATH = "/hk-stock";
     private static final String PROVIDER_NAME = "akshare-hk-stock";
-    private static final String RESPONSE_TYPE_MESSAGE = "responseType must not be null";
     private static final long KLINE_VOLUME_MIN = 100_000L;
     private static final long KLINE_VOLUME_MAX_EXCLUSIVE = 10_000_000L;
     private static final long TICK_VOLUME_MIN = 1_000_000L;
     private static final long TICK_VOLUME_MAX_EXCLUSIVE = 50_000_000L;
     private static final long ORDER_BOOK_VOLUME_MIN = 100L;
     private static final long ORDER_BOOK_VOLUME_MAX_EXCLUSIVE = 10_000L;
-    private static final ParameterizedTypeReference<List<Map<String, Object>>> LIST_MAP_RESPONSE_TYPE =
-        new ParameterizedTypeReference<List<Map<String, Object>>>() {
-        };
-    private static final ParameterizedTypeReference<Map<String, Object>> MAP_RESPONSE_TYPE =
-        new ParameterizedTypeReference<Map<String, Object>>() {
-        };
-    
-    private final DataServiceProperties properties;
-    private final RestTemplate restTemplate;
-    private final Set<String> subscribedSymbols = ConcurrentHashMap.newKeySet();
-    
+
     // Mock data for fallback
-    private final Map<String, BigDecimal> basePrices = new HashMap<>();
-    
+    private final Map<String, BigDecimal> basePrices = new LinkedHashMap<>();
+
     public HKStockProvider(
             DataServiceProperties properties,
             @Qualifier("dataServiceRestTemplate") RestTemplate restTemplate) {
-        this.properties = Objects.requireNonNull(properties, "properties must not be null");
-        this.restTemplate = Objects.requireNonNull(restTemplate, "restTemplate must not be null");
-        // Initialize base prices for popular HK stocks
-        basePrices.put("00700", new BigDecimal("380.00")); // Tencent
-        basePrices.put("09988", new BigDecimal("75.00"));  // Alibaba Health
-        basePrices.put("01898", new BigDecimal("120.00")); // Meituan
-        basePrices.put("09618", new BigDecimal("95.00"));  // JD.com
-        basePrices.put("01211", new BigDecimal("150.00")); // BYD
-        basePrices.put("09888", new BigDecimal("85.00"));  // Baidu
-        basePrices.put("01024", new BigDecimal("45.00"));  // Kuaishou
-        basePrices.put("02015", new BigDecimal("55.00"));  // Li Auto
-        basePrices.put("09868", new BigDecimal("40.00"));  // XPeng
-        basePrices.put("06690", new BigDecimal("25.00"));  // Haier
+        super(properties, restTemplate);
+        initBasePrices();
     }
-    
+
     @Override
     public String getProviderName() {
         return PROVIDER_NAME;
     }
-    
+
     @Override
     public MarketType getMarketType() {
         return MarketType.HK_STOCK;
     }
-    
-    @Override
-    public boolean isAvailable() {
-        return properties.isEnabled();
-    }
-    
-    @Override
-    public int getHealthScore() {
-        if (!properties.isEnabled()) {
-            return 0;
-        }
-        return 100;
-    }
-    
-    @Override
-    public List<KlineData> getKlineData(String symbol, String timeframe, int limit,
-                                         Instant startTime, Instant endTime) 
-            throws MarketDataException {
-        
-        if (!isAvailable()) {
-            LOG.debug("Data service not available, using mock data for HK stock kline");
-            return generateMockKlineData(symbol, timeframe, limit, endTime);
-        }
-        
-        String normalizedSymbol = normalizeSymbol(symbol);
-        
-        try {
-            UriComponentsBuilder builder = UriComponentsBuilder
-                    .fromUriString(properties.getBaseUrl() + HK_STOCK_BASE_PATH + "/kline/{symbol}")
-                    .queryParam("timeframe", timeframe)
-                    .queryParam("limit", limit);
-            
-            if (startTime != null) {
-                builder.queryParam("startTime", startTime.toEpochMilli());
-            }
-            if (endTime != null) {
-                builder.queryParam("endTime", endTime.toEpochMilli());
-            }
-            
-            String url = builder.buildAndExpand(normalizedSymbol).toUriString();
-            
-            LOG.debug("Fetching HK stock kline from data service: symbol={}, timeframe={}", 
-                    normalizedSymbol, timeframe);
-            
-            ResponseEntity<List<Map<String, Object>>> response = restTemplate.exchange(
-                    url,
-                    getHttpGet(),
-                    null,
-                    Objects.requireNonNull(LIST_MAP_RESPONSE_TYPE, RESPONSE_TYPE_MESSAGE)
-            );
-            
-            List<Map<String, Object>> data = response.getBody();
-            if (data == null || data.isEmpty()) {
-                return generateMockKlineData(symbol, timeframe, limit, endTime);
-            }
-            
-            return convertToKlineData(data, normalizedSymbol, timeframe);
-            
-        } catch (RestClientException e) {
-            LOG.error("Failed to fetch HK stock kline from data service: {}", e.getMessage());
-            return generateMockKlineData(symbol, timeframe, limit, endTime);
-        }
-    }
-    
-    @Override
-    public Optional<TickData> getRealTimeTick(String symbol) throws MarketDataException {
-        if (!isAvailable()) {
-            LOG.debug("Data service not available, using mock data for HK stock tick");
-            return generateMockTickData(symbol);
-        }
-        
-        String normalizedSymbol = normalizeSymbol(symbol);
-        
-        try {
-            String url = UriComponentsBuilder
-                    .fromUriString(properties.getBaseUrl() + HK_STOCK_BASE_PATH + "/price/{symbol}")
-                    .buildAndExpand(normalizedSymbol)
-                    .toUriString();
-            
-            LOG.debug("Fetching HK stock price from data service: symbol={}", normalizedSymbol);
-            
-            ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
-                    url,
-                    getHttpGet(),
-                    null,
-                    Objects.requireNonNull(MAP_RESPONSE_TYPE, RESPONSE_TYPE_MESSAGE)
-            );
-            
-            Map<String, Object> data = response.getBody();
-            if (data == null || data.isEmpty()) {
-                return generateMockTickData(symbol);
-            }
-            
-            return Optional.of(convertToTickData(data, normalizedSymbol));
-            
-        } catch (RestClientException e) {
-            LOG.error("Failed to fetch HK stock price from data service: {}", e.getMessage());
-            return generateMockTickData(symbol);
-        }
-    }
-    
-    @Override
-    public void subscribeRealTime(List<String> symbols, RealTimeDataCallback callback) 
-            throws MarketDataException {
-        
-        if (!isAvailable()) {
-            throw new MarketDataException("Provider is not available");
-        }
-        
-        symbols.forEach(sym -> subscribedSymbols.add(normalizeSymbol(sym)));
-        LOG.info("Subscribed to {} HK stocks for real-time data", symbols.size());
-    }
-    
-    @Override
-    public void unsubscribeRealTime(List<String> symbols) {
-        symbols.forEach(sym -> subscribedSymbols.remove(normalizeSymbol(sym)));
-        LOG.info("Unsubscribed from {} HK stocks", symbols.size());
-    }
-    
+
     @Override
     public MarketStatus getMarketStatus() {
         ZonedDateTime now = ZonedDateTime.now(HONG_KONG_ZONE);
@@ -259,145 +100,131 @@ public class HKStockProvider implements MarketDataProvider {
 
         return MarketStatus.CLOSED;
     }
-    
+
     @Override
-    public List<SymbolInfo> searchSymbols(String keyword, int limit) {
-        if (!isAvailable()) {
-            return generateMockSearchResults(keyword, limit);
-        }
-        
-        try {
-            String url = UriComponentsBuilder
-                    .fromUriString(properties.getBaseUrl() + HK_STOCK_BASE_PATH + "/search")
-                    .queryParam("keyword", keyword)
-                    .queryParam("limit", limit)
-                    .toUriString();
-            
-            ResponseEntity<List<Map<String, Object>>> response = restTemplate.exchange(
-                    url,
-                    getHttpGet(),
-                    null,
-                    Objects.requireNonNull(LIST_MAP_RESPONSE_TYPE, RESPONSE_TYPE_MESSAGE)
-            );
-            
-            List<Map<String, Object>> data = response.getBody();
-            if (data == null || data.isEmpty()) {
-                return generateMockSearchResults(keyword, limit);
-            }
-            
-            return data.stream()
-                    .map(this::convertToSymbolInfo)
-                    .limit(limit)
-                    .toList();
-                    
-        } catch (RestClientException e) {
-            LOG.error("Failed to search HK stocks: {}", e.getMessage());
-            return generateMockSearchResults(keyword, limit);
-        }
+    protected Logger logger() {
+        return LOG;
     }
-    
-    // Helper methods
-    
-    private String normalizeSymbol(String symbol) {
+
+    @Override
+    protected String getDataServiceBasePath() {
+        return HK_STOCK_BASE_PATH;
+    }
+
+    @Override
+    protected String getLogMarketName() {
+        return "HK stock";
+    }
+
+    @Override
+    protected String getSubscriptionLabel() {
+        return "HK stocks";
+    }
+
+    @Override
+    protected String normalizeSymbol(String symbol) {
         if (symbol == null || symbol.trim().isEmpty()) {
             return "";
         }
-        
+
         String normalized = symbol.trim().toUpperCase(Locale.ROOT);
-        
-        // Remove .HK suffix if present
+
+        // Remove .HK suffix if present.
         if (normalized.endsWith(".HK")) {
             normalized = normalized.substring(0, normalized.length() - 3);
         }
-        
-        // Pad to 5 digits
+
+        // Pad to 5 digits.
         if (normalized.matches("\\d+")) {
             normalized = String.format("%05d", Integer.parseInt(normalized));
         }
-        
+
         return normalized;
     }
-    
-    private List<KlineData> generateMockKlineData(String symbol, String timeframe, int limit,
-                                                   Instant endTime) {
+
+    @Override
+    protected List<KlineData> generateMockKlineData(String symbol, String timeframe, int limit,
+                                                    Instant startTime, Instant endTime) {
         List<KlineData> klines = new ArrayList<>();
         String normalizedSymbol = normalizeSymbol(symbol);
         BigDecimal basePrice = basePrices.getOrDefault(normalizedSymbol, new BigDecimal("50.00"));
-        
+
         Instant currentTime = endTime != null ? endTime : Instant.now();
         Duration interval = MarketTimeframeParser.parseStandard(timeframe);
-        
+
         BigDecimal currentPrice = basePrice;
         for (int i = 0; i < limit; i++) {
             double changePercent = (Math.random() - 0.5) * 0.04;
             BigDecimal change = currentPrice.multiply(BigDecimal.valueOf(changePercent));
             BigDecimal close = currentPrice.add(change);
-            
+
             BigDecimal high = close.multiply(BigDecimal.valueOf(1 + Math.random() * 0.01));
             BigDecimal low = close.multiply(BigDecimal.valueOf(1 - Math.random() * 0.01));
             BigDecimal open = currentPrice;
-            
+
             long volume = ThreadLocalRandom.current().nextLong(KLINE_VOLUME_MIN, KLINE_VOLUME_MAX_EXCLUSIVE);
-            
+
             klines.add(KlineData.builder()
-                .symbol(normalizedSymbol)
-                .market(MarketType.HK_STOCK.getCode())
-                .timestamp(currentTime)
-                .open(open)
-                .high(high)
-                .low(low)
-                .close(close)
-                .volume(volume)
-                .amount(close.multiply(BigDecimal.valueOf(volume)))
-                .timeframe(timeframe)
-                .build());
-            
+                    .symbol(normalizedSymbol)
+                    .market(MarketType.HK_STOCK.getCode())
+                    .timestamp(currentTime)
+                    .open(open)
+                    .high(high)
+                    .low(low)
+                    .close(close)
+                    .volume(volume)
+                    .amount(close.multiply(BigDecimal.valueOf(volume)))
+                    .timeframe(timeframe)
+                    .build());
+
             currentPrice = close;
             currentTime = currentTime.minus(interval);
         }
-        
+
         Collections.reverse(klines);
         return klines;
     }
-    
-    private Optional<TickData> generateMockTickData(String symbol) {
+
+    @Override
+    protected Optional<TickData> generateMockTickData(String symbol) {
         String normalizedSymbol = normalizeSymbol(symbol);
         BigDecimal basePrice = basePrices.getOrDefault(normalizedSymbol, new BigDecimal("50.00"));
-        
+
         double changePercent = (Math.random() - 0.5) * 0.02;
         BigDecimal price = basePrice.multiply(BigDecimal.valueOf(1 + changePercent));
         BigDecimal change = price.subtract(basePrice);
         BigDecimal changePercentValue = change.divide(basePrice, 4, RoundingMode.HALF_UP)
-                                              .multiply(BigDecimal.valueOf(100));
-        
+                .multiply(BigDecimal.valueOf(100));
+
         long volume = ThreadLocalRandom.current().nextLong(TICK_VOLUME_MIN, TICK_VOLUME_MAX_EXCLUSIVE);
-        
+
         TickData tickData = TickData.builder()
-            .symbol(normalizedSymbol)
-            .market(MarketType.HK_STOCK.getCode())
-            .timestamp(Instant.now())
-            .price(price)
-            .change(change)
-            .changePercent(changePercentValue)
-            .volume(volume)
-            .amount(price.multiply(BigDecimal.valueOf(volume)))
-            .bidPrice(price.multiply(BigDecimal.valueOf(0.999)))
-            .bidVolume(ThreadLocalRandom.current().nextLong(ORDER_BOOK_VOLUME_MIN, ORDER_BOOK_VOLUME_MAX_EXCLUSIVE))
-            .askPrice(price.multiply(BigDecimal.valueOf(1.001)))
-            .askVolume(ThreadLocalRandom.current().nextLong(ORDER_BOOK_VOLUME_MIN, ORDER_BOOK_VOLUME_MAX_EXCLUSIVE))
-            .dayHigh(price.multiply(BigDecimal.valueOf(1.02)))
-            .dayLow(price.multiply(BigDecimal.valueOf(0.98)))
-            .open(basePrice)
-            .prevClose(basePrice)
-            .build();
-        
+                .symbol(normalizedSymbol)
+                .market(MarketType.HK_STOCK.getCode())
+                .timestamp(Instant.now())
+                .price(price)
+                .change(change)
+                .changePercent(changePercentValue)
+                .volume(volume)
+                .amount(price.multiply(BigDecimal.valueOf(volume)))
+                .bidPrice(price.multiply(BigDecimal.valueOf(0.999)))
+                .bidVolume(ThreadLocalRandom.current().nextLong(ORDER_BOOK_VOLUME_MIN, ORDER_BOOK_VOLUME_MAX_EXCLUSIVE))
+                .askPrice(price.multiply(BigDecimal.valueOf(1.001)))
+                .askVolume(ThreadLocalRandom.current().nextLong(ORDER_BOOK_VOLUME_MIN, ORDER_BOOK_VOLUME_MAX_EXCLUSIVE))
+                .dayHigh(price.multiply(BigDecimal.valueOf(1.02)))
+                .dayLow(price.multiply(BigDecimal.valueOf(0.98)))
+                .open(basePrice)
+                .prevClose(basePrice)
+                .build();
+
         return Optional.of(tickData);
     }
-    
-    private List<SymbolInfo> generateMockSearchResults(String keyword, int limit) {
+
+    @Override
+    protected List<SymbolInfo> generateMockSearchResults(String keyword, int limit) {
         List<SymbolInfo> results = new ArrayList<>();
         String upperKeyword = keyword.toUpperCase(Locale.ROOT);
-        
+
         Map<String, String> hkStocks = new LinkedHashMap<>();
         hkStocks.put("00700", "Tencent Holdings Ltd.");
         hkStocks.put("09988", "Alibaba Health Information Technology");
@@ -409,47 +236,50 @@ public class HKStockProvider implements MarketDataProvider {
         hkStocks.put("02015", "Li Auto Inc.");
         hkStocks.put("09868", "XPeng Inc.");
         hkStocks.put("06690", "Haier Smart Home Co.");
-        
+
         hkStocks.entrySet().stream()
-            .filter(e -> e.getKey().contains(upperKeyword) || 
-                        e.getValue().toUpperCase(Locale.ROOT).contains(upperKeyword))
-            .limit(limit)
-            .forEach(e -> results.add(new SymbolInfo(
-                e.getKey(),
-                e.getValue(),
-                MarketType.HK_STOCK.getCode(),
-                "HKEX",
-                "stock"
-            )));
-        
+                .filter(e -> e.getKey().contains(upperKeyword)
+                        || e.getValue().toUpperCase(Locale.ROOT).contains(upperKeyword))
+                .limit(limit)
+                .forEach(e -> results.add(new SymbolInfo(
+                        e.getKey(),
+                        e.getValue(),
+                        MarketType.HK_STOCK.getCode(),
+                        "HKEX",
+                        "stock"
+                )));
+
         return results;
     }
-    
-    private List<KlineData> convertToKlineData(List<Map<String, Object>> data, String symbol, String timeframe) {
+
+    @Override
+    protected List<KlineData> convertToKlineData(List<Map<String, Object>> data, String symbol,
+                                                 String timeframe) {
         List<KlineData> klines = new ArrayList<>();
-        
+
         for (Map<String, Object> item : data) {
             klines.add(KlineData.builder()
-                .symbol(symbol)
-                .market(MarketType.HK_STOCK.getCode())
-                .timestamp(DataConverter.toInstantFromMillis(MarketDataMapReader.getLong(item, "timestamp")))
-                .open(DataConverter.toBigDecimal(MarketDataMapReader.getString(item, "open")))
-                .high(DataConverter.toBigDecimal(MarketDataMapReader.getString(item, "high")))
-                .low(DataConverter.toBigDecimal(MarketDataMapReader.getString(item, "low")))
-                .close(DataConverter.toBigDecimal(MarketDataMapReader.getString(item, "close")))
-                .volume(MarketDataMapReader.getLong(item, "volume"))
-                .amount(DataConverter.toBigDecimal(MarketDataMapReader.getString(item, "amount")))
-                .timeframe(timeframe)
-                .build());
+                    .symbol(symbol)
+                    .market(MarketType.HK_STOCK.getCode())
+                    .timestamp(DataConverter.toInstantFromMillis(MarketDataMapReader.getLong(item, "timestamp")))
+                    .open(DataConverter.toBigDecimal(MarketDataMapReader.getString(item, "open")))
+                    .high(DataConverter.toBigDecimal(MarketDataMapReader.getString(item, "high")))
+                    .low(DataConverter.toBigDecimal(MarketDataMapReader.getString(item, "low")))
+                    .close(DataConverter.toBigDecimal(MarketDataMapReader.getString(item, "close")))
+                    .volume(MarketDataMapReader.getLong(item, "volume"))
+                    .amount(DataConverter.toBigDecimal(MarketDataMapReader.getString(item, "amount")))
+                    .timeframe(timeframe)
+                    .build());
         }
-        
+
         return klines;
     }
-    
-    private TickData convertToTickData(Map<String, Object> data, String symbol) {
+
+    @Override
+    protected TickData convertToTickData(Map<String, Object> data, String symbol) {
         return TickData.builder()
-            .symbol(symbol)
-            .market(MarketType.HK_STOCK.getCode())
+                .symbol(symbol)
+                .market(MarketType.HK_STOCK.getCode())
                 .timestamp(DataConverter.toInstantFromMillis(MarketDataMapReader.getLong(data, "timestamp")))
                 .price(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "price")))
                 .change(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "change")))
@@ -464,24 +294,31 @@ public class HKStockProvider implements MarketDataProvider {
                 .dayLow(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "low")))
                 .open(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "open")))
                 .prevClose(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "prevClose")))
-            .build();
+                .build();
     }
-    
-    private SymbolInfo convertToSymbolInfo(Map<String, Object> data) {
+
+    @Override
+    protected SymbolInfo convertToSymbolInfo(Map<String, Object> data) {
+        String exchange = MarketDataMapReader.getString(data, "exchange");
         return new SymbolInfo(
-            MarketDataMapReader.getString(data, "symbol"),
-            MarketDataMapReader.getString(data, "name"),
-            MarketType.HK_STOCK.getCode(),
-            MarketDataMapReader.getString(data, "exchange") != null
-                ? MarketDataMapReader.getString(data, "exchange")
-                : "HKEX",
-            "stock"
+                MarketDataMapReader.getString(data, "symbol"),
+                MarketDataMapReader.getString(data, "name"),
+                MarketType.HK_STOCK.getCode(),
+                exchange != null ? exchange : "HKEX",
+                "stock"
         );
     }
 
-    
-    private static HttpMethod getHttpGet() {
-        return Objects.requireNonNull(HttpMethod.GET, "HTTP GET must not be null");
+    private void initBasePrices() {
+        basePrices.put("00700", new BigDecimal("380.00"));
+        basePrices.put("09988", new BigDecimal("75.00"));
+        basePrices.put("01898", new BigDecimal("120.00"));
+        basePrices.put("09618", new BigDecimal("95.00"));
+        basePrices.put("01211", new BigDecimal("150.00"));
+        basePrices.put("09888", new BigDecimal("85.00"));
+        basePrices.put("01024", new BigDecimal("45.00"));
+        basePrices.put("02015", new BigDecimal("55.00"));
+        basePrices.put("09868", new BigDecimal("40.00"));
+        basePrices.put("06690", new BigDecimal("25.00"));
     }
-    
 }


### PR DESCRIPTION
## Summary
- migrate ForexProvider/HKStockProvider/FuturesProvider to extend AbstractDataServiceMarketProvider
- unify shared retrieval/subscription/search flow and RestClientException fallback handling in base class
- keep market-specific behavior in subclasses (symbol normalization, mock data, conversion, market status)
- add ADR-0016 and docs index entry

## Validation
- mvn -DskipTests compile -f koduck-backend/pom.xml

Closes #322