### PR TITLE
refactor(ddd): complete remaining service implementation migration

### DIFF
--- a/koduck-backend/docs/ADR-0023-ddd-phase2-complete-service-impl-migration.md
+++ b/koduck-backend/docs/ADR-0023-ddd-phase2-complete-service-impl-migration.md
@@ -1,0 +1,46 @@
+# ADR-0023: DDD Phase 2 完成剩余 ServiceImpl 迁移
+
+- Status: Accepted
+- Date: 2026-04-02
+- Issue: #334
+
+## Context
+
+`ADR-0022` 已完成核心服务首批迁移，但 `com.koduck.service.impl` 仍保留大量实现类，无法达成“领域边界在代码结构可见”的目标。
+
+## Decision
+
+执行 DDD Phase 2：迁移 `service.impl` 中剩余实现类，按领域落到对应 `application` 包，并同步修复测试引用。
+
+- `market.application`：行情聚合、推送、缓存、订阅、分钟线与同步等实现
+- `identity.application`：用户、凭证、配置与资料相关实现
+- `shared.application`：AI、邮件、内存、监控、限流等跨领域能力实现
+
+迁移后，`com.koduck.service.impl` 不再承载业务实现类。
+
+## Consequences
+
+正向影响：
+
+- DDD 领域边界在包结构层面完整落地；
+- 服务实现按业务语义聚合，维护与协作成本下降；
+- 后续可在此基础上增加架构规则检查（禁止回流至旧包）。
+
+代价：
+
+- 包路径变更会影响直接引用实现类的测试/工具代码；
+- 短期需要适配历史脚本或文档中的旧路径。
+
+## Alternatives Considered
+
+1. 保留部分实现于 `service.impl`
+   - 拒绝：无法形成一致的边界规范。
+
+2. 一步迁移到更细颗粒 `domain/application/infrastructure/interfaces`
+   - 未采用：当前阶段先完成 bounded context 级别收敛，避免过度改造。
+
+## Verification
+
+- 主代码 `mvn -DskipTests compile -f koduck-backend/pom.xml` 通过；
+- `com.koduck.service.impl` 中已无实现类文件；
+- 受影响测试导入已切换为新包路径。

--- a/koduck-backend/docs/DOMAIN-MODEL-DESIGN.md
+++ b/koduck-backend/docs/DOMAIN-MODEL-DESIGN.md
@@ -102,14 +102,30 @@ com.koduck
 - 是否复用了 `shared` 中的值对象与异常语义？
 - 变更是否需要补 ADR（新增上下文、重大边界调整、跨域契约变更）？
 
-## 8. 实施状态（Phase 1）
+## 8. 实施状态（Phase 1 + Phase 2）
 
-已完成核心服务首批迁移（接口不变，迁移实现包）：
+已完成从 `com.koduck.service.impl` 到领域 `application` 包的迁移：
 
-- `com.koduck.identity.application.AuthServiceImpl`
-- `com.koduck.market.application.{MarketServiceImpl,KlineServiceImpl,TechnicalIndicatorServiceImpl,WatchlistServiceImpl}`
-- `com.koduck.strategy.application.StrategyServiceImpl`
-- `com.koduck.trading.application.{BacktestServiceImpl,PortfolioServiceImpl}`
-- `com.koduck.community.application.CommunitySignalServiceImpl`
+- `identity.application`：
+  `AuthServiceImpl`, `CredentialServiceImpl`, `ProfileServiceImpl`, `UserServiceImpl`,
+  `UserCacheServiceImpl`, `UserSettingsServiceImpl`
+- `market.application`：
+  `MarketServiceImpl`, `KlineServiceImpl`, `KlineMinutesServiceImpl`, `KlineSyncServiceImpl`,
+  `TechnicalIndicatorServiceImpl`, `WatchlistServiceImpl`, `MarketBreadthServiceImpl`,
+  `MarketFlowServiceImpl`, `MarketSectorNetFlowServiceImpl`, `MarketSentimentServiceImpl`,
+  `PricePushServiceImpl`, `StockCacheServiceImpl`, `StockSubscriptionServiceImpl`,
+  `SyntheticTickServiceImpl`, `TickStreamServiceImpl`
+- `strategy.application`：
+  `StrategyServiceImpl`
+- `trading.application`：
+  `BacktestServiceImpl`, `PortfolioServiceImpl`
+- `community.application`：
+  `CommunitySignalServiceImpl`
+- `shared.application`：
+  `AiAnalysisServiceImpl`, `EmailServiceImpl`, `MemoryServiceImpl`,
+  `MonitoringServiceImpl`, `RateLimiterServiceImpl`
 
-后续迭代将继续把剩余 `service.impl` 类按领域收敛，并补充跨域依赖检查。
+当前状态：
+
+- `com.koduck.service.impl` 已不再承载业务实现类；
+- 领域模块边界已在代码结构中完整体现。

--- a/koduck-backend/docs/README.md
+++ b/koduck-backend/docs/README.md
@@ -164,6 +164,7 @@ mvn spring-boot:run
 - 领域模型与模块划分文档：[`DOMAIN-MODEL-DESIGN.md`](DOMAIN-MODEL-DESIGN.md)
 - DDD 边界治理 ADR：`ADR-0021-ddd-bounded-context-module-partitioning.md`
 - DDD Phase 1 实施 ADR：`ADR-0022-ddd-phase1-code-implementation.md`
+- DDD Phase 2 实施 ADR：`ADR-0023-ddd-phase2-complete-service-impl-migration.md`
 
 ## 测试
 

--- a/koduck-backend/src/main/java/com/koduck/identity/application/CredentialServiceImpl.java
+++ b/koduck-backend/src/main/java/com/koduck/identity/application/CredentialServiceImpl.java
@@ -1,4 +1,4 @@
-package com.koduck.service.impl;
+package com.koduck.identity.application;
 
 import com.koduck.common.constants.HttpHeaderConstants;
 import com.koduck.dto.credential.*;

--- a/koduck-backend/src/main/java/com/koduck/identity/application/ProfileServiceImpl.java
+++ b/koduck-backend/src/main/java/com/koduck/identity/application/ProfileServiceImpl.java
@@ -1,4 +1,4 @@
-package com.koduck.service.impl;
+package com.koduck.identity.application;
 
 import com.koduck.dto.profile.ProfileDTO;
 import com.koduck.dto.profile.UpdateProfileDTO;

--- a/koduck-backend/src/main/java/com/koduck/identity/application/UserCacheServiceImpl.java
+++ b/koduck-backend/src/main/java/com/koduck/identity/application/UserCacheServiceImpl.java
@@ -1,4 +1,4 @@
-package com.koduck.service.impl;
+package com.koduck.identity.application;
 
 import com.koduck.common.constants.RedisKeyConstants;
 import com.koduck.service.cache.CacheLayer;

--- a/koduck-backend/src/main/java/com/koduck/identity/application/UserServiceImpl.java
+++ b/koduck-backend/src/main/java/com/koduck/identity/application/UserServiceImpl.java
@@ -1,4 +1,4 @@
-package com.koduck.service.impl;
+package com.koduck.identity.application;
 
 import com.koduck.dto.common.PageResponse;
 import com.koduck.dto.user.ChangePasswordRequest;

--- a/koduck-backend/src/main/java/com/koduck/identity/application/UserSettingsServiceImpl.java
+++ b/koduck-backend/src/main/java/com/koduck/identity/application/UserSettingsServiceImpl.java
@@ -1,4 +1,4 @@
-package com.koduck.service.impl;
+package com.koduck.identity.application;
 
 import com.koduck.dto.settings.UpdateNotificationRequest;
 import com.koduck.dto.settings.UpdateSettingsRequest;

--- a/koduck-backend/src/main/java/com/koduck/market/application/KlineMinutesServiceImpl.java
+++ b/koduck-backend/src/main/java/com/koduck/market/application/KlineMinutesServiceImpl.java
@@ -1,4 +1,4 @@
-package com.koduck.service.impl;
+package com.koduck.market.application;
 
 import com.koduck.config.properties.DataServiceProperties;
 import com.koduck.dto.market.DataServiceResponse;

--- a/koduck-backend/src/main/java/com/koduck/market/application/KlineSyncServiceImpl.java
+++ b/koduck-backend/src/main/java/com/koduck/market/application/KlineSyncServiceImpl.java
@@ -1,4 +1,4 @@
-package com.koduck.service.impl;
+package com.koduck.market.application;
 
 import com.koduck.common.constants.MarketConstants;
 import com.koduck.config.properties.DataServiceProperties;

--- a/koduck-backend/src/main/java/com/koduck/market/application/MarketBreadthServiceImpl.java
+++ b/koduck-backend/src/main/java/com/koduck/market/application/MarketBreadthServiceImpl.java
@@ -1,4 +1,4 @@
-package com.koduck.service.impl;
+package com.koduck.market.application;
 import com.koduck.dto.market.DailyBreadthDto;
 import com.koduck.mapper.MarketDataMapper;
 import com.koduck.repository.MarketDailyBreadthRepository;

--- a/koduck-backend/src/main/java/com/koduck/market/application/MarketFlowServiceImpl.java
+++ b/koduck-backend/src/main/java/com/koduck/market/application/MarketFlowServiceImpl.java
@@ -1,4 +1,4 @@
-package com.koduck.service.impl;
+package com.koduck.market.application;
 import com.koduck.dto.market.DailyNetFlowDto;
 import com.koduck.mapper.MarketDataMapper;
 import com.koduck.repository.MarketDailyNetFlowRepository;

--- a/koduck-backend/src/main/java/com/koduck/market/application/MarketSectorNetFlowServiceImpl.java
+++ b/koduck-backend/src/main/java/com/koduck/market/application/MarketSectorNetFlowServiceImpl.java
@@ -1,4 +1,4 @@
-package com.koduck.service.impl;
+package com.koduck.market.application;
 import com.koduck.dto.market.SectorNetFlowDto;
 import com.koduck.dto.market.SectorNetFlowItemDto;
 import com.koduck.entity.MarketSectorNetFlow;

--- a/koduck-backend/src/main/java/com/koduck/market/application/MarketSentimentServiceImpl.java
+++ b/koduck-backend/src/main/java/com/koduck/market/application/MarketSentimentServiceImpl.java
@@ -1,4 +1,4 @@
-package com.koduck.service.impl;
+package com.koduck.market.application;
 
 import com.koduck.common.constants.MarketConstants;
 import com.koduck.dto.market.MarketSentimentDto;

--- a/koduck-backend/src/main/java/com/koduck/market/application/PricePushServiceImpl.java
+++ b/koduck-backend/src/main/java/com/koduck/market/application/PricePushServiceImpl.java
@@ -1,4 +1,4 @@
-package com.koduck.service.impl;
+package com.koduck.market.application;
 
 import com.koduck.dto.market.RealtimePriceEventMessage;
 import com.koduck.dto.market.TickDto;

--- a/koduck-backend/src/main/java/com/koduck/market/application/StockCacheServiceImpl.java
+++ b/koduck-backend/src/main/java/com/koduck/market/application/StockCacheServiceImpl.java
@@ -1,4 +1,4 @@
-package com.koduck.service.impl;
+package com.koduck.market.application;
 
 import com.koduck.common.constants.RedisKeyConstants;
 import com.koduck.dto.market.PriceQuoteDto;

--- a/koduck-backend/src/main/java/com/koduck/market/application/StockSubscriptionServiceImpl.java
+++ b/koduck-backend/src/main/java/com/koduck/market/application/StockSubscriptionServiceImpl.java
@@ -1,4 +1,4 @@
-package com.koduck.service.impl;
+package com.koduck.market.application;
 
 import com.koduck.service.StockSubscriptionService;
 import com.koduck.util.SymbolUtils;

--- a/koduck-backend/src/main/java/com/koduck/market/application/SyntheticTickServiceImpl.java
+++ b/koduck-backend/src/main/java/com/koduck/market/application/SyntheticTickServiceImpl.java
@@ -1,4 +1,4 @@
-package com.koduck.service.impl;
+package com.koduck.market.application;
 
 import com.koduck.dto.market.TickDto;
 import com.koduck.entity.StockRealtime;

--- a/koduck-backend/src/main/java/com/koduck/market/application/TickStreamServiceImpl.java
+++ b/koduck-backend/src/main/java/com/koduck/market/application/TickStreamServiceImpl.java
@@ -1,4 +1,4 @@
-package com.koduck.service.impl;
+package com.koduck.market.application;
 
 import com.koduck.dto.market.TickDto;
 import com.koduck.service.TickStreamService;

--- a/koduck-backend/src/main/java/com/koduck/shared/application/AiAnalysisServiceImpl.java
+++ b/koduck-backend/src/main/java/com/koduck/shared/application/AiAnalysisServiceImpl.java
@@ -1,4 +1,4 @@
-package com.koduck.service.impl;
+package com.koduck.shared.application;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.koduck.config.AgentConfig;

--- a/koduck-backend/src/main/java/com/koduck/shared/application/EmailServiceImpl.java
+++ b/koduck-backend/src/main/java/com/koduck/shared/application/EmailServiceImpl.java
@@ -1,4 +1,4 @@
-package com.koduck.service.impl;
+package com.koduck.shared.application;
 
 import com.koduck.config.properties.MailProperties;
 import com.koduck.service.EmailService;

--- a/koduck-backend/src/main/java/com/koduck/shared/application/MemoryServiceImpl.java
+++ b/koduck-backend/src/main/java/com/koduck/shared/application/MemoryServiceImpl.java
@@ -1,4 +1,4 @@
-package com.koduck.service.impl;
+package com.koduck.shared.application;
 
 import com.koduck.entity.MemoryChatMessage;
 import com.koduck.entity.MemoryChatSession;

--- a/koduck-backend/src/main/java/com/koduck/shared/application/MonitoringServiceImpl.java
+++ b/koduck-backend/src/main/java/com/koduck/shared/application/MonitoringServiceImpl.java
@@ -1,4 +1,4 @@
-package com.koduck.service.impl;
+package com.koduck.shared.application;
 import com.koduck.entity.AlertHistory;
 import com.koduck.entity.AlertRule;
 import com.koduck.entity.DataSourceStatus;

--- a/koduck-backend/src/main/java/com/koduck/shared/application/RateLimiterServiceImpl.java
+++ b/koduck-backend/src/main/java/com/koduck/shared/application/RateLimiterServiceImpl.java
@@ -1,4 +1,4 @@
-package com.koduck.service.impl;
+package com.koduck.shared.application;
 
 import com.koduck.config.properties.RateLimitProperties;
 import com.koduck.service.RateLimiterService;

--- a/koduck-backend/src/test/java/com/koduck/service/AiAnalysisServiceImplTest.java
+++ b/koduck-backend/src/test/java/com/koduck/service/AiAnalysisServiceImplTest.java
@@ -19,7 +19,7 @@ import com.koduck.exception.ResourceNotFoundException;
 import com.koduck.repository.BacktestResultRepository;
 import com.koduck.repository.PortfolioPositionRepository;
 import com.koduck.repository.StrategyRepository;
-import com.koduck.service.impl.AiAnalysisServiceImpl;
+import com.koduck.shared.application.AiAnalysisServiceImpl;
 import com.koduck.service.support.AiConversationSupport;
 import com.koduck.service.support.AiRecommendationSupport;
 import com.koduck.service.support.AiStreamRelaySupport;

--- a/koduck-backend/src/test/java/com/koduck/service/MemoryServiceTest.java
+++ b/koduck-backend/src/test/java/com/koduck/service/MemoryServiceTest.java
@@ -6,7 +6,7 @@ import com.koduck.entity.UserMemoryProfile;
 import com.koduck.repository.MemoryChatMessageRepository;
 import com.koduck.repository.MemoryChatSessionRepository;
 import com.koduck.repository.UserMemoryProfileRepository;
-import com.koduck.service.impl.MemoryServiceImpl;
+import com.koduck.shared.application.MemoryServiceImpl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/koduck-backend/src/test/java/com/koduck/service/RateLimiterServiceTest.java
+++ b/koduck-backend/src/test/java/com/koduck/service/RateLimiterServiceTest.java
@@ -1,7 +1,7 @@
 package com.koduck.service;
 
 import com.koduck.config.properties.RateLimitProperties;
-import com.koduck.service.impl.RateLimiterServiceImpl;
+import com.koduck.shared.application.RateLimiterServiceImpl;
 import java.time.Duration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;


### PR DESCRIPTION
## Summary
- complete remaining DDD migration of service implementations from com.koduck.service.impl into bounded-context application packages
- migrate remaining implementations to market.application, identity.application, and shared.application
- update affected tests that directly import implementation classes
- update DDD docs implementation status and add ADR-0023

## Key Result
- com.koduck.service.impl no longer contains implementation classes

## Files
- code migrations under src/main/java/com/koduck/{market,identity,shared}/application
- docs: DOMAIN-MODEL-DESIGN.md, README.md, ADR-0023-ddd-phase2-complete-service-impl-migration.md

## Verification
- mvn -DskipTests compile -f koduck-backend/pom.xml

Closes #334