### PR TITLE
refactor(entity): 消除 koduck-backend Entity 层冗余

### DIFF
--- a/koduck-backend/docs/ADR-0049-entity-redundancy-elimination.md
+++ b/koduck-backend/docs/ADR-0049-entity-redundancy-elimination.md
@@ -1,0 +1,67 @@
+# ADR-0049: Entity 层冗余消除
+
+- Status: Accepted
+- Date: 2026-04-03
+- Issue: #390
+
+## Context
+
+根据 `docs/entity-redundancy-analysis.md` 分析报告，koduck-backend 的 Entity 层存在完全冗余的枚举定义和数据字段。
+
+### 发现的冗余问题
+
+| 严重程度 | 问题 | 影响 |
+|---------|------|------|
+| 🔴 P0 | TradeType 枚举重复定义 | Trade.java 和 BacktestTrade.java 各自定义了完全相同的枚举 |
+| 🔴 P0 | UserMemoryProfile.watchSymbols 与 WatchlistItem 功能重叠 | 数据不一致风险 |
+
+## Decision
+
+### 决策 1: 提取 TradeType 为共享枚举
+
+**理由**:
+- Trade.java 和 BacktestTrade.java 各自定义了完全相同的 TradeType 枚举（BUY, SELL）
+- 属于代码级完全冗余，维护负担（改一处漏一处）
+
+**实施方案**:
+- 创建 `com.koduck.entity.enums.TradeType` 共享枚举
+- 更新 Trade.java 引用新的枚举
+- 更新 BacktestTrade.java 引用新的枚举
+
+### 决策 2: 删除 UserMemoryProfile.watchSymbols 字段
+
+**理由**:
+- UserMemoryProfile.watchSymbols 是 JSONB 字符串数组
+- WatchlistItem 是功能完备的实现（支持排序、备注、市场区分）
+- 两者记录同一业务概念，数据不一致风险
+
+**实施方案**:
+- 删除 UserMemoryProfile.watchSymbols 字段
+- 删除相关的 Builder 方法、getter/setter
+- 如果 AI 需要快速读取关注列表，通过 WatchlistService 查询或缓存层解决
+
+## Consequences
+
+### 正向影响
+
+- 消除重复枚举定义，降低维护成本
+- 消除数据冗余，避免数据不一致
+- 统一关注列表入口（WatchlistItem）
+
+### 消极影响
+
+- 如果 AI 功能依赖 watchSymbols 的快速读取，需要通过其他方式实现（如缓存）
+- 需要更新数据库迁移脚本（可选，因为 JSONB 字段可为空）
+
+### 兼容性
+
+| 方面 | 影响 | 说明 |
+|-----|------|------|
+| 数据库 | 无 | watchSymbols 是 JSONB，删除不影响其他字段 |
+| API 接口 | 无 | Entity 是内部层 |
+| Service 层 | 有 | 需要检查是否有使用 watchSymbols 的服务 |
+
+## Related
+
+- Issue #390
+- `docs/entity-redundancy-analysis.md`

--- a/koduck-backend/src/main/java/com/koduck/entity/BacktestTrade.java
+++ b/koduck-backend/src/main/java/com/koduck/entity/BacktestTrade.java
@@ -15,6 +15,8 @@ import jakarta.persistence.Table;
 
 import org.hibernate.annotations.CreationTimestamp;
 
+import com.koduck.entity.enums.TradeType;
+
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -112,12 +114,4 @@ public class BacktestTrade {
     @Column(name = "created_at", updatable = false)
     @Setter(AccessLevel.NONE)
     private LocalDateTime createdAt;
-
-    /** Enumeration of trade types. */
-    public enum TradeType {
-        /** Buy trade type. */
-        BUY,
-        /** Sell trade type. */
-        SELL
-    }
 }

--- a/koduck-backend/src/main/java/com/koduck/entity/Trade.java
+++ b/koduck-backend/src/main/java/com/koduck/entity/Trade.java
@@ -15,6 +15,8 @@ import jakarta.persistence.Table;
 
 import org.hibernate.annotations.CreationTimestamp;
 
+import com.koduck.entity.enums.TradeType;
+
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -99,18 +101,6 @@ public class Trade {
     /** The notes. */
     @Column(name = "notes", length = 500)
     private String notes;
-
-    /**
-     * Trade type enum.
-     */
-    public enum TradeType {
-
-        /** Buy trade. */
-        BUY,
-
-        /** Sell trade. */
-        SELL
-    }
 
     /**
      * Trade status enum.

--- a/koduck-backend/src/main/java/com/koduck/entity/UserMemoryProfile.java
+++ b/koduck-backend/src/main/java/com/koduck/entity/UserMemoryProfile.java
@@ -1,7 +1,6 @@
 package com.koduck.entity;
 
 import java.time.LocalDateTime;
-import java.util.List;
 import java.util.Map;
 
 import jakarta.persistence.Column;
@@ -38,15 +37,10 @@ public class UserMemoryProfile {
     @Column(name = "risk_preference", length = 64)
     private String riskPreference;
 
-    /** The watch symbols list. */
-    @Column(name = "watch_symbols", nullable = false, columnDefinition = "jsonb")
-    @JdbcTypeCode(SqlTypes.JSON)
-    private List<String> watchSymbols = List.of();
-
     /** The preferred sources list. */
     @Column(name = "preferred_sources", nullable = false, columnDefinition = "jsonb")
     @JdbcTypeCode(SqlTypes.JSON)
-    private List<String> preferredSources = List.of();
+    private java.util.List<String> preferredSources = java.util.List.of();
 
     /** The profile facts map. */
     @Column(name = "profile_facts", nullable = false, columnDefinition = "jsonb")
@@ -78,11 +72,8 @@ public class UserMemoryProfile {
         /** The risk preference. */
         private String riskPreference;
 
-        /** The watch symbols list. */
-        private List<String> watchSymbols;
-
         /** The preferred sources list. */
-        private List<String> preferredSources;
+        private java.util.List<String> preferredSources;
 
         /** The profile facts map. */
         private Map<String, Object> profileFacts;
@@ -113,23 +104,12 @@ public class UserMemoryProfile {
         }
 
         /**
-         * Set the watch symbols.
-         *
-         * @param watchSymbols the watch symbols list
-         * @return the builder
-         */
-        public Builder watchSymbols(List<String> watchSymbols) {
-            this.watchSymbols = CollectionCopyUtils.copyList(watchSymbols);
-            return this;
-        }
-
-        /**
          * Set the preferred sources.
          *
          * @param preferredSources the preferred sources list
          * @return the builder
          */
-        public Builder preferredSources(List<String> preferredSources) {
+        public Builder preferredSources(java.util.List<String> preferredSources) {
             this.preferredSources = CollectionCopyUtils.copyList(preferredSources);
             return this;
         }
@@ -165,7 +145,6 @@ public class UserMemoryProfile {
             UserMemoryProfile profile = new UserMemoryProfile();
             profile.setUserId(userId);
             profile.setRiskPreference(riskPreference);
-            profile.setWatchSymbols(watchSymbols);
             profile.setPreferredSources(preferredSources);
             profile.setProfileFacts(profileFacts);
             profile.setUpdatedAt(updatedAt);
@@ -174,29 +153,11 @@ public class UserMemoryProfile {
     }
 
     /**
-     * Get the watch symbols with defensive copy.
-     *
-     * @return the watch symbols list
-     */
-    public List<String> getWatchSymbols() {
-        return CollectionCopyUtils.copyList(watchSymbols);
-    }
-
-    /**
-     * Set the watch symbols with defensive copy.
-     *
-     * @param watchSymbols the watch symbols list
-     */
-    public void setWatchSymbols(List<String> watchSymbols) {
-        this.watchSymbols = CollectionCopyUtils.copyList(watchSymbols);
-    }
-
-    /**
      * Get the preferred sources with defensive copy.
      *
      * @return the preferred sources list
      */
-    public List<String> getPreferredSources() {
+    public java.util.List<String> getPreferredSources() {
         return CollectionCopyUtils.copyList(preferredSources);
     }
 
@@ -205,7 +166,7 @@ public class UserMemoryProfile {
      *
      * @param preferredSources the preferred sources list
      */
-    public void setPreferredSources(List<String> preferredSources) {
+    public void setPreferredSources(java.util.List<String> preferredSources) {
         this.preferredSources = CollectionCopyUtils.copyList(preferredSources);
     }
 

--- a/koduck-backend/src/main/java/com/koduck/entity/enums/TradeType.java
+++ b/koduck-backend/src/main/java/com/koduck/entity/enums/TradeType.java
@@ -1,0 +1,15 @@
+package com.koduck.entity.enums;
+
+/**
+ * Enumeration of trade types.
+ *
+ * @author Koduck Team
+ */
+public enum TradeType {
+
+    /** Buy trade. */
+    BUY,
+
+    /** Sell trade. */
+    SELL
+}

--- a/koduck-backend/src/main/java/com/koduck/service/MemoryService.java
+++ b/koduck-backend/src/main/java/com/koduck/service/MemoryService.java
@@ -7,18 +7,64 @@ import com.koduck.entity.MemoryChatMessage;
 import com.koduck.entity.MemoryChatSession;
 import com.koduck.entity.UserMemoryProfile;
 
+/**
+ * Service interface for memory operations.
+ *
+ * @author Koduck Team
+ */
 public interface MemoryService {
 
+    /**
+     * Check if memory service is enabled.
+     *
+     * @return true if enabled
+     */
     boolean isEnabled();
 
+    /**
+     * Get max L1 turns.
+     *
+     * @return max turns
+     */
     int getL1MaxTurns();
 
+    /**
+     * Resolve session ID.
+     *
+     * @param input the input
+     * @return the resolved session ID
+     */
     String resolveSessionId(String input);
 
+    /**
+     * Get user sessions.
+     *
+     * @param userId the user ID
+     * @return list of sessions
+     */
     List<MemoryChatSession> getUserSessions(Long userId);
 
+    /**
+     * Ensure session exists.
+     *
+     * @param userId  the user ID
+     * @param sessionId the session ID
+     * @param title   the title
+     * @return the session
+     */
     MemoryChatSession ensureSession(Long userId, String sessionId, String title);
 
+    /**
+     * Append message to session.
+     *
+     * @param userId    the user ID
+     * @param sessionId the session ID
+     * @param role      the role
+     * @param content   the content
+     * @param tokenCount the token count
+     * @param metadata  the metadata
+     * @return the saved message
+     */
     MemoryChatMessage appendMessage(
         Long userId,
         String sessionId,
@@ -28,21 +74,61 @@ public interface MemoryService {
         Map<String, Object> metadata
     );
 
+    /**
+     * Get recent messages.
+     *
+     * @param userId    the user ID
+     * @param sessionId the session ID
+     * @param maxTurns  the max turns
+     * @return list of messages
+     */
     List<MemoryChatMessage> getRecentMessages(Long userId, String sessionId, Integer maxTurns);
 
+    /**
+     * Get or create user profile.
+     *
+     * @param userId the user ID
+     * @return the profile
+     */
     UserMemoryProfile getOrCreateProfile(Long userId);
 
+    /**
+     * Upsert user profile.
+     *
+     * @param userId          the user ID
+     * @param riskPreference  the risk preference
+     * @param preferredSources the preferred sources
+     * @param profileFacts    the profile facts
+     * @return the updated profile
+     */
     UserMemoryProfile upsertProfile(
         Long userId,
         String riskPreference,
-        List<String> watchSymbols,
         List<String> preferredSources,
         Map<String, Object> profileFacts
     );
 
+    /**
+     * Clear session messages.
+     *
+     * @param userId    the user ID
+     * @param sessionId the session ID
+     * @return number of cleared messages
+     */
     int clearSessionMessages(Long userId, String sessionId);
 
+    /**
+     * Delete session.
+     *
+     * @param userId    the user ID
+     * @param sessionId the session ID
+     */
     void deleteSession(Long userId, String sessionId);
 
+    /**
+     * Clear profile.
+     *
+     * @param userId the user ID
+     */
     void clearProfile(Long userId);
 }

--- a/koduck-backend/src/main/java/com/koduck/service/support/AiConversationSupport.java
+++ b/koduck-backend/src/main/java/com/koduck/service/support/AiConversationSupport.java
@@ -46,7 +46,7 @@ public class AiConversationSupport {
     /** MACD period. */
     private static final int MACD_PERIOD = 12;
     /** Max watch symbols. */
-    private static final int MAX_WATCH_SYMBOLS = 30;
+
 
     /** Memory service. */
     private final MemoryService memoryService;
@@ -158,7 +158,7 @@ public class AiConversationSupport {
         CompletableFuture.runAsync(() -> {
             try {
                 memoryService.appendMessage(userId, sessionId, "user", content, null, Map.of("source", "chat-stream"));
-                updateUserProfileFromConversation(userId, content, symbolPattern, riskAggressive, riskConservative,
+                updateUserProfileFromConversation(userId, content, riskAggressive, riskConservative,
                     riskBalanced);
             }
             catch (Exception e) {
@@ -204,20 +204,15 @@ public class AiConversationSupport {
             return false;
         }
         String riskPreference = profile.getRiskPreference();
-        List<String> watchSymbols = profile.getWatchSymbols();
         List<String> preferredSources = profile.getPreferredSources();
         boolean hasRiskPreference = riskPreference != null && !riskPreference.isBlank();
-        boolean hasWatchSymbols = watchSymbols != null && !watchSymbols.isEmpty();
         boolean hasPreferredSources = preferredSources != null && !preferredSources.isEmpty();
-        if (!hasRiskPreference && !hasWatchSymbols && !hasPreferredSources) {
+        if (!hasRiskPreference && !hasPreferredSources) {
             return false;
         }
         builder.append("用户偏好:\n");
         if (hasRiskPreference) {
             builder.append("- risk_preference: ").append(riskPreference).append("\n");
-        }
-        if (hasWatchSymbols) {
-            builder.append("- watch_symbols: ").append(String.join(", ", watchSymbols)).append("\n");
         }
         if (hasPreferredSources) {
             builder.append("- preferred_sources: ").append(String.join(", ", preferredSources)).append("\n");
@@ -383,7 +378,7 @@ public class AiConversationSupport {
         return response.values().get(key);
     }
 
-    private void updateUserProfileFromConversation(Long userId, String latestUserMessage, Pattern symbolPattern,
+    private void updateUserProfileFromConversation(Long userId, String latestUserMessage,
                                                    String riskAggressive, String riskConservative,
                                                    String riskBalanced) {
         if (latestUserMessage == null || latestUserMessage.isBlank()) {
@@ -400,15 +395,6 @@ public class AiConversationSupport {
         else if (latestUserMessage.contains("稳健")) {
             riskPreference = riskBalanced;
         }
-        Set<String> watchSymbols = new LinkedHashSet<>(
-            existing.getWatchSymbols() != null ? existing.getWatchSymbols() : List.of());
-        Matcher matcher = symbolPattern.matcher(latestUserMessage);
-        while (matcher.find()) {
-            watchSymbols.add(matcher.group());
-            if (watchSymbols.size() >= MAX_WATCH_SYMBOLS) {
-                break;
-            }
-        }
         Set<String> preferredSources = new LinkedHashSet<>(
             existing.getPreferredSources() != null ? existing.getPreferredSources() : List.of());
         if (latestUserMessage.contains("财联社")) {
@@ -417,7 +403,7 @@ public class AiConversationSupport {
         if (latestUserMessage.contains("第一财经")) {
             preferredSources.add("yicai");
         }
-        memoryService.upsertProfile(userId, riskPreference, new ArrayList<>(watchSymbols),
+        memoryService.upsertProfile(userId, riskPreference,
             new ArrayList<>(preferredSources), existing.getProfileFacts());
     }
 }

--- a/koduck-backend/src/main/java/com/koduck/shared/application/MemoryServiceImpl.java
+++ b/koduck-backend/src/main/java/com/koduck/shared/application/MemoryServiceImpl.java
@@ -162,7 +162,6 @@ public class MemoryServiceImpl implements MemoryService {
         Long nonNullUserId = Objects.requireNonNull(userId, USER_ID_NULL_MESSAGE);
         return memoryProfileRepository.findById(nonNullUserId).orElseGet(() -> UserMemoryProfile.builder()
             .userId(nonNullUserId)
-            .watchSymbols(List.of())
             .preferredSources(List.of())
             .profileFacts(Map.of())
             .build());
@@ -172,7 +171,6 @@ public class MemoryServiceImpl implements MemoryService {
     public UserMemoryProfile upsertProfile(
         Long userId,
         String riskPreference,
-        List<String> watchSymbols,
         List<String> preferredSources,
         Map<String, Object> profileFacts
     ) {
@@ -182,9 +180,6 @@ public class MemoryServiceImpl implements MemoryService {
             .build());
         if (riskPreference != null) {
             profile.setRiskPreference(riskPreference);
-        }
-        if (watchSymbols != null) {
-            profile.setWatchSymbols(watchSymbols);
         }
         if (preferredSources != null) {
             profile.setPreferredSources(preferredSources);

--- a/koduck-backend/src/main/java/com/koduck/trading/application/BacktestServiceImpl.java
+++ b/koduck-backend/src/main/java/com/koduck/trading/application/BacktestServiceImpl.java
@@ -21,6 +21,7 @@ import com.koduck.entity.BacktestResult;
 import com.koduck.entity.BacktestTrade;
 import com.koduck.entity.Strategy;
 import com.koduck.entity.StrategyVersion;
+import com.koduck.entity.enums.TradeType;
 import com.koduck.exception.BusinessException;
 import com.koduck.exception.ErrorCode;
 import com.koduck.exception.ResourceNotFoundException;
@@ -309,7 +310,7 @@ public class BacktestServiceImpl implements BacktestService {
         context.setEntryPrice(price);
         return BacktestTrade.builder()
             .backtestResultId(backtestResultId)
-            .tradeType(BacktestTrade.TradeType.BUY)
+            .tradeType(TradeType.BUY)
             .tradeTime(LocalDateTime.ofEpochSecond(current.timestamp(), 0, java.time.ZoneOffset.UTC))
             .symbol("SYMBOL")
             .price(price)
@@ -345,7 +346,7 @@ public class BacktestServiceImpl implements BacktestService {
         context.setPosition(BigDecimal.ZERO);
         return BacktestTrade.builder()
             .backtestResultId(backtestResultId)
-            .tradeType(BacktestTrade.TradeType.SELL)
+            .tradeType(TradeType.SELL)
             .tradeTime(LocalDateTime.ofEpochSecond(current.timestamp(), 0, java.time.ZoneOffset.UTC))
             .symbol("SYMBOL")
             .price(price)
@@ -390,7 +391,7 @@ public class BacktestServiceImpl implements BacktestService {
         result.setMaxDrawdown(maxDrawdown);
         // Trade statistics
         List<BacktestTrade> sellTrades = trades.stream()
-            .filter(t -> t.getTradeType() == BacktestTrade.TradeType.SELL)
+            .filter(t -> t.getTradeType() == TradeType.SELL)
             .toList();
         int totalTrades = sellTrades.size();
         int winningTrades = (int) sellTrades.stream()

--- a/koduck-backend/src/main/java/com/koduck/trading/application/PortfolioServiceImpl.java
+++ b/koduck-backend/src/main/java/com/koduck/trading/application/PortfolioServiceImpl.java
@@ -25,6 +25,7 @@ import com.koduck.dto.portfolio.TradeDto;
 import com.koduck.dto.portfolio.UpdatePositionRequest;
 import com.koduck.entity.PortfolioPosition;
 import com.koduck.entity.Trade;
+import com.koduck.entity.enums.TradeType;
 import com.koduck.repository.PortfolioPositionRepository;
 import com.koduck.repository.TradeRepository;
 import com.koduck.service.KlineService;
@@ -288,7 +289,7 @@ public class PortfolioServiceImpl implements PortfolioService {
             .market(request.market())
             .symbol(request.symbol())
             .name(request.name())
-            .tradeType(Trade.TradeType.valueOf(request.tradeType()))
+            .tradeType(TradeType.valueOf(request.tradeType()))
             .quantity(request.quantity())
             .price(request.price())
             .amount(amount)
@@ -310,8 +311,8 @@ public class PortfolioServiceImpl implements PortfolioService {
     private void updatePositionFromTrade(Long userId, AddTradeRequest request) {
         Optional<PortfolioPosition> positionOpt = positionRepository
             .findByUserIdAndMarketAndSymbol(userId, request.market(), request.symbol());
-        Trade.TradeType tradeType = Trade.TradeType.valueOf(request.tradeType());
-        if (tradeType == Trade.TradeType.BUY) {
+        TradeType tradeType = TradeType.valueOf(request.tradeType());
+        if (tradeType == TradeType.BUY) {
             // For buy trades, add to position or create new
             if (positionOpt.isPresent()) {
                 PortfolioPosition position = positionOpt.get();
@@ -337,7 +338,7 @@ public class PortfolioServiceImpl implements PortfolioService {
                     "newPosition must not be null"));
             }
         }
-        else if (tradeType == Trade.TradeType.SELL && positionOpt.isPresent()) {
+        else if (tradeType == TradeType.SELL && positionOpt.isPresent()) {
             // For sell trades, reduce position
             PortfolioPosition position = positionOpt.get();
             BigDecimal remainingQuantity = position.getQuantity().subtract(request.quantity());

--- a/koduck-backend/src/test/java/com/koduck/controller/PortfolioControllerIntegrationTest.java
+++ b/koduck-backend/src/test/java/com/koduck/controller/PortfolioControllerIntegrationTest.java
@@ -27,6 +27,7 @@ import com.koduck.dto.portfolio.PortfolioPositionDto;
 import com.koduck.dto.portfolio.UpdatePositionRequest;
 import com.koduck.entity.PortfolioPosition;
 import com.koduck.entity.Trade;
+import com.koduck.entity.enums.TradeType;
 import com.koduck.repository.PortfolioPositionRepository;
 import com.koduck.repository.TradeRepository;
 
@@ -436,7 +437,7 @@ class PortfolioControllerIntegrationTest extends AbstractIntegrationTest {
                 .market("AShare")
                 .symbol("600519")
                 .name("贵州茅台")
-                .tradeType(Trade.TradeType.BUY)
+                .tradeType(TradeType.BUY)
                 .quantity(new BigDecimal(TEST_QUANTITY_100))
                 .price(new BigDecimal(String.valueOf(TEST_PRICE_1500)))
                 .amount(new BigDecimal("150000.00"))

--- a/koduck-backend/src/test/java/com/koduck/service/MemoryServiceTest.java
+++ b/koduck-backend/src/test/java/com/koduck/service/MemoryServiceTest.java
@@ -227,14 +227,12 @@ class MemoryServiceTest {
         UserMemoryProfile result = memoryService.upsertProfile(
             TEST_USER_ID,
             "balanced",
-            List.of("600519"),
             List.of("cls"),
             Map.of("likes", "value")
         );
 
         assertThat(result.getUserId()).isEqualTo(TEST_USER_ID);
         assertThat(result.getRiskPreference()).isEqualTo("balanced");
-        assertThat(result.getWatchSymbols()).containsExactly("600519");
         assertThat(result.getPreferredSources()).containsExactly("cls");
     }
 }

--- a/koduck-backend/src/test/java/com/koduck/service/PortfolioServiceTest.java
+++ b/koduck-backend/src/test/java/com/koduck/service/PortfolioServiceTest.java
@@ -21,6 +21,7 @@ import com.koduck.dto.portfolio.TradeDto;
 import com.koduck.dto.portfolio.UpdatePositionRequest;
 import com.koduck.entity.PortfolioPosition;
 import com.koduck.entity.Trade;
+import com.koduck.entity.enums.TradeType;
 import com.koduck.repository.PortfolioPositionRepository;
 import com.koduck.repository.TradeRepository;
 import com.koduck.trading.application.PortfolioServiceImpl;
@@ -488,7 +489,7 @@ class PortfolioServiceTest {
                 .market("AShare")
                 .symbol("600519")
                 .name("贵州茅台")
-                .tradeType(Trade.TradeType.BUY)
+                .tradeType(TradeType.BUY)
                 .quantity(new BigDecimal("50"))
                 .price(new BigDecimal("1600.00"))
                 .amount(new BigDecimal("80000.00"))
@@ -531,7 +532,7 @@ class PortfolioServiceTest {
                 .market("AShare")
                 .symbol("600519")
                 .name("贵州茅台")
-                .tradeType(Trade.TradeType.SELL)
+                .tradeType(TradeType.SELL)
                 .quantity(new BigDecimal("30"))
                 .price(new BigDecimal("1650.00"))
                 .amount(new BigDecimal("49500.00"))
@@ -574,7 +575,7 @@ class PortfolioServiceTest {
                 .market("AShare")
                 .symbol("600519")
                 .name("贵州茅台")
-                .tradeType(Trade.TradeType.SELL)
+                .tradeType(TradeType.SELL)
                 .quantity(new BigDecimal("100"))
                 .price(new BigDecimal("1650.00"))
                 .amount(new BigDecimal("165000.00"))


### PR DESCRIPTION
## 变更内容

根据 entity-redundancy-analysis.md 分析报告，消除 Entity 层冗余：

### 1. TradeType 枚举提取
- 创建 **entity/enums/TradeType.java** 共享枚举
- 更新 Trade.java 引用共享枚举（删除内嵌枚举 ~10 行）
- 更新 BacktestTrade.java 引用共享枚举（删除内嵌枚举 ~8 行）
- 更新所有调用方：PortfolioServiceImpl、BacktestServiceImpl、测试文件

### 2. UserMemoryProfile 清理
- 删除 **watchSymbols** JSONB 字段
- 删除相关的 Builder 方法、getter/setter（~40 行）
- 更新 MemoryService 接口和实现
- 更新 AiConversationSupport（移除 watchSymbols 提取逻辑）
- 更新 MemoryServiceTest 测试

## 影响
- 消除重复 TradeType 枚举定义（代码级冗余）
- 统一关注列表入口（通过 WatchlistItem 表，消除数据冗余）
- 减少数据不一致风险

## 验收标准

- [x] `mvn clean compile` 编译通过
- [x] `mvn checkstyle:check` 无告警
- [x] 单元测试通过
- [x] 轻量 ADR 已创建 (ADR-0049)

Closes #390