### PR TITLE
refactor(service): standardize service-layer exception throwing

### DIFF
--- a/koduck-backend/docs/ADR-0018-service-layer-exception-standardization.md
+++ b/koduck-backend/docs/ADR-0018-service-layer-exception-standardization.md
@@ -1,0 +1,50 @@
+# ADR-0018: Service 层异常抛出规范统一
+
+- Status: Accepted
+- Date: 2026-04-02
+- Issue: #326
+
+## Context
+
+当前 Service 层存在异常抛出不一致问题：同类业务场景中同时混用 `IllegalArgumentException`、`IllegalStateException` 与业务异常，导致：
+
+- 全局异常映射语义不稳定（同类错误返回码可能不一致）；
+- 错误语义不清晰，调用方难以基于异常类型做稳定处理；
+- 维护与排障时，需要逐个 Service 猜测异常约定。
+
+## Decision
+
+统一 Service 层异常抛出规范：
+
+- 资源不存在：使用 `ResourceNotFoundException`；
+- 参数/业务规则不满足：使用 `ValidationException` 或 `BusinessException`（绑定 `ErrorCode`）；
+- 状态冲突：使用 `StateException`；
+- 重复操作：使用 `DuplicateException`。
+
+本次在高频 Service 实现中落地替换，移除通用运行时异常在业务路径中的直接抛出。
+
+## Consequences
+
+正向影响：
+
+- Service 异常语义统一，便于全局处理器稳定映射 HTTP 状态码与业务错误码；
+- 错误可观测性提升，日志与接口返回更可预测；
+- 后续新功能可按同一约定扩展，降低认知成本。
+
+代价：
+
+- 需要逐步清理存量代码中剩余的泛化异常；
+- 历史测试若断言具体异常类型，需要同步调整。
+
+## Alternatives Considered
+
+1. 保持现状，依赖全局处理器兜底
+   - 拒绝：错误语义继续漂移，问题会累积。
+
+2. 仅在 Controller 层统一转换
+   - 未采用：根因在 Service 层，延后转换无法提升领域语义。
+
+## Verification
+
+- 关键 Service 实现已将通用运行时异常替换为业务异常体系；
+- 本地 `mvn -DskipTests compile -f koduck-backend/pom.xml` 通过。

--- a/koduck-backend/docs/README.md
+++ b/koduck-backend/docs/README.md
@@ -148,6 +148,10 @@ mvn spring-boot:run
 
 - JDBC Batch 优化 ADR：`ADR-0017-jdbc-batch-for-bulk-persistence.md`
 
+## Service 异常治理
+
+- 异常抛出规范统一 ADR：`ADR-0018-service-layer-exception-standardization.md`
+
 ## 测试
 
 ```bash

--- a/koduck-backend/src/main/java/com/koduck/service/impl/BacktestServiceImpl.java
+++ b/koduck-backend/src/main/java/com/koduck/service/impl/BacktestServiceImpl.java
@@ -4,6 +4,9 @@ import com.koduck.common.constants.MarketConstants;
 import com.koduck.dto.backtest.*;
 import com.koduck.dto.market.KlineDataDto;
 import com.koduck.entity.*;
+import com.koduck.exception.BusinessException;
+import com.koduck.exception.ErrorCode;
+import com.koduck.exception.ResourceNotFoundException;
 import com.koduck.mapper.BacktestTradeMapper;
 import com.koduck.repository.BacktestResultRepository;
 import com.koduck.repository.BacktestTradeRepository;
@@ -150,7 +153,7 @@ public class BacktestServiceImpl implements BacktestService {
         List<KlineDataDto> klineData = klineService.getKlineData(
             result.getMarket(), result.getSymbol(), timeframe, 1000, null);
         if (klineData.isEmpty()) {
-            throw new IllegalStateException("No historical data available");
+            throw new BusinessException(ErrorCode.BACKTEST_INSUFFICIENT_DATA, "No historical data available");
         }
         // Filter by date range
         List<KlineDataDto> filteredData = klineData.stream()
@@ -161,7 +164,9 @@ public class BacktestServiceImpl implements BacktestService {
             .sorted((a, b) -> Long.compare(a.timestamp(), b.timestamp()))
             .toList();
         if (filteredData.size() < 60) {
-            throw new IllegalStateException("Insufficient data for backtest (need at least 60 bars)");
+            throw new BusinessException(
+                    ErrorCode.BACKTEST_INSUFFICIENT_DATA,
+                    "Insufficient data for backtest (need at least 60 bars)");
         }
         // Initialize backtest state
         BacktestExecutionContext context = new BacktestExecutionContext(
@@ -442,11 +447,11 @@ public class BacktestServiceImpl implements BacktestService {
     }
     private BacktestResult loadBacktestResultOrThrow(Long userId, Long backtestId) {
         return requireFound(resultRepository.findByIdAndUserId(backtestId, userId),
-                () -> new IllegalArgumentException("Backtest result not found"));
+                () -> new ResourceNotFoundException("backtest result", backtestId));
     }
     private StrategyVersion loadLatestVersionOrThrow(Long strategyId) {
         return requireFound(versionRepository.findFirstByStrategyIdOrderByVersionNumberDesc(strategyId),
-                () -> new IllegalArgumentException("No version found for strategy"));
+                () -> new ResourceNotFoundException("strategy version for strategy", strategyId));
     }
     /**
      * Convert BacktestResult to DTO.

--- a/koduck-backend/src/main/java/com/koduck/service/impl/CommunitySignalServiceImpl.java
+++ b/koduck-backend/src/main/java/com/koduck/service/impl/CommunitySignalServiceImpl.java
@@ -2,6 +2,8 @@ package com.koduck.service.impl;
 
 import com.koduck.dto.community.*;
 import com.koduck.entity.*;
+import com.koduck.exception.BusinessException;
+import com.koduck.exception.ErrorCode;
 import com.koduck.exception.ResourceNotFoundException;
 import com.koduck.repository.*;
 import com.koduck.service.CommunitySignalService;
@@ -251,7 +253,7 @@ public class CommunitySignalServiceImpl implements CommunitySignalService {
         CommunitySignal signal = loadSignalOrThrow(signalId);
         // Prevent duplicate subscriptions.
         if (subscriptionRepository.existsBySignalIdAndUserId(signalId, userId)) {
-            throw new IllegalArgumentException("已订阅此信号");
+            throw new BusinessException(ErrorCode.SIGNAL_ALREADY_SUBSCRIBED);
         }
         SignalSubscription subscription = SignalSubscription.builder()
                 .signalId(signalId)
@@ -270,7 +272,7 @@ public class CommunitySignalServiceImpl implements CommunitySignalService {
     public void unsubscribeSignal(Long userId, Long signalId) {
         log.info(USER_ID_SIGNAL_ID_LOG_TEMPLATE, userId, signalId);
         if (!subscriptionRepository.existsBySignalIdAndUserId(signalId, userId)) {
-            throw new IllegalArgumentException("未订阅此信号");
+            throw new BusinessException(ErrorCode.SIGNAL_NOT_SUBSCRIBED);
         }
         subscriptionRepository.deleteBySignalIdAndUserId(signalId, userId);
         signalRepository.decrementSubscribeCount(signalId);
@@ -299,7 +301,7 @@ public class CommunitySignalServiceImpl implements CommunitySignalService {
     public void likeSignal(Long userId, Long signalId) {
         log.info(USER_ID_SIGNAL_ID_LOG_TEMPLATE, userId, signalId);
         if (likeRepository.existsBySignalIdAndUserId(signalId, userId)) {
-            throw new IllegalArgumentException("已点赞此信号");
+            throw new BusinessException(ErrorCode.SIGNAL_ALREADY_LIKED);
         }
         SignalLike like = SignalLike.builder()
                 .signalId(signalId)
@@ -316,7 +318,7 @@ public class CommunitySignalServiceImpl implements CommunitySignalService {
     public void unlikeSignal(Long userId, Long signalId) {
         log.info(USER_ID_SIGNAL_ID_LOG_TEMPLATE, userId, signalId);
         if (!likeRepository.existsBySignalIdAndUserId(signalId, userId)) {
-            throw new IllegalArgumentException("未点赞此信号");
+            throw new BusinessException(ErrorCode.SIGNAL_NOT_LIKED);
         }
         likeRepository.deleteBySignalIdAndUserId(signalId, userId);
         signalRepository.decrementLikeCount(signalId);
@@ -329,7 +331,7 @@ public class CommunitySignalServiceImpl implements CommunitySignalService {
     public void favoriteSignal(Long userId, Long signalId, String note) {
         log.info(USER_ID_SIGNAL_ID_LOG_TEMPLATE, userId, signalId);
         if (favoriteRepository.existsBySignalIdAndUserId(signalId, userId)) {
-            throw new IllegalArgumentException("已收藏此信号");
+            throw new BusinessException(ErrorCode.DUPLICATE_ERROR, "已收藏此信号");
         }
         SignalFavorite favorite = SignalFavorite.builder()
                 .signalId(signalId)
@@ -347,7 +349,7 @@ public class CommunitySignalServiceImpl implements CommunitySignalService {
     public void unfavoriteSignal(Long userId, Long signalId) {
         log.info(USER_ID_SIGNAL_ID_LOG_TEMPLATE, userId, signalId);
         if (!favoriteRepository.existsBySignalIdAndUserId(signalId, userId)) {
-            throw new IllegalArgumentException("未收藏此信号");
+            throw new BusinessException(ErrorCode.BUSINESS_ERROR, "未收藏此信号");
         }
         favoriteRepository.deleteBySignalIdAndUserId(signalId, userId);
         signalRepository.decrementFavoriteCount(signalId);

--- a/koduck-backend/src/main/java/com/koduck/service/impl/MemoryServiceImpl.java
+++ b/koduck-backend/src/main/java/com/koduck/service/impl/MemoryServiceImpl.java
@@ -3,6 +3,7 @@ package com.koduck.service.impl;
 import com.koduck.entity.MemoryChatMessage;
 import com.koduck.entity.MemoryChatSession;
 import com.koduck.entity.UserMemoryProfile;
+import com.koduck.exception.StateException;
 import com.koduck.repository.MemoryChatMessageRepository;
 import com.koduck.repository.MemoryChatSessionRepository;
 import com.koduck.repository.UserMemoryProfileRepository;
@@ -115,7 +116,7 @@ public class MemoryServiceImpl implements MemoryService {
         Map<String, Object> metadata
     ) {
         if (!memoryEnabled) {
-            throw new IllegalStateException("Memory is disabled");
+            throw new StateException("Memory is disabled");
         }
         Long nonNullUserId = Objects.requireNonNull(userId, USER_ID_NULL_MESSAGE);
         String nonNullRole = Objects.requireNonNull(role, "role must not be null");

--- a/koduck-backend/src/main/java/com/koduck/service/impl/StrategyServiceImpl.java
+++ b/koduck-backend/src/main/java/com/koduck/service/impl/StrategyServiceImpl.java
@@ -10,6 +10,9 @@ import com.koduck.dto.strategy.UpdateStrategyRequest;
 import com.koduck.entity.Strategy;
 import com.koduck.entity.StrategyParameter;
 import com.koduck.entity.StrategyVersion;
+import com.koduck.exception.BusinessException;
+import com.koduck.exception.ErrorCode;
+import com.koduck.exception.ResourceNotFoundException;
 import com.koduck.mapper.StrategyMapper;
 import com.koduck.repository.StrategyParameterRepository;
 import com.koduck.repository.StrategyRepository;
@@ -255,15 +258,16 @@ def handle_data(context, data):
     }
     private StrategyVersion loadVersionByIdOrThrow(Long versionId) {
         return requireFound(versionRepository.findById(Objects.requireNonNull(versionId, "versionId must not be null")),
-                () -> new IllegalArgumentException("Version not found"));
+                () -> new ResourceNotFoundException("strategy version", versionId));
     }
     private StrategyVersion loadVersionByNumberOrThrow(Long strategyId, Integer versionNumber) {
         return requireFound(versionRepository.findByStrategyIdAndVersionNumber(strategyId, versionNumber),
-                () -> new IllegalArgumentException("Version not found"));
+                () -> new ResourceNotFoundException(
+                        "Strategy version not found: strategyId=" + strategyId + ", version=" + versionNumber));
     }
     private void verifyStrategyOwnershipOrThrow(Long userId, Long strategyId) {
         if (!strategyRepository.existsByIdAndUserId(strategyId, userId)) {
-            throw new IllegalArgumentException("Strategy not found");
+            throw new BusinessException(ErrorCode.STRATEGY_NOT_FOUND, "Strategy not found");
         }
     }
     /**

--- a/koduck-backend/src/main/java/com/koduck/service/impl/TechnicalIndicatorServiceImpl.java
+++ b/koduck-backend/src/main/java/com/koduck/service/impl/TechnicalIndicatorServiceImpl.java
@@ -3,6 +3,9 @@ import com.koduck.common.constants.MarketConstants;
 import com.koduck.dto.indicator.IndicatorListResponse;
 import com.koduck.dto.indicator.IndicatorResponse;
 import com.koduck.dto.market.KlineDataDto;
+import com.koduck.exception.BusinessException;
+import com.koduck.exception.ErrorCode;
+import com.koduck.exception.ValidationException;
 import com.koduck.service.KlineService;
 import com.koduck.service.TechnicalIndicatorService;
 import lombok.RequiredArgsConstructor;
@@ -80,7 +83,9 @@ public class TechnicalIndicatorServiceImpl implements TechnicalIndicatorService 
         List<KlineDataDto> klineData =
             klineService.getKlineData(market, symbol, MarketConstants.DEFAULT_TIMEFRAME, DEFAULT_LIMIT, null);
         if (klineData.isEmpty()) {
-            throw new IllegalArgumentException("No kline data found for " + market + "/" + symbol);
+            throw new BusinessException(
+                    ErrorCode.MARKET_DATA_NOT_FOUND,
+                    "No kline data found for " + market + "/" + symbol);
         }
         // Convert to BarSeries
         BarSeries series = convertToBarSeries(klineData);
@@ -92,7 +97,7 @@ public class TechnicalIndicatorServiceImpl implements TechnicalIndicatorService 
             case "RSI" -> calculateRSI(series, market, symbol, period != null ? period : 14);
             case "BOLL" -> calculateBOLL(series, market, symbol, period != null ? period : 20);
             case "VOL" -> calculateVOL(series, market, symbol, period != null ? period : 5);
-            default -> throw new IllegalArgumentException("Unsupported indicator: " + indicator);
+            default -> throw new ValidationException("Unsupported indicator: " + indicator);
         };
     }
     /**

--- a/koduck-backend/src/main/java/com/koduck/service/impl/WatchlistServiceImpl.java
+++ b/koduck-backend/src/main/java/com/koduck/service/impl/WatchlistServiceImpl.java
@@ -6,6 +6,9 @@ import com.koduck.dto.watchlist.SortWatchlistRequest;
 import com.koduck.dto.watchlist.WatchlistItemDto;
 import com.koduck.entity.StockRealtime;
 import com.koduck.entity.WatchlistItem;
+import com.koduck.exception.DuplicateException;
+import com.koduck.exception.ResourceNotFoundException;
+import com.koduck.exception.StateException;
 import com.koduck.repository.StockRealtimeRepository;
 import com.koduck.repository.WatchlistRepository;
 import com.koduck.service.WatchlistService;
@@ -82,12 +85,12 @@ public class WatchlistServiceImpl implements WatchlistService {
         // Check if already exists (using normalized symbol)
         if (watchlistRepository.existsByUserIdAndMarketAndSymbol(
                 userId, request.market(), normalizedSymbol)) {
-            throw new IllegalArgumentException("Stock already in watchlist");
+            throw new DuplicateException("symbol", normalizedSymbol, "Stock already in watchlist");
         }
         // Check watchlist size limit
         long currentSize = watchlistRepository.countByUserId(userId);
         if (currentSize >= MAX_WATCHLIST_SIZE) {
-            throw new IllegalStateException("Watchlist limit reached (" + MAX_WATCHLIST_SIZE + ")");
+            throw new StateException("Watchlist limit reached (" + MAX_WATCHLIST_SIZE + ")");
         }
         // Get next sort order
         Integer maxOrder = watchlistRepository.findMaxSortOrderByUserId(userId).orElse(-1);
@@ -148,7 +151,7 @@ public class WatchlistServiceImpl implements WatchlistService {
     }
     private WatchlistItem loadWatchlistItemOrThrow(Long itemId) {
         return requireFound(watchlistRepository.findById(Objects.requireNonNull(itemId)),
-                () -> new IllegalArgumentException("Watchlist item not found"));
+                () -> new ResourceNotFoundException("watchlist item", itemId));
     }
     private Map<String, StockRealtime> loadRealtimeMap(List<String> normalizedSymbols) {
         if (normalizedSymbols == null || normalizedSymbols.isEmpty()) {


### PR DESCRIPTION
## Summary\n- standardize service-layer exception throwing to business exception hierarchy\n- replace generic runtime exceptions in key service implementations with domain exceptions\n- add ADR-0018 and docs index entry for service exception governance\n\n## Changes\n- StrategyServiceImpl: use ResourceNotFoundException/BusinessException instead of IllegalArgumentException\n- WatchlistServiceImpl: use DuplicateException/StateException/ResourceNotFoundException\n- TechnicalIndicatorServiceImpl: use ValidationException and BusinessException(ErrorCode)\n- BacktestServiceImpl: use ResourceNotFoundException and BusinessException(ErrorCode)\n- MemoryServiceImpl: use StateException for disabled-memory state\n- CommunitySignalServiceImpl: use BusinessException(ErrorCode) for interaction state checks\n- docs: add ADR-0018-service-layer-exception-standardization.md and update docs/README.md\n\n## Verification\n- mvn -DskipTests compile -f koduck-backend/pom.xml\n\nCloses #326