### PR TITLE
build(style): enforce checkstyle-alibaba and test classification rules

### DIFF
--- a/.github/java-standards/checkstyle-alibaba.xml
+++ b/.github/java-standards/checkstyle-alibaba.xml
@@ -169,19 +169,16 @@
 
         <!-- Javadoc checks for methods -->
         <module name="JavadocMethod">
-            <property name="scope" value="public"/>
+            <property name="accessModifiers" value="public"/>
             <property name="allowMissingParamTags" value="false"/>
             <property name="allowMissingReturnTag" value="false"/>
         </module>
 
         <module name="JavadocType">
-            <property name="scope" value="public"/>
             <property name="authorFormat" value="\S"/>
         </module>
 
-        <module name="JavadocVariable">
-            <property name="scope" value="public"/>
-        </module>
+        <module name="JavadocVariable"/>
 
         <module name="JavadocStyle">
             <property name="checkFirstSentence" value="false"/>

--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -53,6 +53,11 @@ jobs:
           java-version: "23"
           cache: maven
 
+      - name: Run backend checkstyle
+        run: |
+          set -euo pipefail
+          mvn -f koduck-backend/pom.xml -B checkstyle:check
+
       - name: Run backend tests
         run: |
           set -euo pipefail

--- a/.github/workflows/ci-quality-gate.yml
+++ b/.github/workflows/ci-quality-gate.yml
@@ -50,6 +50,11 @@ jobs:
           java-version: "23"
           cache: maven
 
+      - name: Run backend checkstyle
+        run: |
+          set -euo pipefail
+          mvn -f koduck-backend/pom.xml -B checkstyle:check
+
       - name: Run backend tests
         run: |
           set -euo pipefail

--- a/koduck-backend/docs/ADR-0029-checkstyle-alibaba-and-test-classification-governance.md
+++ b/koduck-backend/docs/ADR-0029-checkstyle-alibaba-and-test-classification-governance.md
@@ -1,0 +1,53 @@
+# ADR-0029: 接入 Alibaba Checkstyle 并统一测试分类规范
+
+- Status: Accepted
+- Date: 2026-04-02
+- Issue: #346
+
+## Context
+
+仓库已提供标准规则文件 `.github/java-standards/checkstyle-alibaba.xml`，但未在后端构建流程中有效执行，导致“有标准、无落地”。
+
+同时，测试执行存在分类约定分散的问题：单元、切片、集成、冒烟测试的边界与执行入口未形成统一文档，容易出现环境依赖测试误入默认测试阶段。
+
+## Decision
+
+1. 在 `koduck-backend/pom.xml` 接入 `maven-checkstyle-plugin`：
+   - 规则文件：`${project.basedir}/../.github/java-standards/checkstyle-alibaba.xml`
+   - 绑定到 `validate` 阶段，纳入默认构建流程；
+   - 覆盖主代码与测试代码（`includeTestSourceDirectory=true`）。
+2. 采用“分阶段收敛”策略：
+   - 当前阻断 `error` 级别违规；
+   - 保留 `warning` 可见性用于持续治理。
+3. 明确测试分类与执行边界：
+   - Surefire：Unit + Slice；
+   - Failsafe：Integration + Smoke；
+   - 在 Failsafe includes 中显式纳入 `*SmokeTest.java`。
+4. 新增测试分类规范文档并加入 docs 索引。
+
+## Consequences
+
+正向影响：
+
+- Checkstyle 规则从“文件存在”升级为“构建可执行”；
+- 风格治理有统一入口，降低团队代码风格漂移；
+- 测试分层更加清晰，减少默认测试阶段受环境依赖干扰。
+
+代价：
+
+- 构建时间略有增加；
+- 需要持续处理 warning 存量并规划后续收紧策略。
+
+## Alternatives Considered
+
+1. 仅在 CI 脚本中手工调用 Checkstyle，不写入 Maven 生命周期
+   - 拒绝：与本地构建不一致，维护成本高。
+
+2. 直接阻断 warning
+   - 暂不采用：当前存量较大，先保证规则落地与可观测，再逐步收紧。
+
+## Verification
+
+- `mvn -f koduck-backend/pom.xml -DskipTests checkstyle:check` 可执行；
+- `mvn -f koduck-backend/pom.xml test` 与 `verify` 的测试分层行为符合文档；
+- 文档索引已加入 ADR 与测试分类规范。

--- a/koduck-backend/docs/README.md
+++ b/koduck-backend/docs/README.md
@@ -175,6 +175,11 @@ mvn spring-boot:run
 - 覆盖率门禁 60% ADR：`ADR-0027-coverage-gate-60-and-jacoco-scope-alignment.md`
 - 核心服务覆盖率 60/40 ADR：`ADR-0028-core-service-coverage-gate-6040.md`
 
+## 代码风格与测试分层治理
+
+- 测试分类规范：[`TEST-CLASSIFICATION.md`](TEST-CLASSIFICATION.md)
+- Checkstyle 与测试分类治理 ADR：`ADR-0029-checkstyle-alibaba-and-test-classification-governance.md`
+
 ## 测试
 
 ```bash

--- a/koduck-backend/docs/TEST-CLASSIFICATION.md
+++ b/koduck-backend/docs/TEST-CLASSIFICATION.md
@@ -1,0 +1,44 @@
+# 测试分类规范
+
+本文档定义后端测试分层、命名约定与执行方式，确保本地与 CI 行为一致。
+
+## 分类原则
+
+1. 单元测试（Unit）
+   - 目标：纯业务逻辑验证，不依赖外部基础设施。
+   - 路径：`src/test/java/**`（默认），推荐放在 `src/test/java/**/unit/**`。
+   - 命名：`*Test.java`。
+
+2. 切片测试（Slice）
+   - 目标：针对 Web/JPA 等局部 Spring 切片，验证组件组合行为。
+   - 路径：`src/test/java/**/slice/**`。
+   - 命名：`*Test.java` 或 `*SliceTest.java`。
+
+3. 集成测试（Integration）
+   - 目标：跨模块集成验证，通常依赖 DB/容器/外部组件。
+   - 路径：`src/test/java/**/integration/**`，或后缀 `*IntegrationTest.java`。
+
+4. 冒烟测试（Smoke）
+   - 目标：关键链路快速可用性验证。
+   - 命名：`*SmokeTest.java`。
+   - 执行归属：走 Failsafe（与集成测试同阶段）。
+
+## Maven 执行策略
+
+1. `maven-surefire-plugin`（`test` 阶段）
+   - 默认执行 Unit + Slice。
+   - 默认排除：`integration` 路径、`*IntegrationTest`、`*SmokeTest`。
+
+2. `maven-failsafe-plugin`（`integration-test` / `verify` 阶段）
+   - 执行 `integration` 路径测试、`*IntegrationTest`、`*SmokeTest`。
+
+3. 典型命令
+   - 本地快速回归：`mvn -f koduck-backend/pom.xml test`
+   - 全量含集成：`mvn -f koduck-backend/pom.xml verify`
+   - 仅某一测试类：`mvn -f koduck-backend/pom.xml -Dtest=MarketServiceImplTest test`
+
+## 提交约束
+
+1. 新增测试时必须明确分类（路径或命名至少满足一种分类信号）。
+2. 禁止将依赖外部环境的测试放入默认单元测试范围。
+3. 集成/冒烟测试失败不应通过修改 surefire 排除项来规避，应修复环境或测试本身。

--- a/koduck-backend/pom.xml
+++ b/koduck-backend/pom.xml
@@ -35,8 +35,10 @@
         <!-- Plugin Versions -->
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
         <maven-surefire-plugin.version>3.5.2</maven-surefire-plugin.version>
+        <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
         <maven-pmd-plugin.version>3.28.0</maven-pmd-plugin.version>
         <spotbugs-maven-plugin.version>4.8.6.6</spotbugs-maven-plugin.version>
+        <checkstyle.version>10.17.0</checkstyle.version>
 
         <!-- Annotation Processor Versions -->
         <lombok.version>1.18.36</lombok.version>
@@ -348,6 +350,36 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>${maven-checkstyle-plugin.version}</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.puppycrawl.tools</groupId>
+                        <artifactId>checkstyle</artifactId>
+                        <version>${checkstyle.version}</version>
+                    </dependency>
+                </dependencies>
+                <configuration>
+                    <configLocation>${project.basedir}/../.github/java-standards/checkstyle-alibaba.xml</configLocation>
+                    <consoleOutput>true</consoleOutput>
+                    <includeTestSourceDirectory>true</includeTestSourceDirectory>
+                    <failsOnError>true</failsOnError>
+                    <failOnViolation>true</failOnViolation>
+                    <!-- Phase-in: block only error-severity violations; keep warning visibility. -->
+                    <violationSeverity>error</violationSeverity>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>checkstyle-validate</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven-surefire-plugin.version}</version>
                 <configuration>
@@ -415,6 +447,7 @@
                     <includes>
                         <include>**/integration/**/*Test.java</include>
                         <include>**/*IntegrationTest.java</include>
+                        <include>**/*SmokeTest.java</include>
                     </includes>
                 </configuration>
                 <executions>


### PR DESCRIPTION
## Summary
- wire .github/java-standards/checkstyle-alibaba.xml into Maven via maven-checkstyle-plugin
- execute Checkstyle in validate and in CI (ci-dev / ci-quality-gate)
- align test categorization by documenting Unit/Slice/Integration/Smoke and including *SmokeTest in failsafe
- add ADR-0029 for governance and rollout strategy
- fix Checkstyle rule compatibility (JavadocMethod scope -> accessModifiers) for Checkstyle 10.x

## Validation
- [x] mvn -f koduck-backend/pom.xml -DskipTests checkstyle:check
- [ ] mvn -q -f koduck-backend/pom.xml -DskipITs test (fails due to existing JaCoCo coverage gate, not introduced by this PR)

## Related
Closes #346
