### PR TITLE
style(dto): fix IndicatorResponse record component javadoc format

### DIFF
--- a/koduck-backend/src/main/java/com/koduck/dto/indicator/IndicatorResponse.java
+++ b/koduck-backend/src/main/java/com/koduck/dto/indicator/IndicatorResponse.java
@@ -19,19 +19,19 @@ import com.koduck.util.CollectionCopyUtils;
  * @author Koduck Team
  */
 public record IndicatorResponse(
-    /** Stock symbol. */
+    // Stock symbol.
     String symbol,
-    /** Market identifier. */
+    // Market identifier.
     String market,
-    /** Indicator name. */
+    // Indicator name.
     String indicator,
-    /** Indicator period. */
+    // Indicator period.
     Integer period,
-    /** Indicator values map. */
+    // Indicator values map.
     Map<String, BigDecimal> values,
-    /** Trend direction. */
+    // Trend direction.
     String trend,
-    /** Timestamp of the indicator data. */
+    // Timestamp of the indicator data.
     LocalDateTime timestamp
 ) {
 


### PR DESCRIPTION
## 问题描述

修复 `IndicatorResponse.java` 的编译警告：
```
documentation comment is not attached to any declaration
```

## 修复内容

- 将 record 组件的块注释 `/\*\* \*/` 改为行内注释 `//`
- 类级别的 @param 标签已提供完整文档

## 变更文件

- `koduck-backend/src/main/java/com/koduck/dto/indicator/IndicatorResponse.java`

## 验证结果

- [x] `mvn clean compile` 无 IndicatorResponse 警告

Refs #366