### PR TITLE
fix(checkstyle): resolve warnings in 6 backend files

### DIFF
--- a/koduck-backend/src/main/java/com/koduck/service/market/AKShareDataProvider.java
+++ b/koduck-backend/src/main/java/com/koduck/service/market/AKShareDataProvider.java
@@ -1,5 +1,25 @@
 package com.koduck.service.market;
 
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
 import com.koduck.config.properties.DataServiceProperties;
 import com.koduck.dto.market.DataServiceResponse;
 import com.koduck.dto.market.PriceQuoteDto;
@@ -12,25 +32,6 @@ import com.koduck.market.model.KlineData;
 import com.koduck.market.model.TickData;
 import com.koduck.market.provider.MarketDataProvider;
 import com.koduck.service.market.support.AKShareDataMapperSupport;
-import java.time.Instant;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.core.ParameterizedTypeReference;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.ResponseEntity;
-import org.springframework.lang.NonNull;
-import org.springframework.stereotype.Component;
-import org.springframework.web.client.RestClientException;
-import org.springframework.web.client.RestTemplate;
-import org.springframework.web.util.UriComponentsBuilder;
 
 /**
  * AKShare A股数据提供者实现。
@@ -40,46 +41,70 @@ import org.springframework.web.util.UriComponentsBuilder;
  * @author Koduck Team
  */
 @Component
-public class AKShareDataProvider implements MarketDataProvider
-{
+public class AKShareDataProvider implements MarketDataProvider {
 
+    /** The logger. */
     private static final Logger LOG = LoggerFactory.getLogger(AKShareDataProvider.class);
+    /** Data service disabled message. */
     private static final String DATA_SERVICE_DISABLED_MESSAGE = "Data service is disabled";
+    /** A-share base path. */
     private static final String A_SHARE_BASE_PATH = "/a-share";
+    /** Key symbol. */
     private static final String KEY_SYMBOL = "symbol";
+    /** Key limit. */
     private static final String KEY_LIMIT = "limit";
+    /** Response type message. */
     private static final String RESPONSE_TYPE_MESSAGE = "responseType must not be null";
+    /** HTTP GET message. */
     private static final String HTTP_GET_MESSAGE = "HTTP GET must not be null";
+    /** HTTP POST message. */
     private static final String HTTP_POST_MESSAGE = "HTTP POST must not be null";
+    /** Provider name. */
     private static final String PROVIDER_NAME = "akshare-a-share";
+    /** Health score when disabled. */
     private static final int HEALTH_SCORE_DISABLED = 0;
+    /** Full health score. */
     private static final int HEALTH_SCORE_FULL = 100;
+    /** Asia/Shanghai hour offset. */
     private static final int ASIA_SHANGHAI_HOUR_OFFSET = 8;
+    /** Morning open hour. */
     private static final int OPEN_MORNING_HOUR = 9;
+    /** Morning open minute. */
     private static final int OPEN_MORNING_MINUTE = 30;
+    /** Morning close hour. */
     private static final int CLOSE_MORNING_HOUR = 11;
+    /** Morning close minute. */
     private static final int CLOSE_MORNING_MINUTE = 30;
+    /** Afternoon open hour. */
     private static final int OPEN_AFTERNOON_HOUR = 13;
+    /** Afternoon close hour. */
     private static final int CLOSE_AFTERNOON_HOUR = 15;
+    /** Minutes per hour. */
     private static final int MINUTES_PER_HOUR = 60;
+    /** Asia/Shanghai timezone. */
     private static final String TIMEZONE_ASIA_SHANGHAI = "Asia/Shanghai";
 
+    /** List data response type. */
     private static final ParameterizedTypeReference<
         DataServiceResponse<List<Map<String, Object>>>>
         LIST_DATA_RESPONSE_TYPE =
-        new ParameterizedTypeReference<DataServiceResponse<List<Map<String, Object>>>>()
-        {
+        new ParameterizedTypeReference<DataServiceResponse<List<Map<String, Object>>>>() {
         };
+    /** Map data response type. */
     private static final ParameterizedTypeReference<DataServiceResponse<Map<String, Object>>>
         MAP_DATA_RESPONSE_TYPE =
-        new ParameterizedTypeReference<DataServiceResponse<Map<String, Object>>>()
-        {
+        new ParameterizedTypeReference<DataServiceResponse<Map<String, Object>>>() {
         };
 
+    /** The REST template. */
     private final RestTemplate restTemplate;
+    /** The data service properties. */
     private final DataServiceProperties properties;
+    /** Subscribed symbols set. */
     private final Set<String> subscribedSymbols = ConcurrentHashMap.newKeySet();
+    /** Provider availability flag. */
     private volatile boolean available = true;
+    /** Provider health score. */
     private volatile int healthScore = HEALTH_SCORE_FULL;
 
     /**
@@ -90,8 +115,7 @@ public class AKShareDataProvider implements MarketDataProvider
      */
     public AKShareDataProvider(
         @Qualifier("dataServiceRestTemplate") RestTemplate restTemplate,
-        DataServiceProperties properties)
-    {
+        DataServiceProperties properties) {
         this.restTemplate = Objects.requireNonNull(restTemplate,
             "restTemplate must not be null");
         this.properties = Objects.requireNonNull(properties,
@@ -99,28 +123,23 @@ public class AKShareDataProvider implements MarketDataProvider
     }
 
     @Override
-    public String getProviderName()
-    {
+    public String getProviderName() {
         return PROVIDER_NAME;
     }
 
     @Override
-    public MarketType getMarketType()
-    {
+    public MarketType getMarketType() {
         return MarketType.A_SHARE;
     }
 
     @Override
-    public boolean isAvailable()
-    {
+    public boolean isAvailable() {
         return available && properties.isEnabled();
     }
 
     @Override
-    public int getHealthScore()
-    {
-        if (!properties.isEnabled())
-        {
+    public int getHealthScore() {
+        if (!properties.isEnabled()) {
             return HEALTH_SCORE_DISABLED;
         }
         return healthScore;
@@ -128,28 +147,23 @@ public class AKShareDataProvider implements MarketDataProvider
 
     @Override
     public List<KlineData> getKlineData(String symbol, String timeframe, int limit,
-        Instant startTime, Instant endTime) throws MarketDataException
-    {
+        Instant startTime, Instant endTime) throws MarketDataException {
 
-        if (!isAvailable())
-        {
+        if (!isAvailable()) {
             throw new MarketDataException("Provider is not available");
         }
 
-        try
-        {
+        try {
             UriComponentsBuilder builder = UriComponentsBuilder
                 .fromUriString(properties.getBaseUrl() + A_SHARE_BASE_PATH + "/kline")
                 .queryParam(KEY_SYMBOL, symbol)
                 .queryParam("timeframe", timeframe)
                 .queryParam(KEY_LIMIT, limit);
 
-            if (startTime != null)
-            {
+            if (startTime != null) {
                 builder.queryParam("startTime", startTime.toEpochMilli());
             }
-            if (endTime != null)
-            {
+            if (endTime != null) {
                 builder.queryParam("endTime", endTime.toEpochMilli());
             }
 
@@ -166,18 +180,15 @@ public class AKShareDataProvider implements MarketDataProvider
                 body == null ? null : body.data());
 
         }
-        catch (RestClientException e)
-        {
+        catch (RestClientException e) {
             throw new MarketDataException("Failed to get kline data", e);
         }
     }
 
     @Override
-    public Optional<TickData> getRealTimeTick(String symbol) throws MarketDataException
-    {
+    public Optional<TickData> getRealTimeTick(String symbol) throws MarketDataException {
         PriceQuoteDto priceQuote = getPrice(symbol);
-        if (priceQuote == null)
-        {
+        if (priceQuote == null) {
             return Optional.empty();
         }
 
@@ -205,11 +216,9 @@ public class AKShareDataProvider implements MarketDataProvider
 
     @Override
     public void subscribeRealTime(List<String> symbols, RealTimeDataCallback callback)
-        throws MarketDataException
-    {
+        throws MarketDataException {
 
-        if (!isAvailable())
-        {
+        if (!isAvailable()) {
             throw new MarketDataException("Provider is not available");
         }
 
@@ -221,15 +230,13 @@ public class AKShareDataProvider implements MarketDataProvider
     }
 
     @Override
-    public void unsubscribeRealTime(List<String> symbols)
-    {
+    public void unsubscribeRealTime(List<String> symbols) {
         subscribedSymbols.removeAll(symbols);
         LOG.info("Unsubscribed from {} symbols", symbols.size());
     }
 
     @Override
-    public MarketStatus getMarketStatus()
-    {
+    public MarketStatus getMarketStatus() {
         // A股交易时间：9:30-11:30, 13:00-15:00（北京时间）
         java.time.ZonedDateTime now = java.time.ZonedDateTime.now(
             java.time.ZoneId.of(TIMEZONE_ASIA_SHANGHAI));
@@ -239,8 +246,7 @@ public class AKShareDataProvider implements MarketDataProvider
 
         // 周末
         if (dayOfWeek == java.time.DayOfWeek.SATURDAY
-            || dayOfWeek == java.time.DayOfWeek.SUNDAY)
-        {
+            || dayOfWeek == java.time.DayOfWeek.SUNDAY) {
             return MarketStatus.CLOSED;
         }
 
@@ -250,35 +256,28 @@ public class AKShareDataProvider implements MarketDataProvider
         int openAfternoon = OPEN_AFTERNOON_HOUR * MINUTES_PER_HOUR;
         int closeAfternoon = CLOSE_AFTERNOON_HOUR * MINUTES_PER_HOUR;
 
-        if (timeInMinutes >= openMorning && timeInMinutes <= closeMorning)
-        {
+        if (timeInMinutes >= openMorning && timeInMinutes <= closeMorning) {
             return MarketStatus.OPEN;
         }
-        else if (timeInMinutes > closeMorning && timeInMinutes < openAfternoon)
-        {
+        else if (timeInMinutes > closeMorning && timeInMinutes < openAfternoon) {
             return MarketStatus.BREAK;
         }
-        else if (timeInMinutes >= openAfternoon && timeInMinutes <= closeAfternoon)
-        {
+        else if (timeInMinutes >= openAfternoon && timeInMinutes <= closeAfternoon) {
             return MarketStatus.OPEN;
         }
-        else
-        {
+        else {
             return MarketStatus.CLOSED;
         }
     }
 
     @Override
-    public List<SymbolInfo> searchSymbols(String keyword, int limit)
-    {
-        if (!isAvailable())
-        {
+    public List<SymbolInfo> searchSymbols(String keyword, int limit) {
+        if (!isAvailable()) {
             LOG.warn(DATA_SERVICE_DISABLED_MESSAGE);
             return Collections.emptyList();
         }
 
-        try
-        {
+        try {
             String url = UriComponentsBuilder
                 .fromUriString(properties.getBaseUrl() + A_SHARE_BASE_PATH + "/search")
                 .queryParam("keyword", keyword)
@@ -295,8 +294,7 @@ public class AKShareDataProvider implements MarketDataProvider
                 body == null ? null : body.data());
 
         }
-        catch (RestClientException e)
-        {
+        catch (RestClientException e) {
             LOG.error("Failed to search symbols: {}", e.getMessage());
             return Collections.emptyList();
         }
@@ -310,16 +308,13 @@ public class AKShareDataProvider implements MarketDataProvider
      * @param symbol 股票代码
      * @return 价格报价
      */
-    public PriceQuoteDto getPrice(String symbol)
-    {
-        if (!isAvailable())
-        {
+    public PriceQuoteDto getPrice(String symbol) {
+        if (!isAvailable()) {
             throw new ExternalServiceException("DataService",
                 "Data service is not available");
         }
 
-        try
-        {
+        try {
             String url = UriComponentsBuilder
                 .fromUriString(properties.getBaseUrl() + A_SHARE_BASE_PATH
                     + "/price/{symbol}")
@@ -336,8 +331,7 @@ public class AKShareDataProvider implements MarketDataProvider
                 body == null ? null : body.data());
 
         }
-        catch (RestClientException e)
-        {
+        catch (RestClientException e) {
             throw new ExternalServiceException("DataService",
                 "Failed to get price for " + symbol, e);
         }
@@ -349,21 +343,17 @@ public class AKShareDataProvider implements MarketDataProvider
      * @param symbols 股票代码列表
      * @return 价格报价列表
      */
-    public List<PriceQuoteDto> getBatchPrices(List<String> symbols)
-    {
-        if (!isAvailable())
-        {
+    public List<PriceQuoteDto> getBatchPrices(List<String> symbols) {
+        if (!isAvailable()) {
             LOG.warn(DATA_SERVICE_DISABLED_MESSAGE);
             return Collections.emptyList();
         }
 
-        if (symbols == null || symbols.isEmpty())
-        {
+        if (symbols == null || symbols.isEmpty()) {
             return Collections.emptyList();
         }
 
-        try
-        {
+        try {
             String url = properties.getBaseUrl() + A_SHARE_BASE_PATH + "/price/batch";
 
             Map<String, List<String>> request = Map.of("symbols", symbols);
@@ -377,8 +367,7 @@ public class AKShareDataProvider implements MarketDataProvider
                     getListDataResponseType());
 
             DataServiceResponse<List<Map<String, Object>>> body = response.getBody();
-            if (body == null || body.data() == null)
-            {
+            if (body == null || body.data() == null) {
                 return Collections.emptyList();
             }
 
@@ -387,8 +376,7 @@ public class AKShareDataProvider implements MarketDataProvider
                 .toList();
 
         }
-        catch (RestClientException e)
-        {
+        catch (RestClientException e) {
             LOG.error("Failed to get batch prices: {}", e.getMessage());
             return Collections.emptyList();
         }
@@ -400,16 +388,13 @@ public class AKShareDataProvider implements MarketDataProvider
      * @param limit 限制数量
      * @return 股票信息列表
      */
-    public List<SymbolInfoDto> getHotSymbols(int limit)
-    {
-        if (!isAvailable())
-        {
+    public List<SymbolInfoDto> getHotSymbols(int limit) {
+        if (!isAvailable()) {
             LOG.warn(DATA_SERVICE_DISABLED_MESSAGE);
             return Collections.emptyList();
         }
 
-        try
-        {
+        try {
             String url = UriComponentsBuilder
                 .fromUriString(properties.getBaseUrl() + A_SHARE_BASE_PATH + "/hot")
                 .queryParam(KEY_LIMIT, limit)
@@ -425,8 +410,7 @@ public class AKShareDataProvider implements MarketDataProvider
                 body == null ? null : body.data());
 
         }
-        catch (RestClientException e)
-        {
+        catch (RestClientException e) {
             LOG.error("Failed to get hot symbols: {}", e.getMessage());
             return Collections.emptyList();
         }
@@ -438,16 +422,13 @@ public class AKShareDataProvider implements MarketDataProvider
      * @param symbol 股票代码
      * @return 股票估值
      */
-    public StockValuationDto getStockValuation(String symbol)
-    {
-        if (!isAvailable())
-        {
+    public StockValuationDto getStockValuation(String symbol) {
+        if (!isAvailable()) {
             throw new ExternalServiceException("DataService",
                 "Data service is not available");
         }
 
-        try
-        {
+        try {
             String url = UriComponentsBuilder
                 .fromUriString(properties.getBaseUrl() + A_SHARE_BASE_PATH
                     + "/valuation/{symbol}")
@@ -464,8 +445,7 @@ public class AKShareDataProvider implements MarketDataProvider
                 body == null ? null : body.data());
 
         }
-        catch (RestClientException e)
-        {
+        catch (RestClientException e) {
             throw new ExternalServiceException("DataService",
                 "Failed to get valuation for " + symbol, e);
         }
@@ -477,16 +457,13 @@ public class AKShareDataProvider implements MarketDataProvider
      * @param symbol 股票代码
      * @return 行业信息
      */
-    public StockIndustryDto getStockIndustry(String symbol)
-    {
-        if (!isAvailable())
-        {
+    public StockIndustryDto getStockIndustry(String symbol) {
+        if (!isAvailable()) {
             throw new ExternalServiceException("DataService",
                 "Data service is not available");
         }
 
-        try
-        {
+        try {
             String url = UriComponentsBuilder
                 .fromUriString(properties.getBaseUrl() + "/market/stocks/{symbol}/industry")
                 .buildAndExpand(symbol)
@@ -502,36 +479,31 @@ public class AKShareDataProvider implements MarketDataProvider
                 body == null ? null : body.data());
 
         }
-        catch (RestClientException e)
-        {
+        catch (RestClientException e) {
             throw new ExternalServiceException("DataService",
                 "Failed to get industry for " + symbol, e);
         }
     }
 
 
-    private static HttpMethod getHttpGet()
-    {
+    private static HttpMethod getHttpGet() {
         return Objects.requireNonNull(HttpMethod.GET, HTTP_GET_MESSAGE);
     }
 
 
-    private static HttpMethod getHttpPost()
-    {
+    private static HttpMethod getHttpPost() {
         return Objects.requireNonNull(HttpMethod.POST, HTTP_POST_MESSAGE);
     }
 
 
     private static ParameterizedTypeReference<DataServiceResponse<List<Map<String, Object>>>>
-    getListDataResponseType()
-    {
+        getListDataResponseType() {
         return Objects.requireNonNull(LIST_DATA_RESPONSE_TYPE, RESPONSE_TYPE_MESSAGE);
     }
 
 
     private static ParameterizedTypeReference<DataServiceResponse<Map<String, Object>>>
-    getMapDataResponseType()
-    {
+        getMapDataResponseType() {
         return Objects.requireNonNull(MAP_DATA_RESPONSE_TYPE, RESPONSE_TYPE_MESSAGE);
     }
 }

--- a/koduck-backend/src/main/java/com/koduck/trading/application/BacktestServiceImpl.java
+++ b/koduck-backend/src/main/java/com/koduck/trading/application/BacktestServiceImpl.java
@@ -1,9 +1,26 @@
 package com.koduck.trading.application;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.koduck.common.constants.MarketConstants;
-import com.koduck.dto.backtest.*;
+import com.koduck.dto.backtest.BacktestResultDto;
+import com.koduck.dto.backtest.BacktestTradeDto;
+import com.koduck.dto.backtest.RunBacktestRequest;
 import com.koduck.dto.market.KlineDataDto;
-import com.koduck.entity.*;
+import com.koduck.entity.BacktestResult;
+import com.koduck.entity.BacktestTrade;
+import com.koduck.entity.Strategy;
+import com.koduck.entity.StrategyVersion;
 import com.koduck.exception.BusinessException;
 import com.koduck.exception.ErrorCode;
 import com.koduck.exception.ResourceNotFoundException;
@@ -17,42 +34,61 @@ import com.koduck.service.KlineService;
 import com.koduck.service.support.BacktestExecutionContext;
 import com.koduck.service.support.BacktestSignal;
 import com.koduck.service.support.StrategyAccessSupport;
-import java.math.BigDecimal;
-import java.math.RoundingMode;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
+import com.koduck.util.ServiceValidationUtils;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import static com.koduck.util.ServiceValidationUtils.requireFound;
 
 /**
  * Implementation of BacktestService.
  *
- * @author GitHub Copilot
- * @date 2026-03-31
+ * @author Koduck Team
  */
 @Service
 @Slf4j
 @RequiredArgsConstructor
 public class BacktestServiceImpl implements BacktestService {
 
+    /** The result repository. */
     private final BacktestResultRepository resultRepository;
+    /** The backtest trade repository. */
     private final BacktestTradeRepository backtestTradeRepository;
+    /** The strategy repository. */
     private final StrategyRepository strategyRepository;
+    /** The version repository. */
     private final StrategyVersionRepository versionRepository;
+    /** The kline service. */
     private final KlineService klineService;
+    /** The backtest trade mapper. */
     private final BacktestTradeMapper backtestTradeMapper;
+    /** The strategy access support. */
     private final StrategyAccessSupport strategyAccessSupport;
 
+    /** The decimal scale. */
     private static final int SCALE = 4;
+    /** The default timeframe. */
     private static final String DEFAULT_TIMEFRAME = MarketConstants.DEFAULT_TIMEFRAME;
+    /** The kline data limit. */
+    private static final int KLINE_DATA_LIMIT = 1000;
+    /** The seconds per day. */
+    private static final long SECONDS_PER_DAY = 86400L;
+    /** The minimum bars required. */
+    private static final int MINIMUM_BARS = 60;
+    /** The MA short period. */
+    private static final int MA_SHORT_PERIOD = 20;
+    /** The percentage multiplier. */
+    private static final int PERCENTAGE_MULTIPLIER = 100;
+    /** The days per year. */
+    private static final double DAYS_PER_YEAR = 365.0;
+    /** The trading days per year. */
+    private static final int TRADING_DAYS_PER_YEAR = 252;
+    /** The cash usage ratio. */
+    private static final BigDecimal CASH_USAGE_RATIO = new BigDecimal("0.9");
+    /** The buy signal reason. */
+    private static final String BUY_SIGNAL_REASON = "MA20 crosses above MA60";
+    /** The sell signal reason. */
+    private static final String SELL_SIGNAL_REASON = "MA20 crosses below MA60";
+
     /**
      * Get all backtest results for a user.
      */
@@ -64,6 +100,7 @@ public class BacktestServiceImpl implements BacktestService {
             .map(this::convertToDto)
             .toList();
     }
+
     /**
      * Get a backtest result by id.
      */
@@ -73,6 +110,7 @@ public class BacktestServiceImpl implements BacktestService {
         BacktestResult result = loadBacktestResultOrThrow(userId, id);
         return convertToDto(result);
     }
+
     /**
      * Run a backtest.
      */
@@ -109,7 +147,8 @@ public class BacktestServiceImpl implements BacktestService {
             savedResult.setCompletedAt(LocalDateTime.now());
             resultRepository.save(savedResult);
             log.info("Backtest completed: id={}, user={}", savedResult.getId(), userId);
-        } catch (Exception e) {
+        }
+        catch (Exception e) {
             log.error("Backtest failed: id={}, error={}", savedResult.getId(), e.getMessage(), e);
             savedResult.setStatus(BacktestResult.BacktestStatus.FAILED);
             savedResult.setErrorMessage(e.getMessage());
@@ -118,6 +157,7 @@ public class BacktestServiceImpl implements BacktestService {
         }
         return convertToDto(savedResult);
     }
+
     /**
      * Get trades for a backtest result.
      */
@@ -130,6 +170,7 @@ public class BacktestServiceImpl implements BacktestService {
             .map(this::convertTradeToDto)
             .toList();
     }
+
     /**
      * Delete a backtest result.
      */
@@ -144,6 +185,7 @@ public class BacktestServiceImpl implements BacktestService {
         resultRepository.delete(Objects.requireNonNull(result, "result must not be null"));
         log.info("Deleted backtest result: user={}, id={}", userId, id);
     }
+
     /**
      * Execute backtest logic.
      */
@@ -151,22 +193,22 @@ public class BacktestServiceImpl implements BacktestService {
         // Get historical data
         String timeframe = result.getTimeframe() != null ? result.getTimeframe() : DEFAULT_TIMEFRAME;
         List<KlineDataDto> klineData = klineService.getKlineData(
-            result.getMarket(), result.getSymbol(), timeframe, 1000, null);
+            result.getMarket(), result.getSymbol(), timeframe, KLINE_DATA_LIMIT, null);
         if (klineData.isEmpty()) {
             throw new BusinessException(ErrorCode.BACKTEST_INSUFFICIENT_DATA, "No historical data available");
         }
         // Filter by date range
         List<KlineDataDto> filteredData = klineData.stream()
             .filter(k -> {
-                LocalDate date = LocalDate.ofEpochDay(k.timestamp() / 86400);
+                LocalDate date = LocalDate.ofEpochDay(k.timestamp() / SECONDS_PER_DAY);
                 return !date.isBefore(result.getStartDate()) && !date.isAfter(result.getEndDate());
             })
             .sorted((a, b) -> Long.compare(a.timestamp(), b.timestamp()))
             .toList();
-        if (filteredData.size() < 60) {
+        if (filteredData.size() < MINIMUM_BARS) {
             throw new BusinessException(
                     ErrorCode.BACKTEST_INSUFFICIENT_DATA,
-                    "Insufficient data for backtest (need at least 60 bars)");
+                    "Insufficient data for backtest (need at least " + MINIMUM_BARS + " bars)");
         }
         // Initialize backtest state
         BacktestExecutionContext context = new BacktestExecutionContext(
@@ -177,7 +219,7 @@ public class BacktestServiceImpl implements BacktestService {
         List<BacktestTrade> trades = new ArrayList<>();
         List<BigDecimal> equityCurve = new ArrayList<>();
         // Run backtest simulation
-        for (int i = 60; i < filteredData.size(); i++) {
+        for (int i = MINIMUM_BARS; i < filteredData.size(); i++) {
             List<KlineDataDto> history = filteredData.subList(0, i + 1);
             KlineDataDto current = filteredData.get(i);
             // Simple MA crossover strategy
@@ -188,7 +230,8 @@ public class BacktestServiceImpl implements BacktestService {
                 if (trade != null) {
                     trades.add(trade);
                 }
-            } else if (signal == BacktestSignal.SELL && context.getPosition().compareTo(BigDecimal.ZERO) > 0) {
+            }
+            else if (signal == BacktestSignal.SELL && context.getPosition().compareTo(BigDecimal.ZERO) > 0) {
                 // Execute sell
                 BacktestTrade trade = executeSell(context, current, result.getId());
                 trades.add(trade);
@@ -204,20 +247,21 @@ public class BacktestServiceImpl implements BacktestService {
             backtestTradeRepository.saveAll(trades);
         }
     }
+
     /**
      * Generate trading signal based on MA crossover.
      */
     private BacktestSignal generateSignal(List<KlineDataDto> history) {
-        if (history.size() < 60) {
+        if (history.size() < MINIMUM_BARS) {
             return BacktestSignal.HOLD;
         }
         // Calculate MA20 and MA60
-        BigDecimal ma20 = calculateMA(history, 20);
-        BigDecimal ma60 = calculateMA(history, 60);
+        BigDecimal ma20 = calculateMA(history, MA_SHORT_PERIOD);
+        BigDecimal ma60 = calculateMA(history, MINIMUM_BARS);
         // Calculate previous MA
         List<KlineDataDto> prevHistory = history.subList(0, history.size() - 1);
-        BigDecimal prevMa20 = calculateMA(prevHistory, 20);
-        BigDecimal prevMa60 = calculateMA(prevHistory, 60);
+        BigDecimal prevMa20 = calculateMA(prevHistory, MA_SHORT_PERIOD);
+        BigDecimal prevMa60 = calculateMA(prevHistory, MINIMUM_BARS);
         // Golden cross: MA20 crosses above MA60
         if (ma20.compareTo(ma60) > 0 && prevMa20.compareTo(prevMa60) <= 0) {
             return BacktestSignal.BUY;
@@ -228,6 +272,7 @@ public class BacktestServiceImpl implements BacktestService {
         }
         return BacktestSignal.HOLD;
     }
+
     /**
      * Calculate Moving Average.
      */
@@ -242,6 +287,7 @@ public class BacktestServiceImpl implements BacktestService {
         }
         return sum.divide(BigDecimal.valueOf(period), SCALE, RoundingMode.HALF_UP);
     }
+
     /**
      * Execute buy order.
      */
@@ -250,7 +296,7 @@ public class BacktestServiceImpl implements BacktestService {
         BigDecimal price = current.close().multiply(
             BigDecimal.ONE.add(context.getSlippage())).setScale(SCALE, RoundingMode.HALF_UP);
         // Use 90% of cash for position
-        BigDecimal positionValue = context.getCash().multiply(new BigDecimal("0.9"));
+        BigDecimal positionValue = context.getCash().multiply(CASH_USAGE_RATIO);
         BigDecimal quantity = positionValue.divide(price, 0, RoundingMode.DOWN);
         if (quantity.compareTo(BigDecimal.ZERO) <= 0) {
             return null;
@@ -269,14 +315,15 @@ public class BacktestServiceImpl implements BacktestService {
             .price(price)
             .quantity(quantity)
             .amount(amount)
-                .commission(commission)
-                .slippageCost(amount.multiply(context.getSlippage()).setScale(SCALE, RoundingMode.HALF_UP))
+            .commission(commission)
+            .slippageCost(amount.multiply(context.getSlippage()).setScale(SCALE, RoundingMode.HALF_UP))
             .totalCost(totalCost)
-                .cashAfter(context.getCash())
-                .positionAfter(context.getPosition())
-            .signalReason("MA20 crosses above MA60")
+            .cashAfter(context.getCash())
+            .positionAfter(context.getPosition())
+            .signalReason(BUY_SIGNAL_REASON)
             .build();
     }
+
     /**
      * Execute sell order.
      */
@@ -292,7 +339,7 @@ public class BacktestServiceImpl implements BacktestService {
         BigDecimal pnl = totalCost.subtract(context.getEntryPrice().multiply(quantity));
         BigDecimal pnlPercent = context.getEntryPrice().compareTo(BigDecimal.ZERO) > 0
             ? pnl.divide(context.getEntryPrice().multiply(quantity), SCALE, RoundingMode.HALF_UP)
-                .multiply(BigDecimal.valueOf(100))
+                .multiply(BigDecimal.valueOf(PERCENTAGE_MULTIPLIER))
             : BigDecimal.ZERO;
         context.setCash(context.getCash().add(totalCost));
         context.setPosition(BigDecimal.ZERO);
@@ -304,16 +351,17 @@ public class BacktestServiceImpl implements BacktestService {
             .price(price)
             .quantity(quantity)
             .amount(amount)
-                .commission(commission)
-                .slippageCost(amount.multiply(context.getSlippage()).setScale(SCALE, RoundingMode.HALF_UP))
+            .commission(commission)
+            .slippageCost(amount.multiply(context.getSlippage()).setScale(SCALE, RoundingMode.HALF_UP))
             .totalCost(totalCost)
-                .cashAfter(context.getCash())
-                .positionAfter(context.getPosition())
+            .cashAfter(context.getCash())
+            .positionAfter(context.getPosition())
             .pnl(pnl)
             .pnlPercent(pnlPercent)
-            .signalReason("MA20 crosses below MA60")
+            .signalReason(SELL_SIGNAL_REASON)
             .build();
     }
+
     /**
      * Calculate backtest metrics.
      */
@@ -327,14 +375,14 @@ public class BacktestServiceImpl implements BacktestService {
         // Total return
         BigDecimal totalReturn = finalCapital.subtract(result.getInitialCapital())
             .divide(result.getInitialCapital(), SCALE, RoundingMode.HALF_UP)
-            .multiply(BigDecimal.valueOf(100));
+            .multiply(BigDecimal.valueOf(PERCENTAGE_MULTIPLIER));
         result.setTotalReturn(totalReturn);
         // Annualized return
         long days = ChronoUnit.DAYS.between(result.getStartDate(), result.getEndDate());
-        double years = days / 365.0;
+        double years = days / DAYS_PER_YEAR;
         if (years > 0) {
             double totalReturnFactor = finalCapital.doubleValue() / result.getInitialCapital().doubleValue();
-            double annualizedReturn = (Math.pow(totalReturnFactor, 1.0 / years) - 1) * 100;
+            double annualizedReturn = (Math.pow(totalReturnFactor, 1.0 / years) - 1) * PERCENTAGE_MULTIPLIER;
             result.setAnnualizedReturn(BigDecimal.valueOf(annualizedReturn).setScale(SCALE, RoundingMode.HALF_UP));
         }
         // Max drawdown
@@ -355,7 +403,7 @@ public class BacktestServiceImpl implements BacktestService {
         if (totalTrades > 0) {
             BigDecimal winRate = BigDecimal.valueOf(winningTrades)
                 .divide(BigDecimal.valueOf(totalTrades), SCALE, RoundingMode.HALF_UP)
-                .multiply(BigDecimal.valueOf(100));
+                .multiply(BigDecimal.valueOf(PERCENTAGE_MULTIPLIER));
             result.setWinRate(winRate);
         }
         // Average profit/loss
@@ -387,7 +435,8 @@ public class BacktestServiceImpl implements BacktestService {
             .abs();
         if (grossLoss.compareTo(BigDecimal.ZERO) > 0) {
             result.setProfitFactor(grossProfit.divide(grossLoss, SCALE, RoundingMode.HALF_UP));
-        } else {
+        }
+        else {
             result.setProfitFactor(BigDecimal.ZERO);
         }
         // Sharpe ratio (simplified)
@@ -396,6 +445,7 @@ public class BacktestServiceImpl implements BacktestService {
             result.setSharpeRatio(sharpeRatio);
         }
     }
+
     /**
      * Calculate maximum drawdown.
      */
@@ -408,13 +458,14 @@ public class BacktestServiceImpl implements BacktestService {
             }
             BigDecimal drawdown = peak.subtract(equity)
                 .divide(peak, SCALE, RoundingMode.HALF_UP)
-                .multiply(BigDecimal.valueOf(100));
+                .multiply(BigDecimal.valueOf(PERCENTAGE_MULTIPLIER));
             if (drawdown.compareTo(maxDrawdown) > 0) {
                 maxDrawdown = drawdown;
             }
         }
         return maxDrawdown;
     }
+
     /**
      * Calculate Sharpe ratio (simplified).
      */
@@ -439,20 +490,25 @@ public class BacktestServiceImpl implements BacktestService {
             .divide(BigDecimal.valueOf(returns.size()), SCALE, RoundingMode.HALF_UP);
         BigDecimal stdDev = BigDecimal.valueOf(Math.sqrt(variance.doubleValue()));
         if (stdDev.compareTo(BigDecimal.ZERO) > 0) {
-            // Annualized Sharpe ratio (assuming 252 trading days)
-            return meanReturn.multiply(BigDecimal.valueOf(252))
-                .divide(stdDev.multiply(BigDecimal.valueOf(Math.sqrt(252))), SCALE, RoundingMode.HALF_UP);
+            // Annualized Sharpe ratio (assuming TRADING_DAYS_PER_YEAR trading days)
+            return meanReturn.multiply(BigDecimal.valueOf(TRADING_DAYS_PER_YEAR))
+                .divide(stdDev.multiply(BigDecimal.valueOf(Math.sqrt(TRADING_DAYS_PER_YEAR))),
+                    SCALE, RoundingMode.HALF_UP);
         }
         return BigDecimal.ZERO;
     }
+
     private BacktestResult loadBacktestResultOrThrow(Long userId, Long backtestId) {
-        return requireFound(resultRepository.findByIdAndUserId(backtestId, userId),
+        return ServiceValidationUtils.requireFound(resultRepository.findByIdAndUserId(backtestId, userId),
                 () -> new ResourceNotFoundException("backtest result", backtestId));
     }
+
     private StrategyVersion loadLatestVersionOrThrow(Long strategyId) {
-        return requireFound(versionRepository.findFirstByStrategyIdOrderByVersionNumberDesc(strategyId),
+        return ServiceValidationUtils.requireFound(
+                versionRepository.findFirstByStrategyIdOrderByVersionNumberDesc(strategyId),
                 () -> new ResourceNotFoundException("strategy version for strategy", strategyId));
     }
+
     /**
      * Convert BacktestResult to DTO.
      */
@@ -493,6 +549,7 @@ public class BacktestServiceImpl implements BacktestService {
             .completedAt(result.getCompletedAt())
             .build();
     }
+
     /**
      * Convert BacktestTrade to DTO.
      */

--- a/koduck-backend/src/test/java/com/koduck/controller/CommunitySignalControllerTest.java
+++ b/koduck-backend/src/test/java/com/koduck/controller/CommunitySignalControllerTest.java
@@ -1,14 +1,14 @@
 package com.koduck.controller;
 
-import com.koduck.dto.ApiResponse;
-import com.koduck.dto.community.CommentResponse;
-import com.koduck.dto.community.CreateSignalRequest;
-import com.koduck.dto.community.SignalListResponse;
-import com.koduck.dto.community.SignalResponse;
-import com.koduck.controller.support.AuthenticatedUserResolver;
-import com.koduck.security.UserPrincipal;
-import com.koduck.service.CommunitySignalService;
-import com.koduck.entity.User;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Objects;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,30 +19,52 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import java.math.BigDecimal;
-import java.util.List;
-import java.util.Objects;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import com.koduck.controller.support.AuthenticatedUserResolver;
+import com.koduck.dto.ApiResponse;
+import com.koduck.dto.community.CommentResponse;
+import com.koduck.dto.community.CreateSignalRequest;
+import com.koduck.dto.community.SignalListResponse;
+import com.koduck.dto.community.SignalResponse;
+import com.koduck.entity.User;
+import com.koduck.security.UserPrincipal;
+import com.koduck.service.CommunitySignalService;
 
 /**
  * Unit tests for {@link CommunitySignalController}.
  *
- * @author GitHub Copilot
- * @date 2026-03-05
+ * @author Koduck Team
  */
 @ExtendWith(MockitoExtension.class)
 class CommunitySignalControllerTest {
 
+    /** User principal required message. */
     private static final String USER_PRINCIPAL_REQUIRED_MESSAGE = "userPrincipal must not be null";
+    /** Controller required message. */
     private static final String CONTROLLER_REQUIRED_MESSAGE = "controller must not be null";
+    /** Default page size. */
+    private static final int DEFAULT_PAGE_SIZE = 20;
+    /** Test user ID 1. */
+    private static final Long TEST_USER_ID_1 = 1001L;
+    /** Test user ID 2. */
+    private static final Long TEST_USER_ID_2 = 2002L;
+    /** Test user ID 3. */
+    private static final Long TEST_USER_ID_3 = 3003L;
+    /** Test signal ID 1. */
+    private static final Long TEST_SIGNAL_ID_1 = 11L;
+    /** Test signal ID 2. */
+    private static final Long TEST_SIGNAL_ID_2 = 15L;
+    /** Test comment ID. */
+    private static final Long TEST_COMMENT_ID = 21L;
+    /** Test signal ID for comments. */
+    private static final Long TEST_SIGNAL_ID_FOR_COMMENTS = 9L;
+    /** Test close price. */
+    private static final BigDecimal TEST_CLOSE_PRICE = new BigDecimal("5.20");
 
+    /** The signal service. */
     @Mock
     private CommunitySignalService signalService;
 
+    /** The controller under test. */
     @InjectMocks
     private CommunitySignalController controller;
 
@@ -57,30 +79,31 @@ class CommunitySignalControllerTest {
     @Test
     @DisplayName("shouldGetSignalsWithAnonymousUser")
     void shouldGetSignalsWithAnonymousUser() {
-        SignalListResponse response = SignalListResponse.builder().items(List.of()).total(0L).page(0).size(20).build();
-        when(signalService.getSignals(null, "new", null, null, 0, 20)).thenReturn(response);
+        SignalListResponse response = SignalListResponse.builder()
+                .items(List.of()).total(0L).page(0).size(DEFAULT_PAGE_SIZE).build();
+        when(signalService.getSignals(null, "new", null, null, 0, DEFAULT_PAGE_SIZE)).thenReturn(response);
 
-        ApiResponse<SignalListResponse> result = controller.getSignals(null, "new", null, null, 0, 20);
+        ApiResponse<SignalListResponse> result = controller.getSignals(null, "new", null, null, 0, DEFAULT_PAGE_SIZE);
 
         assertEquals(0, result.getCode());
-        verify(signalService).getSignals(null, "new", null, null, 0, 20);
+        verify(signalService).getSignals(null, "new", null, null, 0, DEFAULT_PAGE_SIZE);
     }
 
     @Test
     @DisplayName("shouldCreateSignalWhenUserIsAuthenticated")
     void shouldCreateSignalWhenUserIsAuthenticated() {
-        UserPrincipal principal = buildUserPrincipal(1001L);
+        UserPrincipal principal = buildUserPrincipal(TEST_USER_ID_1);
         CreateSignalRequest request = new CreateSignalRequest();
         request.setSymbol("AAPL");
 
         SignalResponse signalResponse = SignalResponse.builder().id(1L).symbol("AAPL").build();
-        when(signalService.createSignal(1001L, request)).thenReturn(signalResponse);
+        when(signalService.createSignal(TEST_USER_ID_1, request)).thenReturn(signalResponse);
 
         ApiResponse<SignalResponse> result = controller.createSignal(principal, request);
 
         assertEquals(0, result.getCode());
         assertEquals("AAPL", result.getData().getSymbol());
-        verify(signalService).createSignal(1001L, request);
+        verify(signalService).createSignal(TEST_USER_ID_1, request);
     }
 
     @Test
@@ -100,45 +123,46 @@ class CommunitySignalControllerTest {
     @Test
     @DisplayName("shouldCloseSignalWhenUserIsAuthenticated")
     void shouldCloseSignalWhenUserIsAuthenticated() {
-        UserPrincipal principal = buildUserPrincipal(2002L);
-        SignalResponse signalResponse = SignalResponse.builder().id(11L).build();
-        when(signalService.closeSignal(2002L, 11L, "HIT_TARGET", new BigDecimal("5.20")))
+        UserPrincipal principal = buildUserPrincipal(TEST_USER_ID_2);
+        SignalResponse signalResponse = SignalResponse.builder().id(TEST_SIGNAL_ID_1).build();
+        when(signalService.closeSignal(TEST_USER_ID_2, TEST_SIGNAL_ID_1, "HIT_TARGET", TEST_CLOSE_PRICE))
                 .thenReturn(signalResponse);
 
         ApiResponse<SignalResponse> result = controller.closeSignal(
                 principal,
-                11L,
+                TEST_SIGNAL_ID_1,
                 "HIT_TARGET",
-                new BigDecimal("5.20")
+                TEST_CLOSE_PRICE
         );
 
         assertEquals(0, result.getCode());
-        verify(signalService).closeSignal(2002L, 11L, "HIT_TARGET", new BigDecimal("5.20"));
+        verify(signalService).closeSignal(TEST_USER_ID_2, TEST_SIGNAL_ID_1, "HIT_TARGET", TEST_CLOSE_PRICE);
     }
 
     @Test
     @DisplayName("shouldDeleteSignalWithEnglishSuccessMessage")
     void shouldDeleteSignalWithEnglishSuccessMessage() {
-        UserPrincipal principal = buildUserPrincipal(3003L);
+        UserPrincipal principal = buildUserPrincipal(TEST_USER_ID_3);
 
-        ApiResponse<Void> result = controller.deleteSignal(principal, 15L);
+        ApiResponse<Void> result = controller.deleteSignal(principal, TEST_SIGNAL_ID_2);
 
         assertEquals(0, result.getCode());
         assertEquals("Deleted successfully", result.getMessage());
-        verify(signalService).deleteSignal(3003L, 15L);
+        verify(signalService).deleteSignal(TEST_USER_ID_3, TEST_SIGNAL_ID_2);
     }
 
     @Test
     @DisplayName("shouldGetCommentsBySignalIdAndPaging")
     void shouldGetCommentsBySignalIdAndPaging() {
-        CommentResponse comment = CommentResponse.builder().id(21L).content("Good signal").build();
-        when(signalService.getComments(9L, 0, 20)).thenReturn(List.of(comment));
+        CommentResponse comment = CommentResponse.builder().id(TEST_COMMENT_ID).content("Good signal").build();
+        when(signalService.getComments(TEST_SIGNAL_ID_FOR_COMMENTS, 0, DEFAULT_PAGE_SIZE)).thenReturn(List.of(comment));
 
-        ApiResponse<List<CommentResponse>> result = controller.getComments(9L, 0, 20);
+        ApiResponse<List<CommentResponse>> result =
+                controller.getComments(TEST_SIGNAL_ID_FOR_COMMENTS, 0, DEFAULT_PAGE_SIZE);
 
         assertEquals(0, result.getCode());
         assertEquals(1, result.getData().size());
-        verify(signalService).getComments(9L, 0, 20);
+        verify(signalService).getComments(TEST_SIGNAL_ID_FOR_COMMENTS, 0, DEFAULT_PAGE_SIZE);
     }
 
     private UserPrincipal buildUserPrincipal(Long userId) {

--- a/koduck-backend/src/test/java/com/koduck/controller/PortfolioControllerIntegrationTest.java
+++ b/koduck-backend/src/test/java/com/koduck/controller/PortfolioControllerIntegrationTest.java
@@ -1,21 +1,17 @@
 package com.koduck.controller;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.koduck.AbstractIntegrationTest;
-import com.koduck.dto.ApiResponse;
-import com.koduck.dto.auth.LoginRequest;
-import com.koduck.dto.auth.RegisterRequest;
-import com.koduck.dto.auth.TokenResponse;
-import com.koduck.dto.portfolio.AddPositionRequest;
-import com.koduck.dto.portfolio.AddTradeRequest;
-import com.koduck.dto.portfolio.PortfolioPositionDto;
-import com.koduck.dto.portfolio.PortfolioSummaryDto;
-import com.koduck.dto.portfolio.TradeDto;
-import com.koduck.dto.portfolio.UpdatePositionRequest;
-import com.koduck.entity.PortfolioPosition;
-import com.koduck.entity.Trade;
-import com.koduck.repository.PortfolioPositionRepository;
-import com.koduck.repository.TradeRepository;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -26,39 +22,65 @@ import org.springframework.test.context.TestConstructor;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
-import java.math.BigDecimal;
-import java.time.LocalDateTime;
-import java.util.List;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import com.koduck.AbstractIntegrationTest;
+import com.koduck.dto.ApiResponse;
+import com.koduck.dto.auth.RegisterRequest;
+import com.koduck.dto.auth.TokenResponse;
+import com.koduck.dto.portfolio.AddPositionRequest;
+import com.koduck.dto.portfolio.AddTradeRequest;
+import com.koduck.dto.portfolio.PortfolioPositionDto;
+import com.koduck.dto.portfolio.UpdatePositionRequest;
+import com.koduck.entity.PortfolioPosition;
+import com.koduck.entity.Trade;
+import com.koduck.repository.PortfolioPositionRepository;
+import com.koduck.repository.TradeRepository;
 
 /**
  * Integration tests for {@link PortfolioController}.
- * <p>Tests portfolio management endpoints including positions, 
+ * <p>Tests portfolio management endpoints including positions,
  * trades, and summary operations.</p>
  *
- * @author GitHub Copilot
- * @date 2026-04-01
+ * @author Koduck Team
  */
 @AutoConfigureMockMvc
 @TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
 class PortfolioControllerIntegrationTest extends AbstractIntegrationTest {
 
+    /** The authorization header. */
     private static final String AUTHORIZATION_HEADER = "Authorization";
+    /** The bearer prefix. */
     private static final String BEARER_PREFIX = "Bearer ";
+    /** The bad request code. */
+    private static final int BAD_REQUEST_CODE = 400;
+    /** Test quantity 100. */
+    private static final int TEST_QUANTITY_100 = 100;
+    /** Test price 1500. */
+    private static final double TEST_PRICE_1500 = 1500.00;
+    /** Test quantity 1000. */
+    private static final int TEST_QUANTITY_1000 = 1000;
+    /** Test quantity 2000. */
+    private static final int TEST_QUANTITY_2000 = 2000;
+    /** Test price 13. */
+    private static final double TEST_PRICE_13 = 13.00;
+    /** Non-existent ID. */
+    private static final long NON_EXISTENT_ID = 999999L;
+    /** Test quantity 200. */
+    private static final int TEST_QUANTITY_200 = 200;
 
+    /** The MockMvc instance. */
     private final MockMvc mockMvc;
+    /** The object mapper. */
     private final ObjectMapper objectMapper;
+    /** The position repository. */
     private final PortfolioPositionRepository positionRepository;
+    /** The trade repository. */
     private final TradeRepository tradeRepository;
 
+    /** The access token for the test user. */
     private String accessToken;
+    /** The test user ID. */
     private Long userId;
 
     @Autowired
@@ -117,6 +139,21 @@ class PortfolioControllerIntegrationTest extends AbstractIntegrationTest {
     private record RegisteredUser(String accessToken, Long userId, String username) {
     }
 
+    private void addTradeRequest() throws Exception {
+        AddTradeRequest tradeRequest = new AddTradeRequest(
+                "AShare", "000001", "平安银行", "BUY",
+                new BigDecimal(TEST_QUANTITY_1000), new BigDecimal("12.50"),
+                LocalDateTime.now()
+        );
+
+        mockMvc.perform(post("/api/v1/portfolio/trades")
+                        .header(AUTHORIZATION_HEADER, bearerToken(accessToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(tradeRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(0));
+    }
+
     // ==================== Get Positions Tests ====================
 
     @Test
@@ -139,8 +176,8 @@ class PortfolioControllerIntegrationTest extends AbstractIntegrationTest {
                 .market("AShare")
                 .symbol("600519")
                 .name("贵州茅台")
-                .quantity(new BigDecimal("100"))
-                .avgCost(new BigDecimal("1500.00"))
+                .quantity(new BigDecimal(TEST_QUANTITY_100))
+                .avgCost(new BigDecimal(String.valueOf(TEST_PRICE_1500)))
                 .build();
         positionRepository.save(position);
 
@@ -151,8 +188,8 @@ class PortfolioControllerIntegrationTest extends AbstractIntegrationTest {
                 .andExpect(jsonPath("$.data").isArray())
                 .andExpect(jsonPath("$.data[0].symbol").value("600519"))
                 .andExpect(jsonPath("$.data[0].name").value("贵州茅台"))
-                .andExpect(jsonPath("$.data[0].quantity").value(100))
-                .andExpect(jsonPath("$.data[0].avgCost").value(1500.00));
+                .andExpect(jsonPath("$.data[0].quantity").value(TEST_QUANTITY_100))
+                .andExpect(jsonPath("$.data[0].avgCost").value(TEST_PRICE_1500));
     }
 
     @Test
@@ -185,7 +222,7 @@ class PortfolioControllerIntegrationTest extends AbstractIntegrationTest {
                 .market("AShare")
                 .symbol("000001")
                 .name("平安银行")
-                .quantity(new BigDecimal("1000"))
+                .quantity(new BigDecimal(TEST_QUANTITY_1000))
                 .avgCost(new BigDecimal("12.50"))
                 .build();
         positionRepository.save(position);
@@ -205,8 +242,8 @@ class PortfolioControllerIntegrationTest extends AbstractIntegrationTest {
     @DisplayName("添加持仓-新股票")
     void addPositionNew() throws Exception {
         AddPositionRequest request = new AddPositionRequest(
-                "AShare", "600519", "贵州茅台", 
-                new BigDecimal("100"), new BigDecimal("1500.00")
+                "AShare", "600519", "贵州茅台",
+                new BigDecimal(TEST_QUANTITY_100), new BigDecimal(String.valueOf(TEST_PRICE_1500))
         );
 
         mockMvc.perform(post("/api/v1/portfolio")
@@ -217,8 +254,8 @@ class PortfolioControllerIntegrationTest extends AbstractIntegrationTest {
                 .andExpect(jsonPath("$.code").value(0))
                 .andExpect(jsonPath("$.data.symbol").value("600519"))
                 .andExpect(jsonPath("$.data.name").value("贵州茅台"))
-                .andExpect(jsonPath("$.data.quantity").value(100))
-                .andExpect(jsonPath("$.data.avgCost").value(1500.00));
+                .andExpect(jsonPath("$.data.quantity").value(TEST_QUANTITY_100))
+                .andExpect(jsonPath("$.data.avgCost").value(TEST_PRICE_1500));
     }
 
     @Test
@@ -237,8 +274,8 @@ class PortfolioControllerIntegrationTest extends AbstractIntegrationTest {
 
         // Add more of the same stock
         AddPositionRequest request = new AddPositionRequest(
-                "AShare", "000001", "平安银行", 
-                new BigDecimal("500"), new BigDecimal("13.00")
+                "AShare", "000001", "平安银行",
+                new BigDecimal("500"), new BigDecimal(String.valueOf(TEST_PRICE_13))
         );
 
         mockMvc.perform(post("/api/v1/portfolio")
@@ -247,15 +284,15 @@ class PortfolioControllerIntegrationTest extends AbstractIntegrationTest {
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(0))
-                .andExpect(jsonPath("$.data.quantity").value(1000)); // 500 + 500
+                .andExpect(jsonPath("$.data.quantity").value(TEST_QUANTITY_1000)); // 500 + 500
     }
 
     @Test
     @DisplayName("添加持仓-参数验证失败-空市场")
     void addPositionValidationEmptyMarket() throws Exception {
         AddPositionRequest request = new AddPositionRequest(
-                "", "600519", "贵州茅台", 
-                new BigDecimal("100"), new BigDecimal("1500.00")
+                "", "600519", "贵州茅台",
+                new BigDecimal(TEST_QUANTITY_100), new BigDecimal(String.valueOf(TEST_PRICE_1500))
         );
 
         mockMvc.perform(post("/api/v1/portfolio")
@@ -263,15 +300,15 @@ class PortfolioControllerIntegrationTest extends AbstractIntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.code").value(400));
+                .andExpect(jsonPath("$.code").value(BAD_REQUEST_CODE));
     }
 
     @Test
     @DisplayName("添加持仓-参数验证失败-无效数量")
     void addPositionValidationInvalidQuantity() throws Exception {
         AddPositionRequest request = new AddPositionRequest(
-                "AShare", "600519", "贵州茅台", 
-                new BigDecimal("-100"), new BigDecimal("1500.00")
+                "AShare", "600519", "贵州茅台",
+                new BigDecimal("-100"), new BigDecimal(String.valueOf(TEST_PRICE_1500))
         );
 
         mockMvc.perform(post("/api/v1/portfolio")
@@ -279,7 +316,7 @@ class PortfolioControllerIntegrationTest extends AbstractIntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.code").value(400));
+                .andExpect(jsonPath("$.code").value(BAD_REQUEST_CODE));
     }
 
     // ==================== Update Position Tests ====================
@@ -293,13 +330,13 @@ class PortfolioControllerIntegrationTest extends AbstractIntegrationTest {
                 .market("AShare")
                 .symbol("000001")
                 .name("平安银行")
-                .quantity(new BigDecimal("1000"))
+                .quantity(new BigDecimal(TEST_QUANTITY_1000))
                 .avgCost(new BigDecimal("12.50"))
                 .build();
         PortfolioPosition saved = positionRepository.save(position);
 
         UpdatePositionRequest request = new UpdatePositionRequest(
-                new BigDecimal("2000"), new BigDecimal("13.00")
+                new BigDecimal(TEST_QUANTITY_2000), new BigDecimal(String.valueOf(TEST_PRICE_13))
         );
 
         mockMvc.perform(put("/api/v1/portfolio/{id}", saved.getId())
@@ -308,18 +345,18 @@ class PortfolioControllerIntegrationTest extends AbstractIntegrationTest {
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(0))
-                .andExpect(jsonPath("$.data.quantity").value(2000))
-                .andExpect(jsonPath("$.data.avgCost").value(13.00));
+                .andExpect(jsonPath("$.data.quantity").value(TEST_QUANTITY_2000))
+                .andExpect(jsonPath("$.data.avgCost").value(TEST_PRICE_13));
     }
 
     @Test
     @DisplayName("更新持仓-不存在")
     void updatePositionNotFound() throws Exception {
         UpdatePositionRequest request = new UpdatePositionRequest(
-                new BigDecimal("2000"), new BigDecimal("13.00")
+                new BigDecimal(TEST_QUANTITY_2000), new BigDecimal(String.valueOf(TEST_PRICE_13))
         );
 
-        mockMvc.perform(put("/api/v1/portfolio/{id}", 999999)
+        mockMvc.perform(put("/api/v1/portfolio/{id}", NON_EXISTENT_ID)
                         .header(AUTHORIZATION_HEADER, bearerToken(accessToken))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
@@ -331,7 +368,7 @@ class PortfolioControllerIntegrationTest extends AbstractIntegrationTest {
     @DisplayName("更新持仓-无效ID")
     void updatePositionInvalidId() throws Exception {
         UpdatePositionRequest request = new UpdatePositionRequest(
-                new BigDecimal("2000"), new BigDecimal("13.00")
+                new BigDecimal(TEST_QUANTITY_2000), new BigDecimal(String.valueOf(TEST_PRICE_13))
         );
 
         mockMvc.perform(put("/api/v1/portfolio/{id}", -1)
@@ -339,7 +376,7 @@ class PortfolioControllerIntegrationTest extends AbstractIntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.code").value(400));
+                .andExpect(jsonPath("$.code").value(BAD_REQUEST_CODE));
     }
 
     // ==================== Delete Position Tests ====================
@@ -353,7 +390,7 @@ class PortfolioControllerIntegrationTest extends AbstractIntegrationTest {
                 .market("AShare")
                 .symbol("000001")
                 .name("平安银行")
-                .quantity(new BigDecimal("1000"))
+                .quantity(new BigDecimal(TEST_QUANTITY_1000))
                 .avgCost(new BigDecimal("12.50"))
                 .build();
         PortfolioPosition saved = positionRepository.save(position);
@@ -370,7 +407,7 @@ class PortfolioControllerIntegrationTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("删除持仓-不存在静默处理")
     void deletePositionNotFound() throws Exception {
-        mockMvc.perform(delete("/api/v1/portfolio/{id}", 999999)
+        mockMvc.perform(delete("/api/v1/portfolio/{id}", NON_EXISTENT_ID)
                         .header(AUTHORIZATION_HEADER, bearerToken(accessToken)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(0));
@@ -399,8 +436,8 @@ class PortfolioControllerIntegrationTest extends AbstractIntegrationTest {
                 .symbol("600519")
                 .name("贵州茅台")
                 .tradeType(Trade.TradeType.BUY)
-                .quantity(new BigDecimal("100"))
-                .price(new BigDecimal("1500.00"))
+                .quantity(new BigDecimal(TEST_QUANTITY_100))
+                .price(new BigDecimal(String.valueOf(TEST_PRICE_1500)))
                 .amount(new BigDecimal("150000.00"))
                 .tradeTime(LocalDateTime.now())
                 .build();
@@ -422,7 +459,7 @@ class PortfolioControllerIntegrationTest extends AbstractIntegrationTest {
     void addTradeBuyCreatePosition() throws Exception {
         AddTradeRequest request = new AddTradeRequest(
                 "AShare", "600519", "贵州茅台", "BUY",
-                new BigDecimal("100"), new BigDecimal("1500.00"),
+                new BigDecimal(TEST_QUANTITY_100), new BigDecimal(String.valueOf(TEST_PRICE_1500)),
                 LocalDateTime.now()
         );
 
@@ -434,14 +471,14 @@ class PortfolioControllerIntegrationTest extends AbstractIntegrationTest {
                 .andExpect(jsonPath("$.code").value(0))
                 .andExpect(jsonPath("$.data.symbol").value("600519"))
                 .andExpect(jsonPath("$.data.tradeType").value("BUY"))
-                .andExpect(jsonPath("$.data.quantity").value(100))
-                .andExpect(jsonPath("$.data.price").value(1500.00));
+                .andExpect(jsonPath("$.data.quantity").value(TEST_QUANTITY_100))
+                .andExpect(jsonPath("$.data.price").value(TEST_PRICE_1500));
 
         // Verify position was created
         List<PortfolioPosition> positions = positionRepository.findByUserId(userId);
         assertThat(positions).hasSize(1);
         assertThat(positions.get(0).getSymbol()).isEqualTo("600519");
-        assertThat(positions.get(0).getQuantity()).isEqualByComparingTo(new BigDecimal("100"));
+        assertThat(positions.get(0).getQuantity()).isEqualByComparingTo(new BigDecimal(TEST_QUANTITY_100));
     }
 
     @Test
@@ -453,14 +490,14 @@ class PortfolioControllerIntegrationTest extends AbstractIntegrationTest {
                 .market("AShare")
                 .symbol("000001")
                 .name("平安银行")
-                .quantity(new BigDecimal("1000"))
+                .quantity(new BigDecimal(TEST_QUANTITY_1000))
                 .avgCost(new BigDecimal("12.00"))
                 .build();
         positionRepository.save(position);
 
         AddTradeRequest request = new AddTradeRequest(
                 "AShare", "000001", "平安银行", "BUY",
-                new BigDecimal("500"), new BigDecimal("13.00"),
+                new BigDecimal("500"), new BigDecimal(String.valueOf(TEST_PRICE_13)),
                 LocalDateTime.now()
         );
 
@@ -486,7 +523,7 @@ class PortfolioControllerIntegrationTest extends AbstractIntegrationTest {
                 .market("AShare")
                 .symbol("000001")
                 .name("平安银行")
-                .quantity(new BigDecimal("1000"))
+                .quantity(new BigDecimal(TEST_QUANTITY_1000))
                 .avgCost(new BigDecimal("12.00"))
                 .build();
         positionRepository.save(position);
@@ -519,14 +556,14 @@ class PortfolioControllerIntegrationTest extends AbstractIntegrationTest {
                 .market("AShare")
                 .symbol("000001")
                 .name("平安银行")
-                .quantity(new BigDecimal("1000"))
+                .quantity(new BigDecimal(TEST_QUANTITY_1000))
                 .avgCost(new BigDecimal("12.00"))
                 .build();
         positionRepository.save(position);
 
         AddTradeRequest request = new AddTradeRequest(
                 "AShare", "000001", "平安银行", "SELL",
-                new BigDecimal("1000"), new BigDecimal("14.00"),
+                new BigDecimal(TEST_QUANTITY_1000), new BigDecimal("14.00"),
                 LocalDateTime.now()
         );
 
@@ -547,7 +584,7 @@ class PortfolioControllerIntegrationTest extends AbstractIntegrationTest {
     void addTradeValidationEmptyMarket() throws Exception {
         AddTradeRequest request = new AddTradeRequest(
                 "", "600519", "贵州茅台", "BUY",
-                new BigDecimal("100"), new BigDecimal("1500.00"),
+                new BigDecimal(TEST_QUANTITY_100), new BigDecimal(String.valueOf(TEST_PRICE_1500)),
                 LocalDateTime.now()
         );
 
@@ -556,7 +593,7 @@ class PortfolioControllerIntegrationTest extends AbstractIntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.code").value(400));
+                .andExpect(jsonPath("$.code").value(BAD_REQUEST_CODE));
     }
 
     @Test
@@ -564,7 +601,7 @@ class PortfolioControllerIntegrationTest extends AbstractIntegrationTest {
     void addTradeValidationInvalidTradeType() throws Exception {
         AddTradeRequest request = new AddTradeRequest(
                 "AShare", "600519", "贵州茅台", "INVALID",
-                new BigDecimal("100"), new BigDecimal("1500.00"),
+                new BigDecimal(TEST_QUANTITY_100), new BigDecimal(String.valueOf(TEST_PRICE_1500)),
                 LocalDateTime.now()
         );
 
@@ -580,7 +617,7 @@ class PortfolioControllerIntegrationTest extends AbstractIntegrationTest {
     void addTradeValidationZeroPrice() throws Exception {
         AddTradeRequest request = new AddTradeRequest(
                 "AShare", "600519", "贵州茅台", "BUY",
-                new BigDecimal("100"), new BigDecimal("0"),
+                new BigDecimal(TEST_QUANTITY_100), new BigDecimal("0"),
                 LocalDateTime.now()
         );
 
@@ -589,7 +626,7 @@ class PortfolioControllerIntegrationTest extends AbstractIntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.code").value(400));
+                .andExpect(jsonPath("$.code").value(BAD_REQUEST_CODE));
     }
 
     // ==================== End-to-End Flow Test ====================
@@ -599,8 +636,8 @@ class PortfolioControllerIntegrationTest extends AbstractIntegrationTest {
     void portfolioEndToEndFlow() throws Exception {
         // Step 1: Add a position
         AddPositionRequest addRequest = new AddPositionRequest(
-                "AShare", "600519", "贵州茅台", 
-                new BigDecimal("100"), new BigDecimal("1500.00")
+                "AShare", "600519", "贵州茅台",
+                new BigDecimal(TEST_QUANTITY_100), new BigDecimal(String.valueOf(TEST_PRICE_1500))
         );
 
         MvcResult addResult = mockMvc.perform(post("/api/v1/portfolio")
@@ -626,7 +663,7 @@ class PortfolioControllerIntegrationTest extends AbstractIntegrationTest {
 
         // Step 3: Update the position
         UpdatePositionRequest updateRequest = new UpdatePositionRequest(
-                new BigDecimal("200"), new BigDecimal("1550.00")
+                new BigDecimal(TEST_QUANTITY_200), new BigDecimal("1550.00")
         );
 
         mockMvc.perform(put("/api/v1/portfolio/{id}", positionId)
@@ -635,7 +672,7 @@ class PortfolioControllerIntegrationTest extends AbstractIntegrationTest {
                         .content(objectMapper.writeValueAsString(updateRequest)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(0))
-                .andExpect(jsonPath("$.data.quantity").value(200));
+                .andExpect(jsonPath("$.data.quantity").value(TEST_QUANTITY_200));
 
         // Step 4: Get summary
         mockMvc.perform(get("/api/v1/portfolio/summary")
@@ -644,18 +681,7 @@ class PortfolioControllerIntegrationTest extends AbstractIntegrationTest {
                 .andExpect(jsonPath("$.code").value(0));
 
         // Step 5: Add a trade
-        AddTradeRequest tradeRequest = new AddTradeRequest(
-                "AShare", "000001", "平安银行", "BUY",
-                new BigDecimal("1000"), new BigDecimal("12.50"),
-                LocalDateTime.now()
-        );
-
-        mockMvc.perform(post("/api/v1/portfolio/trades")
-                        .header(AUTHORIZATION_HEADER, bearerToken(accessToken))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(tradeRequest)))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value(0));
+        addTradeRequest();
 
         // Step 6: Get trades
         mockMvc.perform(get("/api/v1/portfolio/trades")

--- a/koduck-backend/src/test/java/com/koduck/controller/UserControllerIntegrationTest.java
+++ b/koduck-backend/src/test/java/com/koduck/controller/UserControllerIntegrationTest.java
@@ -1,6 +1,26 @@
 package com.koduck.controller;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.TestConstructor;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import com.koduck.AbstractIntegrationTest;
 import com.koduck.dto.ApiResponse;
 import com.koduck.dto.auth.LoginRequest;
@@ -12,61 +32,52 @@ import com.koduck.dto.user.UpdateProfileRequest;
 import com.koduck.dto.user.UpdateUserRequest;
 import com.koduck.dto.user.UserDetailResponse;
 import com.koduck.entity.User;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.http.MediaType;
-import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.test.context.TestConstructor;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MvcResult;
-
-import java.nio.charset.StandardCharsets;
-
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
  * Integration tests for {@link UserController} user and admin endpoints.
  *
- * @author GitHub Copilot
- * @date 2026-03-31
+ * @author Koduck Team
  */
 @AutoConfigureMockMvc
 @TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
 @SuppressWarnings("null")
 class UserControllerIntegrationTest extends AbstractIntegrationTest {
 
-        private static final int ADMIN_ROLE_ID = 1;
-        private static final String AUTHORIZATION_HEADER = "Authorization";
-        private static final String BEARER_PREFIX = "Bearer ";
+    /** The admin role ID. */
+    private static final int ADMIN_ROLE_ID = 1;
+    /** The authorization header name. */
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    /** The bearer prefix. */
+    private static final String BEARER_PREFIX = "Bearer ";
 
-        private final MockMvc mockMvc;
-        private final ObjectMapper objectMapper;
-        private final JdbcTemplate jdbcTemplate;
+    /** The MockMvc instance. */
+    private final MockMvc mockMvc;
+    /** The object mapper. */
+    private final ObjectMapper objectMapper;
+    /** The JDBC template. */
+    private final JdbcTemplate jdbcTemplate;
 
+    /** The access token for the normal user. */
     private String accessToken;
+    /** The access token for the admin user. */
     private String adminAccessToken;
+    /** The normal user ID. */
     private Long normalUserId;
+    /** The normal user name. */
     private String normalUsername;
 
-        UserControllerIntegrationTest(
-                        MockMvc mockMvc,
-                        ObjectMapper objectMapper,
-                        JdbcTemplate jdbcTemplate) {
-                this.mockMvc = mockMvc;
-                this.objectMapper = objectMapper;
-                this.jdbcTemplate = jdbcTemplate;
-        }
+    UserControllerIntegrationTest(
+            MockMvc mockMvc,
+            ObjectMapper objectMapper,
+            JdbcTemplate jdbcTemplate) {
+        this.mockMvc = mockMvc;
+        this.objectMapper = objectMapper;
+        this.jdbcTemplate = jdbcTemplate;
+    }
 
     @BeforeEach
     void setUp() throws Exception {
-                String suffix = Long.toString(System.nanoTime());
+        String suffix = Long.toString(System.nanoTime());
 
         RegisteredUser normalUser = registerUser("testuser_" + suffix, "password123", "Test User");
         accessToken = normalUser.accessToken();
@@ -78,14 +89,14 @@ class UserControllerIntegrationTest extends AbstractIntegrationTest {
         jdbcTemplate.update(
                 "INSERT INTO user_roles (user_id, role_id) VALUES (?, ?) ON CONFLICT DO NOTHING",
                 adminUser.userId(),
-                                ADMIN_ROLE_ID);
+                ADMIN_ROLE_ID);
 
         adminAccessToken = loginAndGetAccessToken(adminUser.username(), "password123");
     }
 
-        private String bearerToken(String token) {
-                return BEARER_PREFIX + token;
-        }
+    private String bearerToken(String token) {
+        return BEARER_PREFIX + token;
+    }
 
     private RegisteredUser registerUser(String username, String password, String nickname) throws Exception {
         RegisterRequest registerRequest = new RegisterRequest();
@@ -133,7 +144,7 @@ class UserControllerIntegrationTest extends AbstractIntegrationTest {
     @DisplayName("获取当前用户信息")
     void getCurrentUser() throws Exception {
         mockMvc.perform(get("/api/v1/users/me")
-                                                .header(AUTHORIZATION_HEADER, bearerToken(accessToken)))
+                        .header(AUTHORIZATION_HEADER, bearerToken(accessToken)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(0))
                 .andExpect(jsonPath("$.data.username").value(normalUsername))
@@ -148,7 +159,7 @@ class UserControllerIntegrationTest extends AbstractIntegrationTest {
         request.setAvatarUrl("https://example.com/avatar.png");
 
         mockMvc.perform(put("/api/v1/users/me")
-                                                .header(AUTHORIZATION_HEADER, bearerToken(accessToken))
+                        .header(AUTHORIZATION_HEADER, bearerToken(accessToken))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
@@ -205,7 +216,7 @@ class UserControllerIntegrationTest extends AbstractIntegrationTest {
     @DisplayName("普通用户无法访问管理员接口")
     void normalUserCannotAccessAdminEndpoint() throws Exception {
         mockMvc.perform(get("/api/v1/users")
-                                                .header(AUTHORIZATION_HEADER, bearerToken(accessToken)))
+                        .header(AUTHORIZATION_HEADER, bearerToken(accessToken)))
                 .andExpect(status().isForbidden());
     }
 
@@ -233,7 +244,7 @@ class UserControllerIntegrationTest extends AbstractIntegrationTest {
     @DisplayName("管理员可获取指定用户详情")
     void adminCanGetUserById() throws Exception {
         mockMvc.perform(get("/api/v1/users/{id}", normalUserId)
-                                                .header(AUTHORIZATION_HEADER, bearerToken(adminAccessToken)))
+                        .header(AUTHORIZATION_HEADER, bearerToken(adminAccessToken)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(0))
                 .andExpect(jsonPath("$.data.id").value(normalUserId))

--- a/koduck-backend/src/test/java/com/koduck/service/MarketServiceImplBatchPricesTest.java
+++ b/koduck-backend/src/test/java/com/koduck/service/MarketServiceImplBatchPricesTest.java
@@ -1,58 +1,72 @@
 package com.koduck.service;
 
-import com.koduck.dto.market.PriceQuoteDto;
-import com.koduck.entity.StockRealtime;
-import com.koduck.repository.StockBasicRepository;
-import com.koduck.repository.StockRealtimeRepository;
-import com.koduck.market.application.MarketServiceImpl;
-import com.koduck.service.support.MarketFallbackSupport;
-import com.koduck.service.support.MarketServiceSupport;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.math.BigDecimal;
-import java.time.LocalDateTime;
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
+import com.koduck.dto.market.PriceQuoteDto;
+import com.koduck.entity.StockRealtime;
+import com.koduck.market.application.MarketServiceImpl;
+import com.koduck.repository.StockBasicRepository;
+import com.koduck.repository.StockRealtimeRepository;
+import com.koduck.service.support.MarketFallbackSupport;
+import com.koduck.service.support.MarketServiceSupport;
 
 /**
  * Unit tests focused on the {@link MarketServiceImpl#getBatchPrices(List)}
  * behaviour.
  *
- * <p>This class exercises the cache‑first merging logic: when some symbols
+ * <p>This class exercises the cache-first merging logic: when some symbols
  * are returned from the cache and the remainder are fetched from the
  * repository, the result should preserve the input order and include both
  * sources.</p>
+ *
+ * @author Koduck Team
  */
 @ExtendWith(MockitoExtension.class)
 class MarketServiceImplBatchPricesTest {
+
+    /** The stock realtime repository. */
     @Mock
     StockRealtimeRepository stockRealtimeRepository;
+
+    /** The stock basic repository. */
     @Mock
     StockBasicRepository stockBasicRepository;
+
+    /** The stock cache service. */
     @Mock
     StockCacheService stockCacheService;
+
+    /** The market service support. */
     @Mock
     MarketServiceSupport marketServiceSupport;
+
+    /** The market fallback support. */
     @Mock
     MarketFallbackSupport marketFallbackSupport;
 
+    /** The market service under test. */
     private MarketServiceImpl marketService;
 
     @BeforeEach
     void setUp() {
-      MarketServiceSupport realMarketServiceSupport =
-        new MarketServiceSupport(stockRealtimeRepository, stockBasicRepository);
+        MarketServiceSupport realMarketServiceSupport =
+            new MarketServiceSupport(stockRealtimeRepository, stockBasicRepository);
         marketService = new MarketServiceImpl(
             stockRealtimeRepository,
             stockBasicRepository,
             stockCacheService,
-        realMarketServiceSupport,
+            realMarketServiceSupport,
             marketFallbackSupport);
     }
 
@@ -62,19 +76,22 @@ class MarketServiceImplBatchPricesTest {
      * both items in the same order as the input argument.
      */
     @Test
-    void getBatchPricesShouldMergeCachedAndDb(){
-    PriceQuoteDto cached = PriceQuoteDto.builder().symbol("000001").name("A").build();
-    StockRealtime dbEntity = new StockRealtime();
-    dbEntity.setSymbol("600000"); dbEntity.setName("B");
-    dbEntity.setPrice(new BigDecimal("8.50")); dbEntity.setOpenPrice(new BigDecimal("8.50"));
-    dbEntity.setHigh(new BigDecimal("8.50")); dbEntity.setLow(new BigDecimal("8.50"));
-    dbEntity.setPrevClose(new BigDecimal("8.50")); dbEntity.setUpdatedAt(LocalDateTime.now());
-    when(stockCacheService.getCachedStockTracks(List.of("000001","600000"))).thenReturn(List.of(cached));
-    when(stockRealtimeRepository.findBySymbolIn(List.of("600000"))).thenReturn(List.of(dbEntity));
-    List<PriceQuoteDto> result = marketService.getBatchPrices(List.of("000001","600000"));
-    assertThat(result).hasSize(2);
-    assertThat(result.get(0).symbol()).isEqualTo("000001");
-    assertThat(result.get(1).symbol()).isEqualTo("600000");
-  }
+    void getBatchPricesShouldMergeCachedAndDb() {
+        PriceQuoteDto cached = PriceQuoteDto.builder().symbol("000001").name("A").build();
+        StockRealtime dbEntity = new StockRealtime();
+        dbEntity.setSymbol("600000");
+        dbEntity.setName("B");
+        dbEntity.setPrice(new BigDecimal("8.50"));
+        dbEntity.setOpenPrice(new BigDecimal("8.50"));
+        dbEntity.setHigh(new BigDecimal("8.50"));
+        dbEntity.setLow(new BigDecimal("8.50"));
+        dbEntity.setPrevClose(new BigDecimal("8.50"));
+        dbEntity.setUpdatedAt(LocalDateTime.now());
+        when(stockCacheService.getCachedStockTracks(List.of("000001", "600000"))).thenReturn(List.of(cached));
+        when(stockRealtimeRepository.findBySymbolIn(List.of("600000"))).thenReturn(List.of(dbEntity));
+        List<PriceQuoteDto> result = marketService.getBatchPrices(List.of("000001", "600000"));
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).symbol()).isEqualTo("000001");
+        assertThat(result.get(1).symbol()).isEqualTo("600000");
+    }
 }
-


### PR DESCRIPTION
Fix checkstyle warnings in 6 backend files as described in #376.

## Changes

### Files Modified
1. **MarketServiceImplBatchPricesTest.java** - Fixed import order, indentation, Javadoc
2. **PortfolioControllerIntegrationTest.java** - Fixed import order, added Javadoc, extracted magic numbers to constants
3. **UserControllerIntegrationTest.java** - Fixed import order, indentation, added Javadoc
4. **CommunitySignalControllerTest.java** - Fixed import order, added Javadoc, extracted magic numbers
5. **BacktestServiceImpl.java** - Fixed import order, added Javadoc on constants, extracted magic numbers
6. **AKShareDataProvider.java** - Fixed import order, removed unused import, fixed brace style (Allman to K&R), added Javadoc

## Verification
- `mvn clean compile` passes
- Checkstyle shows 0 violations for modified files

Closes #376