### PR TITLE
style(dto): fix Checkstyle warnings for 10 DTO classes

### DIFF
--- a/koduck-backend/docs/ADR-0039-dto-checkstyle-batch4-fix.md
+++ b/koduck-backend/docs/ADR-0039-dto-checkstyle-batch4-fix.md
@@ -1,0 +1,84 @@
+# ADR-0039: DTO Checkstyle 代码风格修复（Batch 4）
+
+- Status: Accepted
+- Date: 2026-04-02
+- Issue: #370
+
+## Context
+
+执行 `mvn -f koduck-backend/pom.xml clean compile checkstyle:check` 时发现 10 个 DTO 文件存在 Checkstyle 代码风格告警：
+
+1. `ChatStreamRequest.java`
+2. `TradeDto.java`
+3. `DailyNetFlowDto.java`
+4. `KlineDataDto.java`
+5. `StockIndustryDto.java`
+6. `StockValuationDto.java`
+7. `CapitalRiverDto.java`
+8. `UpdateSignalRequest.java`
+9. `CommentResponse.java`
+10. `SignalResponse.java`
+
+### 告警分类
+
+| 告警类型 | 影响文件 | 说明 |
+|---------|---------|------|
+| `ImportOrder` | ChatStreamRequest, DailyNetFlowDto, UpdateSignalRequest, CommentResponse, SignalResponse | 导入顺序不符合 Alibaba 规范 |
+| `AvoidStarImport` | UpdateSignalRequest | 使用了 `.*` 形式的导入 |
+| `JavadocType` | TradeDto, DailyNetFlowDto, KlineDataDto, StockIndustryDto, StockValuationDto, CapitalRiverDto, UpdateSignalRequest, CommentResponse | 缺少 `@author` 标签，Record 缺少 `@param` 标签 |
+| `JavadocVariable` | 全部 10 个文件 | Builder 及内部类的私有字段缺少 Javadoc 注释 |
+| `Indentation` | CapitalRiverDto | Record 紧凑构造函数缩进不正确 |
+| `OneStatementPerLine` | UpdateSignalRequest | Builder 方法一行多个语句 |
+| `LeftCurly` | UpdateSignalRequest | 类、方法的花括号未放置在前一行 |
+
+## Decision
+
+### 修复范围
+
+统一修复上述 10 个文件中的所有 Checkstyle 告警，确保 `mvn checkstyle:check` 零告警。
+
+### 修复规则
+
+1. **Import 顺序**：按照 Alibaba Java 编码规范，导入顺序为 `java.*` → 第三方包 → `com.koduck.*`。
+
+2. **避免星号导入**：将 `jakarta.validation.constraints.*` 展开为具体类导入。
+
+3. **Javadoc 规范（Alibaba）**：
+   - Java Record 的类级别 Javadoc 必须为每个组件添加 `@param` 标签，并包含 `@author`
+   - 所有类、字段、方法必须添加 Javadoc 注释
+
+4. **缩进规范**：
+   - 使用 4 个空格缩进
+   - Record 紧凑构造函数缩进保持一致
+
+5. **代码格式**：
+   - 每行只能有一个语句
+   - 类声明、方法声明的左花括号必须位于前一行末尾（`eol` 风格）
+
+## Consequences
+
+### 正向影响
+
+- 10 个 DTO 文件通过 Checkstyle 检查
+- 代码风格与项目 Alibaba 规范一致
+- 为后续 CI 门禁扫清障碍
+
+### 消极影响
+
+- 无功能变化，纯代码风格修复
+- 修改文件较多，但均为文档和格式调整
+
+### 兼容性
+
+| 方面 | 影响 | 说明 |
+|-----|------|------|
+| 业务逻辑 | 无 | 仅调整导入顺序、添加 Javadoc、修复格式 |
+| API 接口 | 无 | 类结构和字段完全不变 |
+| 序列化 | 无 | 未修改字段和注解 |
+| 测试 | 无 | 测试用例无需修改 |
+
+## Related
+
+- Issue #370
+- ADR-0029: 接入 Alibaba Checkstyle 并统一测试分类规范
+- ADR-0038: DTO Checkstyle 代码风格修复（Batch 3）

--- a/koduck-backend/src/main/java/com/koduck/dto/ai/ChatStreamRequest.java
+++ b/koduck-backend/src/main/java/com/koduck/dto/ai/ChatStreamRequest.java
@@ -1,15 +1,14 @@
 package com.koduck.dto.ai;
 
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotEmpty;
-
 import java.util.List;
 import java.util.Map;
 
+import com.koduck.util.CollectionCopyUtils;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-
-import com.koduck.util.CollectionCopyUtils;
 
 /**
  * AI 对话流请求 DTO。
@@ -117,14 +116,23 @@ public class ChatStreamRequest {
      */
     public static final class Builder {
 
+        /** 提供商，默认 minimax。 */
         private String provider = "minimax";
+        /** 可选模型名称，为空时使用提供商默认模型。 */
         private String model;
+        /** API密钥。 */
         private String apiKey;
+        /** API基础地址。 */
         private String apiBase;
+        /** 会话ID，用于记忆检索和写回。 */
         private String sessionId;
+        /** 运行时角色ID（如 general/architect/coder/reviewer/analyst）。 */
         private String role = "general";
+        /** 可选运行时选项，传递给 koduck-agent。 */
         private Map<String, Object> runtime;
+        /** 保持向后兼容：为true时后端注入无工具守护提示词。 */
         private Boolean disableToolCalls = false;
+        /** 消息列表。 */
         private List<ChatMessageRequest> messages;
 
         /**

--- a/koduck-backend/src/main/java/com/koduck/dto/community/CommentResponse.java
+++ b/koduck-backend/src/main/java/com/koduck/dto/community/CommentResponse.java
@@ -1,37 +1,53 @@
 package com.koduck.dto.community;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
-import com.koduck.common.constants.DateTimePatternConstants;
-import com.koduck.util.CollectionCopyUtils;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
 import java.time.LocalDateTime;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import com.koduck.common.constants.DateTimePatternConstants;
+import com.koduck.util.CollectionCopyUtils;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
 /**
- *  DTO
+ * Comment response DTO.
+ *
+ * @author Koduck Team
  */
 @Data
 @NoArgsConstructor
 public class CommentResponse {
 
+    /** Comment ID. */
     private Long id;
+    /** Signal ID. */
     private Long signalId;
+    /** User ID. */
     private Long userId;
+    /** Username. */
     private String username;
+    /** Avatar URL. */
     private String avatarUrl;
+    /** Parent comment ID. */
     private Long parentId;
 
+    /** Comment content. */
     private String content;
+    /** Like count. */
     private Integer likeCount;
+    /** Deleted flag. */
     private Boolean isDeleted;
 
+    /** Reply comments list. */
     private List<CommentResponse> replies;
 
+    /** Created time. */
     @JsonFormat(pattern = DateTimePatternConstants.STANDARD_DATE_TIME_PATTERN)
     private LocalDateTime createdAt;
 
+    /** Updated time. */
     @JsonFormat(pattern = DateTimePatternConstants.STANDARD_DATE_TIME_PATTERN)
     private LocalDateTime updatedAt;
 
@@ -49,17 +65,29 @@ public class CommentResponse {
 
     public static final class Builder {
 
+        /** Comment ID. */
         private Long id;
+        /** Signal ID. */
         private Long signalId;
+        /** User ID. */
         private Long userId;
+        /** Username. */
         private String username;
+        /** Avatar URL. */
         private String avatarUrl;
+        /** Parent comment ID. */
         private Long parentId;
+        /** Comment content. */
         private String content;
+        /** Like count. */
         private Integer likeCount;
+        /** Deleted flag. */
         private Boolean isDeleted;
+        /** Reply comments list. */
         private List<CommentResponse> replies;
+        /** Created time. */
         private LocalDateTime createdAt;
+        /** Updated time. */
         private LocalDateTime updatedAt;
 
         public Builder id(Long id) {

--- a/koduck-backend/src/main/java/com/koduck/dto/community/SignalResponse.java
+++ b/koduck-backend/src/main/java/com/koduck/dto/community/SignalResponse.java
@@ -1,12 +1,15 @@
 package com.koduck.dto.community;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.koduck.common.constants.DateTimePatternConstants;
-import com.koduck.util.CollectionCopyUtils;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.koduck.common.constants.DateTimePatternConstants;
+import com.koduck.util.CollectionCopyUtils;
+
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -182,34 +185,63 @@ public class SignalResponse {
      */
     public static final class Builder {
 
+        /** Signal ID. */
         private Long id;
+        /** User ID. */
         private Long userId;
+        /** Username. */
         private String username;
+        /** Avatar URL. */
         private String avatarUrl;
+        /** Strategy ID. */
         private Long strategyId;
+        /** Strategy name. */
         private String strategyName;
+        /** Stock symbol. */
         private String symbol;
+        /** Signal type. */
         private String signalType;
+        /** Signal reason. */
         private String reason;
+        /** Target price. */
         private BigDecimal targetPrice;
+        /** Stop loss price. */
         private BigDecimal stopLoss;
+        /** Time frame for the signal. */
         private String signalTimeFrame;
+        /** Confidence level (0-100). */
         private Integer confidence;
+        /** Signal status. */
         private String status;
+        /** Result status. */
         private String resultStatus;
+        /** Result profit. */
         private BigDecimal resultProfit;
+        /** Expiration time. */
         private LocalDateTime expiresAt;
+        /** Like count. */
         private Integer likeCount;
+        /** Favorite count. */
         private Integer favoriteCount;
+        /** Subscribe count. */
         private Integer subscribeCount;
+        /** Comment count. */
         private Integer commentCount;
+        /** View count. */
         private Integer viewCount;
+        /** Whether the signal is featured. */
         private Boolean isFeatured;
+        /** List of tags. */
         private List<String> tags;
+        /** Whether the current user has liked this signal. */
         private Boolean isLiked;
+        /** Whether the current user has favorited this signal. */
         private Boolean isFavorited;
+        /** Whether the current user has subscribed to this signal. */
         private Boolean isSubscribed;
+        /** Creation time. */
         private LocalDateTime createdAt;
+        /** Last update time. */
         private LocalDateTime updatedAt;
 
         /**

--- a/koduck-backend/src/main/java/com/koduck/dto/community/UpdateSignalRequest.java
+++ b/koduck-backend/src/main/java/com/koduck/dto/community/UpdateSignalRequest.java
@@ -1,38 +1,52 @@
 package com.koduck.dto.community;
 
-import com.koduck.util.CollectionCopyUtils;
-import jakarta.validation.constraints.*;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
 import java.math.BigDecimal;
 import java.util.List;
 
+import com.koduck.util.CollectionCopyUtils;
+
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Digits;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
 /**
- *  DTO
+ * Update signal request DTO.
+ *
+ * @author Koduck Team
  */
 @Data
 @NoArgsConstructor
 public class UpdateSignalRequest {
 
+    /** 推荐理由. */
     @Size(max = 2000, message = "推荐理由最多 2000 个字符")
     private String reason;
 
+    /** 目标价格. */
     @DecimalMin(value = "0.0001", message = "目标价格必须大于 0")
     @Digits(integer = 15, fraction = 4, message = "目标价格格式不正确")
     private BigDecimal targetPrice;
 
+    /** 止损价格. */
     @DecimalMin(value = "0.0001", message = "止损价格必须大于 0")
     @Digits(integer = 15, fraction = 4, message = "止损价格格式不正确")
     private BigDecimal stopLoss;
 
+    /** 信心指数. */
     @Min(value = 0, message = "信心指数最小为 0")
     @Max(value = 100, message = "信心指数最大为 100")
     private Integer confidence;
 
+    /** 状态. */
     @Pattern(regexp = "ACTIVE|CLOSED|CANCELLED", message = "状态必须是 ACTIVE, CLOSED 或 CANCELLED")
     private String status;
 
+    /** 标签列表. */
     private List<String> tags;
 
     public UpdateSignalRequest(String reason, BigDecimal targetPrice, BigDecimal stopLoss, Integer confidence,
@@ -49,22 +63,98 @@ public class UpdateSignalRequest {
         return new Builder();
     }
 
+    /** Builder class for UpdateSignalRequest. */
     public static final class Builder {
 
+        /** 推荐理由. */
         private String reason;
+
+        /** 目标价格. */
         private BigDecimal targetPrice;
+
+        /** 止损价格. */
         private BigDecimal stopLoss;
+
+        /** 信心指数. */
         private Integer confidence;
+
+        /** 状态. */
         private String status;
+
+        /** 标签列表. */
         private List<String> tags;
 
-        public Builder reason(String reason) { this.reason = reason; return this; }
-        public Builder targetPrice(BigDecimal targetPrice) { this.targetPrice = targetPrice; return this; }
-        public Builder stopLoss(BigDecimal stopLoss) { this.stopLoss = stopLoss; return this; }
-        public Builder confidence(Integer confidence) { this.confidence = confidence; return this; }
-        public Builder status(String status) { this.status = status; return this; }
-        public Builder tags(List<String> tags) { this.tags = CollectionCopyUtils.copyList(tags); return this; }
+        /**
+         * Set reason.
+         *
+         * @param reason the reason
+         * @return this builder
+         */
+        public Builder reason(String reason) {
+            this.reason = reason;
+            return this;
+        }
 
+        /**
+         * Set target price.
+         *
+         * @param targetPrice the target price
+         * @return this builder
+         */
+        public Builder targetPrice(BigDecimal targetPrice) {
+            this.targetPrice = targetPrice;
+            return this;
+        }
+
+        /**
+         * Set stop loss.
+         *
+         * @param stopLoss the stop loss
+         * @return this builder
+         */
+        public Builder stopLoss(BigDecimal stopLoss) {
+            this.stopLoss = stopLoss;
+            return this;
+        }
+
+        /**
+         * Set confidence.
+         *
+         * @param confidence the confidence
+         * @return this builder
+         */
+        public Builder confidence(Integer confidence) {
+            this.confidence = confidence;
+            return this;
+        }
+
+        /**
+         * Set status.
+         *
+         * @param status the status
+         * @return this builder
+         */
+        public Builder status(String status) {
+            this.status = status;
+            return this;
+        }
+
+        /**
+         * Set tags.
+         *
+         * @param tags the tags
+         * @return this builder
+         */
+        public Builder tags(List<String> tags) {
+            this.tags = CollectionCopyUtils.copyList(tags);
+            return this;
+        }
+
+        /**
+         * Build the UpdateSignalRequest.
+         *
+         * @return the UpdateSignalRequest instance
+         */
         public UpdateSignalRequest build() {
             return new UpdateSignalRequest(reason, targetPrice, stopLoss, confidence, status, tags);
         }

--- a/koduck-backend/src/main/java/com/koduck/dto/market/CapitalRiverDto.java
+++ b/koduck-backend/src/main/java/com/koduck/dto/market/CapitalRiverDto.java
@@ -1,30 +1,42 @@
 package com.koduck.dto.market;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
-
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
 /**
  * Capital River response DTO.
+ *
+ * @author koduck
+ * @param market the market
+ * @param indicator the indicator
+ * @param tradeDate the trade date
+ * @param inflow the inflow
+ * @param outflow the outflow
+ * @param bubbles the bubbles
+ * @param tracks the tracks
+ * @param breadthBands the breadth bands
+ * @param source the source
+ * @param quality the quality
  */
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record CapitalRiverDto(
-        String market,
-        String indicator,
-        LocalDate tradeDate,
-        BigDecimal inflow,
-        BigDecimal outflow,
-        List<CapitalRiverBubbleDto> bubbles,
-        CapitalRiverTracksDto tracks,
-        CapitalRiverBreadthBandsDto breadthBands,
-        String source,
-        String quality
+    String market,
+    String indicator,
+    LocalDate tradeDate,
+    BigDecimal inflow,
+    BigDecimal outflow,
+    List<CapitalRiverBubbleDto> bubbles,
+    CapitalRiverTracksDto tracks,
+    CapitalRiverBreadthBandsDto breadthBands,
+    String source,
+    String quality
 ) {
-        public CapitalRiverDto {
-                bubbles = bubbles == null ? null : List.copyOf(bubbles);
-        }
+    public CapitalRiverDto {
+        bubbles = bubbles == null ? null : List.copyOf(bubbles);
+    }
 }
 

--- a/koduck-backend/src/main/java/com/koduck/dto/market/DailyNetFlowDto.java
+++ b/koduck-backend/src/main/java/com/koduck/dto/market/DailyNetFlowDto.java
@@ -1,14 +1,27 @@
 package com.koduck.dto.market;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
-
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
 /**
  * Daily market net flow DTO.
+ *
+ * @author Koduck
+ * @param market the market
+ * @param flowType the flow type
+ * @param tradeDate the trade date
+ * @param netInflow the net inflow
+ * @param totalInflow the total inflow
+ * @param totalOutflow the total outflow
+ * @param currency the currency
+ * @param source the source
+ * @param quality the quality
+ * @param snapshotTime the snapshot time
+ * @param updatedAt the updated at
  */
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record DailyNetFlowDto(

--- a/koduck-backend/src/main/java/com/koduck/dto/market/KlineDataDto.java
+++ b/koduck-backend/src/main/java/com/koduck/dto/market/KlineDataDto.java
@@ -4,6 +4,15 @@ import java.math.BigDecimal;
 
 /**
  * K-line (candlestick) data DTO.
+ *
+ * @param timestamp the timestamp
+ * @param open the open price
+ * @param high the high price
+ * @param low the low price
+ * @param close the close price
+ * @param volume the volume
+ * @param amount the amount
+ * @author Koduck Team
  */
 public record KlineDataDto(
     Long timestamp,
@@ -20,12 +29,19 @@ public record KlineDataDto(
     }
     
     public static class Builder {
+        /** Timestamp. */
         private Long timestamp;
+        /** Open price. */
         private BigDecimal open;
+        /** High price. */
         private BigDecimal high;
+        /** Low price. */
         private BigDecimal low;
+        /** Close price. */
         private BigDecimal close;
+        /** Volume. */
         private Long volume;
+        /** Amount. */
         private BigDecimal amount;
         
         public Builder timestamp(Long timestamp) {

--- a/koduck-backend/src/main/java/com/koduck/dto/market/StockIndustryDto.java
+++ b/koduck-backend/src/main/java/com/koduck/dto/market/StockIndustryDto.java
@@ -5,6 +5,14 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 /**
  * Stock industry metadata DTO.
+ *
+ * @param symbol the symbol
+ * @param name the name
+ * @param industry the industry
+ * @param sector the sector
+ * @param subIndustry the sub industry
+ * @param board the board
+ * @author koduck
  */
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record StockIndustryDto(
@@ -26,11 +34,17 @@ public record StockIndustryDto(
     }
 
     public static class Builder {
+        /** Symbol. */
         private String symbol;
+        /** Name. */
         private String name;
+        /** Industry. */
         private String industry;
+        /** Sector. */
         private String sector;
+        /** Sub industry. */
         private String subIndustry;
+        /** Board. */
         private String board;
 
         public Builder symbol(String symbol) {

--- a/koduck-backend/src/main/java/com/koduck/dto/market/StockValuationDto.java
+++ b/koduck-backend/src/main/java/com/koduck/dto/market/StockValuationDto.java
@@ -1,11 +1,25 @@
 package com.koduck.dto.market;
 
+import java.math.BigDecimal;
+
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import java.math.BigDecimal;
 
 /**
  * Stock valuation metrics DTO.
+ *
+ * @param symbol the symbol
+ * @param name the name
+ * @param peTtm the PE TTM
+ * @param pb the PB
+ * @param psTtm the PS TTM
+ * @param marketCap the market cap
+ * @param floatMarketCap the float market cap
+ * @param totalShares the total shares
+ * @param floatShares the float shares
+ * @param floatRatio the float ratio
+ * @param turnoverRate the turnover rate
+ * @author koduck
  */
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record StockValuationDto(
@@ -32,16 +46,27 @@ public record StockValuationDto(
     }
 
     public static class Builder {
+        /** Symbol. */
         private String symbol;
+        /** Name. */
         private String name;
+        /** PE TTM. */
         private BigDecimal peTtm;
+        /** PB. */
         private BigDecimal pb;
+        /** PS TTM. */
         private BigDecimal psTtm;
+        /** Market cap. */
         private BigDecimal marketCap;
+        /** Float market cap. */
         private BigDecimal floatMarketCap;
+        /** Total shares. */
         private BigDecimal totalShares;
+        /** Float shares. */
         private BigDecimal floatShares;
+        /** Float ratio. */
         private BigDecimal floatRatio;
+        /** Turnover rate. */
         private BigDecimal turnoverRate;
 
         public Builder symbol(String symbol) {

--- a/koduck-backend/src/main/java/com/koduck/dto/portfolio/TradeDto.java
+++ b/koduck-backend/src/main/java/com/koduck/dto/portfolio/TradeDto.java
@@ -5,16 +5,29 @@ import java.time.LocalDateTime;
 
 /**
  * Trade record DTO.
- * Issue #210: Added status and notes fields
+ *
+ * @param id the trade ID
+ * @param market the market
+ * @param symbol the stock symbol
+ * @param name the stock name
+ * @param tradeType the trade type (BUY/SELL)
+ * @param status the trade status
+ * @param notes the trade notes
+ * @param quantity the quantity
+ * @param price the price
+ * @param amount the amount
+ * @param tradeTime the trade time
+ * @param createdAt the creation time
+ * @author Koduck Team
  */
 public record TradeDto(
     Long id,
     String market,
     String symbol,
     String name,
-    String tradeType,    // BUY/SELL
-    String status,       // PENDING/SUCCESS/FAILED/CANCELLED
-    String notes,        // 交易备注
+    String tradeType,
+    String status,
+    String notes,
     BigDecimal quantity,
     BigDecimal price,
     BigDecimal amount,
@@ -26,83 +39,175 @@ public record TradeDto(
         return new Builder();
     }
     
+    /**
+     * Builder class for TradeDto.
+     */
     public static class Builder {
+        /** The trade ID. */
         private Long id;
+        /** The market. */
         private String market;
+        /** The stock symbol. */
         private String symbol;
+        /** The stock name. */
         private String name;
+        /** The trade type (BUY/SELL). */
         private String tradeType;
-        private String status = "SUCCESS";  // Default status
+        /** The trade status. Default is SUCCESS. */
+        private String status = "SUCCESS";
+        /** The trade notes. */
         private String notes;
+        /** The quantity. */
         private BigDecimal quantity;
+        /** The price. */
         private BigDecimal price;
+        /** The amount. */
         private BigDecimal amount;
+        /** The trade time. */
         private LocalDateTime tradeTime;
+        /** The creation time. */
         private LocalDateTime createdAt;
-        
+
+        /**
+         * Sets the trade ID.
+         *
+         * @param id the trade ID
+         * @return this Builder instance
+         */
         public Builder id(Long id) {
             this.id = id;
             return this;
         }
-        
+
+        /**
+         * Sets the market.
+         *
+         * @param market the market
+         * @return this Builder instance
+         */
         public Builder market(String market) {
             this.market = market;
             return this;
         }
-        
+
+        /**
+         * Sets the stock symbol.
+         *
+         * @param symbol the stock symbol
+         * @return this Builder instance
+         */
         public Builder symbol(String symbol) {
             this.symbol = symbol;
             return this;
         }
-        
+
+        /**
+         * Sets the stock name.
+         *
+         * @param name the stock name
+         * @return this Builder instance
+         */
         public Builder name(String name) {
             this.name = name;
             return this;
         }
-        
+
+        /**
+         * Sets the trade type.
+         *
+         * @param tradeType the trade type (BUY/SELL)
+         * @return this Builder instance
+         */
         public Builder tradeType(String tradeType) {
             this.tradeType = tradeType;
             return this;
         }
-        
+
+        /**
+         * Sets the trade status.
+         *
+         * @param status the trade status
+         * @return this Builder instance
+         */
         public Builder status(String status) {
             this.status = status;
             return this;
         }
-        
+
+        /**
+         * Sets the trade notes.
+         *
+         * @param notes the trade notes
+         * @return this Builder instance
+         */
         public Builder notes(String notes) {
             this.notes = notes;
             return this;
         }
-        
+
+        /**
+         * Sets the quantity.
+         *
+         * @param quantity the quantity
+         * @return this Builder instance
+         */
         public Builder quantity(BigDecimal quantity) {
             this.quantity = quantity;
             return this;
         }
-        
+
+        /**
+         * Sets the price.
+         *
+         * @param price the price
+         * @return this Builder instance
+         */
         public Builder price(BigDecimal price) {
             this.price = price;
             return this;
         }
-        
+
+        /**
+         * Sets the amount.
+         *
+         * @param amount the amount
+         * @return this Builder instance
+         */
         public Builder amount(BigDecimal amount) {
             this.amount = amount;
             return this;
         }
-        
+
+        /**
+         * Sets the trade time.
+         *
+         * @param tradeTime the trade time
+         * @return this Builder instance
+         */
         public Builder tradeTime(LocalDateTime tradeTime) {
             this.tradeTime = tradeTime;
             return this;
         }
-        
+
+        /**
+         * Sets the creation time.
+         *
+         * @param createdAt the creation time
+         * @return this Builder instance
+         */
         public Builder createdAt(LocalDateTime createdAt) {
             this.createdAt = createdAt;
             return this;
         }
-        
+
+        /**
+         * Builds and returns a new TradeDto instance.
+         *
+         * @return a new TradeDto instance
+         */
         public TradeDto build() {
             return new TradeDto(id, market, symbol, name, tradeType, status, notes,
-                    quantity, price, amount, tradeTime, createdAt);
+                quantity, price, amount, tradeTime, createdAt);
         }
     }
 }


### PR DESCRIPTION
## 概述

修复 10 个 DTO 文件的 Checkstyle 代码风格告警，遵循 Alibaba Java Coding Guidelines。

## 修复文件

1. ChatStreamRequest.java - 修复导入顺序，为 Builder 字段添加 Javadoc
2. TradeDto.java - 添加 @author、@param 标签，为 Builder 添加 Javadoc
3. DailyNetFlowDto.java - 修复导入顺序，添加 Javadoc
4. KlineDataDto.java - 添加 @param 标签，为 Builder 添加 Javadoc
5. StockIndustryDto.java - 添加 @param 标签，为 Builder 添加 Javadoc
6. StockValuationDto.java - 修复导入顺序，添加 Javadoc
7. CapitalRiverDto.java - 修复缩进，添加 Javadoc
8. UpdateSignalRequest.java - 修复导入顺序，移除星号导入，格式化 Builder
9. CommentResponse.java - 修复导入顺序，添加 Javadoc
10. SignalResponse.java - 修复导入顺序，为 Builder 添加 Javadoc

## 主要变更

- 导入顺序: 按照 java.* → 第三方包 → com.koduck.* 的模式重新排序
- Javadoc: 为所有 record/class 添加 @author 标签，为 record 组件添加 @param 标签
- Builder 类: 为所有 Builder 类的私有字段添加 Javadoc 注释
- 代码格式: 修复 record 紧凑构造函数缩进，展开星号导入，每行一个语句

## 验证

- [x] mvn clean compile checkstyle:check 通过
- [x] 无 Checkstyle violations

## 相关

Closes #370
