### PR TITLE
style(checkstyle): fix warnings in 7 backend DTO and Repository files

### DIFF
--- a/koduck-backend/docs/ADR-0043-checkstyle-batch4-fix.md
+++ b/koduck-backend/docs/ADR-0043-checkstyle-batch4-fix.md
@@ -1,0 +1,97 @@
+# ADR-0043: 后端 DTO 与 Repository Checkstyle 告警修复 - Batch 4
+
+- Status: Accepted
+- Date: 2026-04-02
+- Issue: #378
+
+## Context
+
+执行 `mvn -f koduck-backend/pom.xml clean compile checkstyle:check` 时发现 koduck-backend 模块的 7 个核心文件存在代码风格告警，涵盖 DTO 和 Repository 层：
+
+### 告警统计
+
+| 文件 | 告警类型 |
+|------|----------|
+| `DailyBreadthDto.java` | ImportOrder, JavadocType |
+| `AlertRuleRequest.java` | JavadocType (Unknown tag 'date', missing @param) |
+| `SignalListResponse.java` | ImportOrder, JavadocType, JavadocVariable |
+| `UserSignalStatsRepository.java` | ImportOrder, JavadocType, JavadocMethod |
+| `StrategyVersionRepository.java` | ImportOrder, JavadocType, JavadocMethod |
+| `StrategyRepository.java` | ImportOrder, JavadocType, JavadocMethod, LineLength |
+| `BacktestResultRepository.java` | ImportOrder, JavadocType, JavadocMethod |
+
+### 具体问题
+
+1. **ImportOrder**: 导入顺序不符合规范（`java.*` → `javax.*` → `org.*` → `com.*`），组间未空行分隔
+2. **JavadocType**: 类注释缺少 `@author` 标签，或包含不支持的 `@date` 标签
+3. **JavadocVariable**: 字段缺少 Javadoc 注释
+4. **JavadocMethod**: 方法注释缺少 `@param` 和 `@return` 标签
+5. **LineLength**: `StrategyRepository.java` 中第 56 行 SQL 超过 120 字符限制
+
+这些告警影响代码可读性和维护性，需要在实施硬性 CI 门禁前完成修复。
+
+## Decision
+
+### 修复范围
+
+修复以下 7 个文件的 Checkstyle 告警：
+
+| 文件路径 | 主要问题 |
+|---------|---------|
+| `dto/market/DailyBreadthDto.java` | ImportOrder, JavadocType |
+| `dto/monitoring/AlertRuleRequest.java` | JavadocType (@date tag, @param) |
+| `dto/community/SignalListResponse.java` | ImportOrder, JavadocType, JavadocVariable |
+| `repository/UserSignalStatsRepository.java` | ImportOrder, JavadocType, JavadocMethod |
+| `repository/StrategyVersionRepository.java` | ImportOrder, JavadocType, JavadocMethod |
+| `repository/StrategyRepository.java` | ImportOrder, JavadocType, JavadocMethod, LineLength |
+| `repository/BacktestResultRepository.java` | ImportOrder, JavadocType, JavadocMethod |
+
+### 修复规则
+
+1. **Import 顺序**:
+   - 顺序: `java.*` → `javax.*` → `org.*` → `com.*`
+   - 组间空行分隔
+
+2. **Javadoc**:
+   - 移除不支持的 `@date` 标签
+   - 类注释添加 `@author Koduck Team` 标签
+   - 字段添加简洁描述注释
+   - Repository 方法补充 `@param` 和 `@return` 说明
+
+3. **代码格式**:
+   - 行长度 ≤ 120 字符，超长 SQL/HQL 进行合理换行
+
+### 修复策略
+
+采用手动修复：
+- 告警涉及 Javadoc 描述，手动修复可确保文档语义准确
+- Repository 中的长 SQL 需要结合语义进行换行，手动处理更可靠
+- 边修复边验证，避免引入新问题
+
+## Consequences
+
+### 正向影响
+
+- 7 个核心文件 Checkstyle 零告警通过
+- 代码可读性和维护性提升
+- 为实施硬性 CI 门禁扫清障碍
+
+### 消极影响
+
+- 修复耗时约 30-60 分钟
+- 需要仔细验证不破坏编译和测试功能
+
+### 兼容性
+
+| 方面 | 影响 | 说明 |
+|-----|------|------|
+| 业务逻辑 | 无 | 仅修改格式和注释 |
+| API 接口 | 无 | DTO 字段和类型保持不变 |
+| 序列化 | 无 | 未修改字段名和注解 |
+| 测试 | 无 | 测试用例无需修改 |
+
+## Related
+
+- Issue #378
+- ADR-0042: 后端核心文件 Checkstyle 告警修复 - Batch 3
+- ADR-0029: 接入 Alibaba Checkstyle 并统一测试分类规范

--- a/koduck-backend/src/main/java/com/koduck/dto/community/SignalListResponse.java
+++ b/koduck-backend/src/main/java/com/koduck/dto/community/SignalListResponse.java
@@ -1,34 +1,48 @@
 package com.koduck.dto.community;
 
+import java.util.List;
+
 import com.koduck.util.CollectionCopyUtils;
+
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.List;
-
 /**
- *  DTO
+ * Signal list response DTO.
+ *
+ * @author Koduck Team
  */
 @Data
 @NoArgsConstructor
 public class SignalListResponse {
 
+    /** Signal items. */
     private List<SignalResponse> items;
+    /** Total count. */
     private long total;
+    /** Current page. */
     private int page;
+    /** Page size. */
     private int size;
+    /** Total pages. */
     private int totalPages;
 
     public static Builder builder() {
         return new Builder();
     }
 
+    /** Builder for SignalListResponse. */
     public static final class Builder {
 
+        /** Signal items. */
         private List<SignalResponse> items;
+        /** Total count. */
         private long total;
+        /** Current page. */
         private int page;
+        /** Page size. */
         private int size;
+        /** Total pages. */
         private int totalPages;
 
         public Builder items(List<SignalResponse> items) {

--- a/koduck-backend/src/main/java/com/koduck/dto/market/DailyBreadthDto.java
+++ b/koduck-backend/src/main/java/com/koduck/dto/market/DailyBreadthDto.java
@@ -1,13 +1,28 @@
 package com.koduck.dto.market;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
-
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
 /**
  * Daily market breadth DTO.
+ *
+ * @author Koduck Team
+ * @param market the market
+ * @param breadthType the breadth type
+ * @param tradeDate the trade date
+ * @param gainers the gainers
+ * @param losers the losers
+ * @param unchanged the unchanged
+ * @param suspended the suspended
+ * @param totalStocks the total stocks
+ * @param advanceDeclineLine the advance decline line
+ * @param source the source
+ * @param quality the quality
+ * @param snapshotTime the snapshot time
+ * @param updatedAt the updated at
  */
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record DailyBreadthDto(

--- a/koduck-backend/src/main/java/com/koduck/dto/monitoring/AlertRuleRequest.java
+++ b/koduck-backend/src/main/java/com/koduck/dto/monitoring/AlertRuleRequest.java
@@ -5,8 +5,16 @@ import java.math.BigDecimal;
 /**
  * Request body for creating or updating an alert rule.
  *
- * @author GitHub Copilot
- * @date 2026-03-31
+ * @author Koduck Team
+ * @param ruleName the rule name
+ * @param ruleType the rule type
+ * @param metricName the metric name
+ * @param threshold the threshold
+ * @param operator the operator
+ * @param severity the severity
+ * @param enabled the enabled
+ * @param cooldownMinutes the cooldown minutes
+ * @param description the description
  */
 public record AlertRuleRequest(
         String ruleName,

--- a/koduck-backend/src/main/java/com/koduck/repository/BacktestResultRepository.java
+++ b/koduck-backend/src/main/java/com/koduck/repository/BacktestResultRepository.java
@@ -1,49 +1,71 @@
 package com.koduck.repository;
 
-import com.koduck.entity.BacktestResult;
+import java.util.List;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-import java.util.Optional;
+import com.koduck.entity.BacktestResult;
 
 /**
  * Repository for backtest result operations.
+ *
+ * @author Koduck Team
  */
 @Repository
 public interface BacktestResultRepository extends JpaRepository<BacktestResult, Long> {
-    
+
     /**
      * Find all backtest results for a user.
+     *
+     * @param userId the user ID
+     * @return list of backtest results
      */
     List<BacktestResult> findByUserIdOrderByCreatedAtDesc(Long userId);
-    
+
     /**
      * Find backtest results by user and strategy.
+     *
+     * @param userId the user ID
+     * @param strategyId the strategy ID
+     * @return list of backtest results
      */
     List<BacktestResult> findByUserIdAndStrategyIdOrderByCreatedAtDesc(Long userId, Long strategyId);
-    
+
     /**
      * Find a backtest result by id and user.
+     *
+     * @param id the backtest result ID
+     * @param userId the user ID
+     * @return the backtest result
      */
     Optional<BacktestResult> findByIdAndUserId(Long id, Long userId);
-    
+
     /**
      * Update status.
+     *
+     * @param id the backtest result ID
+     * @param status the backtest status
      */
     @Modifying
     @Query("UPDATE BacktestResult br SET br.status = :status WHERE br.id = :id")
     void updateStatus(@Param("id") Long id, @Param("status") BacktestResult.BacktestStatus status);
-    
+
     /**
      * Update status and error message.
+     *
+     * @param id the backtest result ID
+     * @param status the backtest status
+     * @param errorMessage the error message
      */
     @Modifying
-    @Query("UPDATE BacktestResult br SET br.status = :status, br.errorMessage = :errorMessage WHERE br.id = :id")
-    void updateStatusAndError(@Param("id") Long id, 
-                              @Param("status") BacktestResult.BacktestStatus status, 
+    @Query("UPDATE BacktestResult br SET br.status = :status, "
+            + "br.errorMessage = :errorMessage WHERE br.id = :id")
+    void updateStatusAndError(@Param("id") Long id,
+                              @Param("status") BacktestResult.BacktestStatus status,
                               @Param("errorMessage") String errorMessage);
 }

--- a/koduck-backend/src/main/java/com/koduck/repository/StrategyRepository.java
+++ b/koduck-backend/src/main/java/com/koduck/repository/StrategyRepository.java
@@ -1,62 +1,94 @@
 package com.koduck.repository;
 
-import com.koduck.entity.Strategy;
+import java.util.List;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-import java.util.Optional;
+import com.koduck.entity.Strategy;
 
 /**
  * Repository for strategy operations.
+ *
+ * @author Koduck Team
  */
 @Repository
 public interface StrategyRepository extends JpaRepository<Strategy, Long> {
-    
+
     /**
      * Find all strategies for a user.
+     *
+     * @param userId the user ID
+     * @return list of strategies
      */
     List<Strategy> findByUserId(Long userId);
-    
+
     /**
      * Find strategies for a user by status.
+     *
+     * @param userId the user ID
+     * @param status the strategy status
+     * @return list of strategies
      */
     List<Strategy> findByUserIdAndStatus(Long userId, Strategy.StrategyStatus status);
-    
+
     /**
      * Find a strategy by id and user.
+     *
+     * @param id the strategy ID
+     * @param userId the user ID
+     * @return the strategy
      */
     Optional<Strategy> findByIdAndUserId(Long id, Long userId);
-    
+
     /**
      * Check if a strategy exists by id and user.
+     *
+     * @param id the strategy ID
+     * @param userId the user ID
+     * @return true if exists
      */
     boolean existsByIdAndUserId(Long id, Long userId);
-    
+
     /**
      * Delete a strategy by id and user.
+     *
+     * @param id the strategy ID
+     * @param userId the user ID
      */
     @Modifying
     @Query("DELETE FROM Strategy s WHERE s.id = :id AND s.userId = :userId")
     void deleteByIdAndUserId(@Param("id") Long id, @Param("userId") Long userId);
-    
+
     /**
      * Count strategies for a user.
+     *
+     * @param userId the user ID
+     * @return the count
      */
     long countByUserId(Long userId);
-    
+
     /**
      * Update strategy status.
+     *
+     * @param id the strategy ID
+     * @param userId the user ID
+     * @param status the strategy status
      */
     @Modifying
-    @Query("UPDATE Strategy s SET s.status = :status WHERE s.id = :id AND s.userId = :userId")
-    void updateStatus(@Param("id") Long id, @Param("userId") Long userId, @Param("status") Strategy.StrategyStatus status);
-    
+    @Query("UPDATE Strategy s SET s.status = :status "
+            + "WHERE s.id = :id AND s.userId = :userId")
+    void updateStatus(@Param("id") Long id, @Param("userId") Long userId,
+                      @Param("status") Strategy.StrategyStatus status);
+
     /**
      * Increment current version.
+     *
+     * @param id the strategy ID
      */
     @Modifying
     @Query("UPDATE Strategy s SET s.currentVersion = s.currentVersion + 1 WHERE s.id = :id")

--- a/koduck-backend/src/main/java/com/koduck/repository/StrategyVersionRepository.java
+++ b/koduck-backend/src/main/java/com/koduck/repository/StrategyVersionRepository.java
@@ -1,57 +1,80 @@
 package com.koduck.repository;
 
-import com.koduck.entity.StrategyVersion;
+import java.util.List;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-import java.util.Optional;
+import com.koduck.entity.StrategyVersion;
 
 /**
  * Repository for strategy version operations.
+ *
+ * @author Koduck Team
  */
 @Repository
 public interface StrategyVersionRepository extends JpaRepository<StrategyVersion, Long> {
-    
+
     /**
      * Find all versions for a strategy.
+     *
+     * @param strategyId the strategy ID
+     * @return list of strategy versions
      */
     List<StrategyVersion> findByStrategyIdOrderByVersionNumberDesc(Long strategyId);
-    
+
     /**
      * Find a specific version by strategy and version number.
+     *
+     * @param strategyId the strategy ID
+     * @param versionNumber the version number
+     * @return the strategy version
      */
     Optional<StrategyVersion> findByStrategyIdAndVersionNumber(Long strategyId, Integer versionNumber);
-    
+
     /**
      * Find the latest version for a strategy.
+     *
+     * @param strategyId the strategy ID
+     * @return the latest strategy version
      */
     Optional<StrategyVersion> findFirstByStrategyIdOrderByVersionNumberDesc(Long strategyId);
-    
+
     /**
      * Find the active version for a strategy.
+     *
+     * @param strategyId the strategy ID
+     * @return the active strategy version
      */
     Optional<StrategyVersion> findByStrategyIdAndIsActiveTrue(Long strategyId);
-    
+
     /**
      * Deactivate all versions for a strategy.
+     *
+     * @param strategyId the strategy ID
      */
     @Modifying
     @Query("UPDATE StrategyVersion sv SET sv.isActive = false WHERE sv.strategyId = :strategyId")
     void deactivateAllVersions(@Param("strategyId") Long strategyId);
-    
+
     /**
      * Activate a specific version.
+     *
+     * @param id the version ID
      */
     @Modifying
     @Query("UPDATE StrategyVersion sv SET sv.isActive = true WHERE sv.id = :id")
     void activateVersion(@Param("id") Long id);
-    
+
     /**
      * Count versions for a strategy.
+     *
+     * @param strategyId the strategy ID
+     * @return the count
      */
     long countByStrategyId(Long strategyId);
 }

--- a/koduck-backend/src/main/java/com/koduck/repository/UserSignalStatsRepository.java
+++ b/koduck-backend/src/main/java/com/koduck/repository/UserSignalStatsRepository.java
@@ -1,75 +1,103 @@
 package com.koduck.repository;
 
-import com.koduck.entity.UserSignalStats;
+import java.math.BigDecimal;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.math.BigDecimal;
-import java.util.Optional;
+import com.koduck.entity.UserSignalStats;
 
 /**
- *  Repository
+ * Repository for user signal stats operations.
+ *
+ * @author Koduck Team
  */
 @Repository
 public interface UserSignalStatsRepository extends JpaRepository<UserSignalStats, Long> {
 
     /**
-     *  ID 
+     * Find stats by user ID.
+     *
+     * @param userId the user ID
+     * @return the user signal stats
      */
     Optional<UserSignalStats> findByUserId(Long userId);
 
     /**
-     * 
+     * Check if stats exists by user ID.
+     *
+     * @param userId the user ID
+     * @return true if exists
      */
     boolean existsByUserId(Long userId);
 
     /**
-     * 
+     * Increment total signals.
+     *
+     * @param userId the user ID
      */
     @Modifying
     @Query("UPDATE UserSignalStats s SET s.totalSignals = s.totalSignals + 1 WHERE s.userId = :userId")
     void incrementTotalSignals(@Param("userId") Long userId);
 
     /**
-     * 
+     * Increment win signals.
+     *
+     * @param userId the user ID
      */
     @Modifying
-    @Query("UPDATE UserSignalStats s SET s.winSignals = s.winSignals + 1, s.totalSignals = s.totalSignals + 1 WHERE s.userId = :userId")
+    @Query("UPDATE UserSignalStats s SET s.winSignals = s.winSignals + 1, "
+            + "s.totalSignals = s.totalSignals + 1 WHERE s.userId = :userId")
     void incrementWinSignals(@Param("userId") Long userId);
 
     /**
-     * 
+     * Increment loss signals.
+     *
+     * @param userId the user ID
      */
     @Modifying
-    @Query("UPDATE UserSignalStats s SET s.lossSignals = s.lossSignals + 1, s.totalSignals = s.totalSignals + 1 WHERE s.userId = :userId")
+    @Query("UPDATE UserSignalStats s SET s.lossSignals = s.lossSignals + 1, "
+            + "s.totalSignals = s.totalSignals + 1 WHERE s.userId = :userId")
     void incrementLossSignals(@Param("userId") Long userId);
 
     /**
-     * 
+     * Increment follower count.
+     *
+     * @param userId the user ID
      */
     @Modifying
     @Query("UPDATE UserSignalStats s SET s.followerCount = s.followerCount + 1 WHERE s.userId = :userId")
     void incrementFollowerCount(@Param("userId") Long userId);
 
     /**
-     * 
+     * Decrement follower count.
+     *
+     * @param userId the user ID
      */
     @Modifying
-    @Query("UPDATE UserSignalStats s SET s.followerCount = s.followerCount - 1 WHERE s.userId = :userId AND s.followerCount > 0")
+    @Query("UPDATE UserSignalStats s SET s.followerCount = s.followerCount - 1 "
+            + "WHERE s.userId = :userId AND s.followerCount > 0")
     void decrementFollowerCount(@Param("userId") Long userId);
 
     /**
-     * 
+     * Update average profit.
+     *
+     * @param userId the user ID
+     * @param avgProfit the average profit
      */
     @Modifying
     @Query("UPDATE UserSignalStats s SET s.avgProfit = :avgProfit WHERE s.userId = :userId")
     void updateAvgProfit(@Param("userId") Long userId, @Param("avgProfit") BigDecimal avgProfit);
 
     /**
-     * 
+     * Update reputation score.
+     *
+     * @param userId the user ID
+     * @param score the score
      */
     @Modifying
     @Query("UPDATE UserSignalStats s SET s.reputationScore = :score WHERE s.userId = :userId")


### PR DESCRIPTION
## Summary

修复 7 个后端核心文件的 Checkstyle 风格告警：

- `DailyBreadthDto.java`
- `AlertRuleRequest.java`
- `SignalListResponse.java`
- `UserSignalStatsRepository.java`
- `StrategyVersionRepository.java`
- `StrategyRepository.java`
- `BacktestResultRepository.java`

## Changes

- 修正 Import 顺序（`java.*` → `javax.*` → `org.*` → `com.*`）
- 补充缺失的 Javadoc（`@author`, `@param`, `@return`）
- 移除不支持的 `@date` 标签
- 将超过 120 字符的 SQL/HQL 进行合理换行
- 新增 ADR-0043 记录本次修复决策

## Verification

- `mvn -f koduck-backend/pom.xml clean compile` 编译通过
- `mvn -f koduck-backend/pom.xml checkstyle:check` 零告警
- PMD / SpotBugs / 编译检查均通过（quality-check.sh 中除预先存在的 JaCoCo 覆盖率门禁外全部通过）

Closes #378