### PR TITLE
refactor(constant): 消除 koduck-backend 常量重复定义

### DIFF
--- a/koduck-backend/docs/ADR-0052-constant-redundancy-elimination.md
+++ b/koduck-backend/docs/ADR-0052-constant-redundancy-elimination.md
@@ -1,0 +1,78 @@
+# ADR-0052: Constant 层冗余消除
+
+- Status: Accepted
+- Date: 2026-04-03
+- Issue: #396
+
+## Context
+
+根据 `koduck-backend/docs/constant-redundancy-analysis.md` 分析报告，koduck-backend 存在大量常量重复定义问题：
+
+- 16 组重复定义的常量
+- 涉及 20+ 个文件
+- 违反 DRY 原则，增加维护成本
+
+### 冗余类型
+
+1. **完全重复定义**：同值同变量名在不同文件中独立定义（如 `KEY_SYMBOL = "symbol"` 出现在 3 个文件）
+2. **重复包装已集中常量**：本地变量包装 `MarketConstants` 已有常量
+3. **同值不同变量名**：相同概念使用不同变量名（如 `ZoneId.of("Asia/Shanghai")` 出现在 4 个文件）
+
+## Decision
+
+### 决策 1: 新增集中常量类
+
+| 新常量类 | 职责 | 包含常量 |
+|----------|------|---------|
+| `MapKeyConstants` | Map 字段键名 | `KEY_SYMBOL`, `KEY_NAME`, `KEY_CONTENT` |
+| `LlmConstants` | LLM 提供商相关 | `PROVIDER_MINIMAX`, `ENV_LLM_API_BASE` |
+| `AiConstants` | AI 分析相关 | `RISK_AGGRESSIVE`, `RISK_CONSERVATIVE` |
+| `DataServicePathConstants` | 数据服务路径 | `A_SHARE_BASE_PATH` |
+
+### 决策 2: 扩展现有常量类
+
+| 现有类 | 新增常量 |
+|--------|---------|
+| `MarketConstants` | `STOCK_TYPE`, `A_SHARE_INDEX_SYMBOL`, `ALL_TIMEFRAMES` |
+| `DateTimePatternConstants` | `MARKET_ZONE_ID` (重命名为 `DateTimeConstants`) |
+
+### 决策 3: 消除冗余包装
+
+删除本地变量包装，直接引用 `MarketConstants`：
+- `DEFAULT_TIMEFRAME = MarketConstants.DEFAULT_TIMEFRAME` → 直接引用
+- `DEFAULT_MARKET = MarketConstants.DEFAULT_MARKET` → 直接引用
+
+## Consequences
+
+### 正向影响
+
+- 消除代码重复，统一常量管理
+- 提高可维护性，减少变更遗漏风险
+- 符合 DRY 原则
+
+### 消极影响
+
+- 需要修改多个文件（20+ 个）
+- 需要创建 4 个新常量类
+- 有一定的代码变更量
+
+### 兼容性
+
+| 方面 | 影响 | 说明 |
+|-----|------|------|
+| API 接口 | 无 | 常量变更不影响 API |
+| 业务逻辑 | 无 | 常量值保持不变 |
+| 序列化 | 无 | 不涉及实体变更 |
+| 测试 | 低 | 需验证常量引用正确 |
+
+## 实施顺序
+
+1. 先新增常量类和常量字段
+2. 逐步替换引用（按模块分批）
+3. 删除冗余的本地常量定义
+4. 运行质量检查确保全绿
+
+## Related
+
+- Issue #396
+- `koduck-backend/docs/constant-redundancy-analysis.md`

--- a/koduck-backend/src/main/java/com/koduck/common/constants/AiConstants.java
+++ b/koduck-backend/src/main/java/com/koduck/common/constants/AiConstants.java
@@ -1,0 +1,21 @@
+package com.koduck.common.constants;
+
+/**
+ * AI analysis related constants.
+ *
+ * @author Koduck Team
+ */
+public final class AiConstants {
+
+    /** Aggressive risk preference. */
+    public static final String RISK_AGGRESSIVE = "aggressive";
+
+    /** Conservative risk preference. */
+    public static final String RISK_CONSERVATIVE = "conservative";
+
+    /** Balanced risk preference. */
+    public static final String RISK_BALANCED = "balanced";
+
+    private AiConstants() {
+    }
+}

--- a/koduck-backend/src/main/java/com/koduck/common/constants/DataServicePathConstants.java
+++ b/koduck-backend/src/main/java/com/koduck/common/constants/DataServicePathConstants.java
@@ -1,0 +1,24 @@
+package com.koduck.common.constants;
+
+/**
+ * Data service API path constants.
+ *
+ * @author Koduck Team
+ */
+public final class DataServicePathConstants {
+
+    /** A-Share base path. */
+    public static final String A_SHARE_BASE_PATH = "/a-share";
+
+    /** HK Stock base path. */
+    public static final String HK_STOCK_BASE_PATH = "/hk-stock";
+
+    /** Forex base path. */
+    public static final String FOREX_BASE_PATH = "/forex";
+
+    /** Futures base path. */
+    public static final String FUTURES_BASE_PATH = "/futures";
+
+    private DataServicePathConstants() {
+    }
+}

--- a/koduck-backend/src/main/java/com/koduck/common/constants/DateTimePatternConstants.java
+++ b/koduck-backend/src/main/java/com/koduck/common/constants/DateTimePatternConstants.java
@@ -1,5 +1,7 @@
 package com.koduck.common.constants;
 
+import java.time.ZoneId;
+
 /**
  * Common date-time pattern constants used across backend modules.
  *
@@ -11,6 +13,16 @@ public final class DateTimePatternConstants {
      * Standard date-time pattern.
      */
     public static final String STANDARD_DATE_TIME_PATTERN = "yyyy-MM-dd HH:mm:ss";
+
+    /**
+     * Market time zone (Asia/Shanghai).
+     */
+    public static final ZoneId MARKET_ZONE_ID = ZoneId.of("Asia/Shanghai");
+
+    /**
+     * Market time zone string identifier.
+     */
+    public static final String TIMEZONE_ASIA_SHANGHAI = "Asia/Shanghai";
 
     private DateTimePatternConstants() {
     }

--- a/koduck-backend/src/main/java/com/koduck/common/constants/LlmConstants.java
+++ b/koduck-backend/src/main/java/com/koduck/common/constants/LlmConstants.java
@@ -1,0 +1,27 @@
+package com.koduck.common.constants;
+
+/**
+ * LLM provider and configuration constants.
+ *
+ * @author Koduck Team
+ */
+public final class LlmConstants {
+
+    /** Minimax provider identifier. */
+    public static final String PROVIDER_MINIMAX = "minimax";
+
+    /** DeepSeek provider identifier. */
+    public static final String PROVIDER_DEEPSEEK = "deepseek";
+
+    /** OpenAI provider identifier. */
+    public static final String PROVIDER_OPENAI = "openai";
+
+    /** Environment variable name for LLM API base URL. */
+    public static final String ENV_LLM_API_BASE = "LLM_API_BASE";
+
+    /** Environment variable name for LLM API key. */
+    public static final String ENV_LLM_API_KEY = "LLM_API_KEY";
+
+    private LlmConstants() {
+    }
+}

--- a/koduck-backend/src/main/java/com/koduck/common/constants/MapKeyConstants.java
+++ b/koduck-backend/src/main/java/com/koduck/common/constants/MapKeyConstants.java
@@ -1,0 +1,30 @@
+package com.koduck.common.constants;
+
+/**
+ * Common Map key constants used across backend modules.
+ *
+ * @author Koduck Team
+ */
+public final class MapKeyConstants {
+
+    /** Key for symbol field. */
+    public static final String KEY_SYMBOL = "symbol";
+
+    /** Key for name field. */
+    public static final String KEY_NAME = "name";
+
+    /** Key for content field. */
+    public static final String KEY_CONTENT = "content";
+
+    /** Key for volume field. */
+    public static final String KEY_VOLUME = "volume";
+
+    /** Key for amount field. */
+    public static final String KEY_AMOUNT = "amount";
+
+    /** Key for change percent field. */
+    public static final String KEY_CHANGE_PERCENT = "changePercent";
+
+    private MapKeyConstants() {
+    }
+}

--- a/koduck-backend/src/main/java/com/koduck/common/constants/MarketConstants.java
+++ b/koduck-backend/src/main/java/com/koduck/common/constants/MarketConstants.java
@@ -31,6 +31,20 @@ public final class MarketConstants {
     /** Default market breadth type (all A-shares). */
     public static final String DEFAULT_BREADTH_TYPE = "ALL_A";
 
+    /** Stock type identifier. */
+    public static final String STOCK_TYPE = "STOCK";
+
+    /** A-Share index symbol (上证指数). */
+    public static final String A_SHARE_INDEX_SYMBOL = "000001";
+
+    /** All supported timeframe values (immutable). */
+    private static final String[] ALL_TIMEFRAMES = {
+        "1m", "5m", "15m", "30m", "60m", "1D", "1W", "1M"
+    };
+
+    /** Immutable list of all supported timeframes. */
+    public static final java.util.List<String> ALL_TIMEFRAMES_LIST = java.util.List.of(ALL_TIMEFRAMES);
+
     private MarketConstants() {
     }
 }

--- a/koduck-backend/src/main/java/com/koduck/controller/MarketAdvancedController.java
+++ b/koduck-backend/src/main/java/com/koduck/controller/MarketAdvancedController.java
@@ -34,6 +34,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 import com.koduck.common.constants.ApiMessageConstants;
 import com.koduck.common.constants.ApiStatusCodeConstants;
+import com.koduck.common.constants.DateTimePatternConstants;
 import com.koduck.common.constants.MarketConstants;
 import com.koduck.common.constants.PaginationConstants;
 import com.koduck.config.properties.DataServiceProperties;
@@ -80,7 +81,7 @@ import lombok.extern.slf4j.Slf4j;
 public class MarketAdvancedController {
 
     /** Market timezone (Asia/Shanghai). */
-    private static final ZoneId MARKET_ZONE = ZoneId.of("Asia/Shanghai");
+    private static final ZoneId MARKET_ZONE = DateTimePatternConstants.MARKET_ZONE_ID;
 
     /** Fear greed index API path. */
     private static final String FEAR_GREED_INDEX_PATH = System.getProperty(

--- a/koduck-backend/src/main/java/com/koduck/service/impl/AiAnalysisServiceImpl.java
+++ b/koduck-backend/src/main/java/com/koduck/service/impl/AiAnalysisServiceImpl.java
@@ -26,6 +26,8 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import com.koduck.common.constants.AiConstants;
+import com.koduck.common.constants.MapKeyConstants;
 import com.koduck.config.AgentConfig;
 import com.koduck.dto.ai.BacktestInterpretResponse;
 import com.koduck.dto.ai.ChatStreamRequest;
@@ -73,13 +75,13 @@ public class AiAnalysisServiceImpl implements AiAnalysisService {
     private static final String KEY_MESSAGE = "message";
 
     /** Key for content in response. */
-    private static final String KEY_CONTENT = "content";
+    private static final String KEY_CONTENT = MapKeyConstants.KEY_CONTENT;
 
     /** Risk level: aggressive. */
-    private static final String RISK_AGGRESSIVE = "aggressive";
+    private static final String RISK_AGGRESSIVE = AiConstants.RISK_AGGRESSIVE;
 
     /** Risk level: conservative. */
-    private static final String RISK_CONSERVATIVE = "conservative";
+    private static final String RISK_CONSERVATIVE = AiConstants.RISK_CONSERVATIVE;
 
     /** Risk level: balanced. */
     private static final String RISK_BALANCED = "balanced";

--- a/koduck-backend/src/main/java/com/koduck/service/impl/BacktestServiceImpl.java
+++ b/koduck-backend/src/main/java/com/koduck/service/impl/BacktestServiceImpl.java
@@ -67,8 +67,6 @@ public class BacktestServiceImpl implements BacktestService {
 
     /** The decimal scale. */
     private static final int SCALE = 4;
-    /** The default timeframe. */
-    private static final String DEFAULT_TIMEFRAME = MarketConstants.DEFAULT_TIMEFRAME;
     /** The kline data limit. */
     private static final int KLINE_DATA_LIMIT = 1000;
     /** The seconds per day. */
@@ -133,7 +131,7 @@ public class BacktestServiceImpl implements BacktestService {
             .symbol(request.symbol())
             .startDate(request.startDate())
             .endDate(request.endDate())
-            .timeframe(request.timeframe() != null ? request.timeframe() : DEFAULT_TIMEFRAME)
+            .timeframe(request.timeframe() != null ? request.timeframe() : MarketConstants.DEFAULT_TIMEFRAME)
             .initialCapital(request.initialCapital())
             .commissionRate(request.commissionRate() != null ? request.commissionRate() : new BigDecimal("0.001"))
             .slippage(request.slippage() != null ? request.slippage() : new BigDecimal("0.001"))
@@ -192,7 +190,7 @@ public class BacktestServiceImpl implements BacktestService {
      */
     private void executeBacktest(BacktestResult result) {
         // Get historical data
-        String timeframe = result.getTimeframe() != null ? result.getTimeframe() : DEFAULT_TIMEFRAME;
+        String timeframe = result.getTimeframe() != null ? result.getTimeframe() : MarketConstants.DEFAULT_TIMEFRAME;
         List<KlineDataDto> klineData = klineService.getKlineData(
             result.getMarket(), result.getSymbol(), timeframe, KLINE_DATA_LIMIT, null);
         if (klineData.isEmpty()) {

--- a/koduck-backend/src/main/java/com/koduck/service/impl/KlineServiceImpl.java
+++ b/koduck-backend/src/main/java/com/koduck/service/impl/KlineServiceImpl.java
@@ -5,6 +5,8 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
+
+import com.koduck.common.constants.DateTimePatternConstants;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
@@ -39,11 +41,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class KlineServiceImpl implements KlineService {
 
-    private static final ZoneId MARKET_ZONE = ZoneId.of("Asia/Shanghai");
-    private static final String DEFAULT_MARKET = MarketConstants.DEFAULT_MARKET;
-    private static final String DEFAULT_TIMEFRAME = MarketConstants.DEFAULT_TIMEFRAME;
-    private static final String WEEKLY_TIMEFRAME = MarketConstants.WEEKLY_TIMEFRAME;
-    private static final String MONTHLY_TIMEFRAME = MarketConstants.MONTHLY_TIMEFRAME;
+    private static final ZoneId MARKET_ZONE = DateTimePatternConstants.MARKET_ZONE_ID;
 
     private final KlineDataRepository klineDataRepository;
     private final StockRealtimeRepository stockRealtimeRepository;
@@ -177,14 +175,14 @@ public class KlineServiceImpl implements KlineService {
     private List<String> buildMarketCandidates(String market) {
         // Strict match only - avoid cross-market data mixing
         if (market == null || market.isBlank()) {
-            return List.of(DEFAULT_MARKET);
+            return List.of(MarketConstants.DEFAULT_MARKET);
         }
         return List.of(market.trim());
     }
     private List<String> buildTimeframeCandidates(String timeframe) {
         LinkedHashSet<String> candidates = new LinkedHashSet<>();
         if (timeframe == null || timeframe.isBlank()) {
-            candidates.add(DEFAULT_TIMEFRAME);
+            candidates.add(MarketConstants.DEFAULT_TIMEFRAME);
             return new ArrayList<>(candidates);
         }
         String normalized = timeframe.trim();
@@ -215,9 +213,9 @@ public class KlineServiceImpl implements KlineService {
     private String normalizeTimeframeAlias(String timeframe) {
         String lower = timeframe.toLowerCase(Locale.ROOT);
         return switch (lower) {
-            case "1d", "day", "daily" -> DEFAULT_TIMEFRAME;
-            case "1w", "week", "weekly" -> WEEKLY_TIMEFRAME;
-            case "month", "monthly", "1mo", "1mth" -> MONTHLY_TIMEFRAME;
+            case "1d", "day", "daily" -> MarketConstants.DEFAULT_TIMEFRAME;
+            case "1w", "week", "weekly" -> MarketConstants.WEEKLY_TIMEFRAME;
+            case "month", "monthly", "1mo", "1mth" -> MarketConstants.MONTHLY_TIMEFRAME;
             default -> timeframe;
         };
     }
@@ -279,9 +277,9 @@ public class KlineServiceImpl implements KlineService {
             return data;
         }
         boolean isDailyOrHigher = timeframe != null && 
-            (timeframe.equalsIgnoreCase(DEFAULT_TIMEFRAME) || 
-             timeframe.equalsIgnoreCase(WEEKLY_TIMEFRAME) || 
-             timeframe.equalsIgnoreCase(MONTHLY_TIMEFRAME) ||
+            (timeframe.equalsIgnoreCase(MarketConstants.DEFAULT_TIMEFRAME) || 
+             timeframe.equalsIgnoreCase(MarketConstants.WEEKLY_TIMEFRAME) || 
+             timeframe.equalsIgnoreCase(MarketConstants.MONTHLY_TIMEFRAME) ||
              timeframe.toLowerCase(Locale.ROOT).matches("^(day|daily|week|weekly|month|monthly|1mth|1mo)$"));
         java.util.LinkedHashMap<Long, KlineDataDto> uniqueMap = new java.util.LinkedHashMap<>();
         for (KlineDataDto item : data) {

--- a/koduck-backend/src/main/java/com/koduck/service/impl/KlineSyncServiceImpl.java
+++ b/koduck-backend/src/main/java/com/koduck/service/impl/KlineSyncServiceImpl.java
@@ -18,6 +18,7 @@ import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import com.koduck.common.constants.DataServicePathConstants;
 import com.koduck.common.constants.MarketConstants;
 import com.koduck.config.properties.DataServiceProperties;
 import com.koduck.dto.market.DataServiceResponse;
@@ -49,14 +50,7 @@ public class KlineSyncServiceImpl implements KlineSyncService {
     /** Mapper for K-line data DTO conversion. */
     private final KlineDataDtoMapper klineDataDtoMapper;
 
-    /** Base path for A-share API. */
-    private static final String A_SHARE_BASE_PATH = "/a-share";
-
-    /** Default market. */
-    private static final String DEFAULT_MARKET = MarketConstants.DEFAULT_MARKET;
-
-    /** Default timeframe. */
-    private static final String DEFAULT_TIMEFRAME = MarketConstants.DEFAULT_TIMEFRAME;
+    // Using constants from MarketConstants and DataServicePathConstants directly
 
     /** Default interval between batch operations (milliseconds). */
     private static final long DEFAULT_BATCH_INTERVAL_MILLIS = 500L;
@@ -102,7 +96,7 @@ public class KlineSyncServiceImpl implements KlineSyncService {
         log.info("Starting daily K-line data sync");
         // Popular A-share stocks to sync
         List<String> popularSymbols = List.of(
-            "000001",
+            MarketConstants.A_SHARE_INDEX_SYMBOL,
             "000002",
             "000858",
             "002326",
@@ -113,7 +107,7 @@ public class KlineSyncServiceImpl implements KlineSyncService {
         );
         for (String symbol : popularSymbols) {
             try {
-                syncSymbolKlineInternal(DEFAULT_MARKET, symbol, DEFAULT_TIMEFRAME);
+                syncSymbolKlineInternal(MarketConstants.DEFAULT_MARKET, symbol, MarketConstants.DEFAULT_TIMEFRAME);
                 // Avoid rate limiting
                 Thread.sleep(SYNC_SLEEP_MILLIS);
             }
@@ -205,7 +199,7 @@ public class KlineSyncServiceImpl implements KlineSyncService {
         try {
             log.debug("Syncing K-line data for {}/{}/{}", market, symbol, timeframe);
             java.net.URI requestUri = UriComponentsBuilder
-                    .fromUriString(properties.getBaseUrl() + A_SHARE_BASE_PATH + "/kline")
+                    .fromUriString(properties.getBaseUrl() + DataServicePathConstants.A_SHARE_BASE_PATH + "/kline")
                     .queryParam("symbol", symbol)
                     .queryParam("timeframe", timeframe)
                     .queryParam("limit", DEFAULT_KLINE_QUERY_LIMIT)

--- a/koduck-backend/src/main/java/com/koduck/service/impl/MarketSentimentServiceImpl.java
+++ b/koduck-backend/src/main/java/com/koduck/service/impl/MarketSentimentServiceImpl.java
@@ -157,7 +157,7 @@ public class MarketSentimentServiceImpl implements MarketSentimentService {
     /**
      * Shanghai Composite Index as representative for A-share market.
      */
-    private static final String A_SHARE_INDEX = "000001";
+    private static final String A_SHARE_INDEX = MarketConstants.A_SHARE_INDEX_SYMBOL;
 
     /**
      * Tencent (00700) as proxy for HK market.

--- a/koduck-backend/src/main/java/com/koduck/service/impl/MarketServiceImpl.java
+++ b/koduck-backend/src/main/java/com/koduck/service/impl/MarketServiceImpl.java
@@ -13,6 +13,7 @@ import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
+import com.koduck.common.constants.MarketConstants;
 import com.koduck.config.CacheConfig;
 import com.koduck.dto.market.MarketIndexDto;
 import com.koduck.dto.market.PriceQuoteDto;
@@ -45,9 +46,9 @@ public class MarketServiceImpl implements MarketService {
     
     // Main index symbols
     private static final List<String> MAIN_INDICES = List.of(
-            "000001",  // 
-            "399001",  // 
-            "399006"   // 
+            MarketConstants.A_SHARE_INDEX_SYMBOL,  // 上证指数
+            "399001",     // 深证成指
+            "399006"      // 创业板指
     );
     
     private final StockRealtimeRepository stockRealtimeRepository;

--- a/koduck-backend/src/main/java/com/koduck/service/impl/PortfolioServiceImpl.java
+++ b/koduck-backend/src/main/java/com/koduck/service/impl/PortfolioServiceImpl.java
@@ -51,8 +51,7 @@ public class PortfolioServiceImpl implements PortfolioService {
     /** Service for K-line data. */
     private final KlineService klineService;
 
-    /** Default timeframe for price queries. */
-    private static final String DEFAULT_TIMEFRAME = MarketConstants.DEFAULT_TIMEFRAME;
+    // Use MarketConstants.MarketConstants.DEFAULT_TIMEFRAME directly
 
     /** Error message for null position. */
     private static final String POSITION_NULL_MESSAGE = "position must not be null";
@@ -103,7 +102,7 @@ public class PortfolioServiceImpl implements PortfolioService {
         BigDecimal totalDailyPnl = BigDecimal.ZERO;
         for (PortfolioPosition position : positions) {
             Optional<BigDecimal> currentPriceOpt = klineService.getLatestPrice(
-                position.getMarket(), position.getSymbol(), DEFAULT_TIMEFRAME);
+                position.getMarket(), position.getSymbol(), MarketConstants.DEFAULT_TIMEFRAME);
             BigDecimal currentPrice = currentPriceOpt.orElse(position.getAvgCost());
             BigDecimal cost = position.getAvgCost().multiply(position.getQuantity());
             BigDecimal marketValue = currentPrice.multiply(position.getQuantity());
@@ -142,7 +141,7 @@ public class PortfolioServiceImpl implements PortfolioService {
     private Optional<BigDecimal> calculatePositionDailyPnl(
             PortfolioPosition position, BigDecimal currentPrice) {
         Optional<BigDecimal> prevCloseOpt = klineService.getPreviousClosePrice(
-            position.getMarket(), position.getSymbol(), DEFAULT_TIMEFRAME);
+            position.getMarket(), position.getSymbol(), MarketConstants.DEFAULT_TIMEFRAME);
         if (prevCloseOpt.isEmpty()) {
             log.warn("Previous close price not available for {}/{}, skipping daily PnL calculation",
                 position.getMarket(), position.getSymbol());
@@ -364,7 +363,7 @@ public class PortfolioServiceImpl implements PortfolioService {
     private PortfolioPositionDto convertToDtoWithCalculations(PortfolioPosition position) {
         // Get real-time price
         Optional<BigDecimal> currentPriceOpt = klineService.getLatestPrice(
-            position.getMarket(), position.getSymbol(), DEFAULT_TIMEFRAME);
+            position.getMarket(), position.getSymbol(), MarketConstants.DEFAULT_TIMEFRAME);
         BigDecimal currentPrice = currentPriceOpt.orElse(position.getAvgCost());
         BigDecimal marketValue = currentPrice.multiply(position.getQuantity());
         BigDecimal cost = position.getAvgCost().multiply(position.getQuantity());

--- a/koduck-backend/src/main/java/com/koduck/service/impl/StockCacheServiceImpl.java
+++ b/koduck-backend/src/main/java/com/koduck/service/impl/StockCacheServiceImpl.java
@@ -10,6 +10,7 @@ import java.util.function.Consumer;
 
 import org.springframework.stereotype.Service;
 
+import com.koduck.common.constants.MapKeyConstants;
 import com.koduck.common.constants.RedisKeyConstants;
 import com.koduck.dto.market.PriceQuoteDto;
 import com.koduck.service.StockCacheService;
@@ -31,10 +32,10 @@ public class StockCacheServiceImpl implements StockCacheService {
     private static final String KEY_NULL_MESSAGE = "key must not be null";
 
     /** Key for symbol field in map. */
-    private static final String KEY_SYMBOL = "symbol";
+    private static final String KEY_SYMBOL = MapKeyConstants.KEY_SYMBOL;
 
     /** Key for name field in map. */
-    private static final String KEY_NAME = "name";
+    private static final String KEY_NAME = MapKeyConstants.KEY_NAME;
 
     /** Key for type field in map. */
     private static final String KEY_TYPE = "type";

--- a/koduck-backend/src/main/java/com/koduck/service/impl/StrategyServiceImpl.java
+++ b/koduck-backend/src/main/java/com/koduck/service/impl/StrategyServiceImpl.java
@@ -43,7 +43,7 @@ import static com.koduck.util.ServiceValidationUtils.requireFound;
 @RequiredArgsConstructor
 public class StrategyServiceImpl implements StrategyService {
 
-    private static final String DEFAULT_TEMPLATE_SYMBOL = "000001";
+    private static final String DEFAULT_TEMPLATE_SYMBOL = MarketConstants.A_SHARE_INDEX_SYMBOL;
     private static final String TEMPLATE_SYMBOL_PLACEHOLDER = "__DEFAULT_SYMBOL__";
     private static final String TEMPLATE_MARKET_PLACEHOLDER = "__DEFAULT_MARKET__";
 

--- a/koduck-backend/src/main/java/com/koduck/service/impl/SyntheticTickServiceImpl.java
+++ b/koduck-backend/src/main/java/com/koduck/service/impl/SyntheticTickServiceImpl.java
@@ -4,6 +4,8 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+
+import com.koduck.common.constants.DateTimePatternConstants;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -34,7 +36,7 @@ import lombok.extern.slf4j.Slf4j;
 public class SyntheticTickServiceImpl implements SyntheticTickService {
 
     /** The market timezone (Asia/Shanghai). */
-    private static final ZoneId MARKET_ZONE = ZoneId.of("Asia/Shanghai");
+    private static final ZoneId MARKET_ZONE = DateTimePatternConstants.MARKET_ZONE_ID;
 
     /** Time formatter for tick timestamps (HH:mm:ss). */
     private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm:ss");

--- a/koduck-backend/src/main/java/com/koduck/service/impl/UserSettingsServiceImpl.java
+++ b/koduck-backend/src/main/java/com/koduck/service/impl/UserSettingsServiceImpl.java
@@ -18,6 +18,7 @@ import com.koduck.entity.UserSettings;
 import com.koduck.mapper.UserSettingsMapper;
 import com.koduck.repository.UserSettingsRepository;
 import com.koduck.service.UserSettingsService;
+import com.koduck.common.constants.LlmConstants;
 import com.koduck.service.support.UserSettingsLlmConfigSupport;
 
 import lombok.RequiredArgsConstructor;
@@ -33,7 +34,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class UserSettingsServiceImpl implements UserSettingsService {
 
-    private static final String PROVIDER_MINIMAX = "minimax";
+    private static final String PROVIDER_MINIMAX = LlmConstants.PROVIDER_MINIMAX;
 
     private final UserSettingsRepository settingsRepository;
 

--- a/koduck-backend/src/main/java/com/koduck/service/market/AKShareDataProvider.java
+++ b/koduck-backend/src/main/java/com/koduck/service/market/AKShareDataProvider.java
@@ -21,6 +21,8 @@ import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import com.koduck.common.constants.DataServicePathConstants;
+import com.koduck.common.constants.MapKeyConstants;
 import com.koduck.config.properties.DataServiceProperties;
 import com.koduck.dto.market.DataServiceResponse;
 import com.koduck.dto.market.PriceQuoteDto;
@@ -49,9 +51,9 @@ public class AKShareDataProvider implements MarketDataProvider {
     /** Data service disabled message. */
     private static final String DATA_SERVICE_DISABLED_MESSAGE = "Data service is disabled";
     /** A-share base path. */
-    private static final String A_SHARE_BASE_PATH = "/a-share";
+    private static final String A_SHARE_BASE_PATH = DataServicePathConstants.A_SHARE_BASE_PATH;
     /** Key symbol. */
-    private static final String KEY_SYMBOL = "symbol";
+    private static final String KEY_SYMBOL = MapKeyConstants.KEY_SYMBOL;
     /** Key limit. */
     private static final String KEY_LIMIT = "limit";
     /** Response type message. */

--- a/koduck-backend/src/main/java/com/koduck/service/market/FuturesProvider.java
+++ b/koduck-backend/src/main/java/com/koduck/service/market/FuturesProvider.java
@@ -18,6 +18,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
+import com.koduck.common.constants.DateTimePatternConstants;
 import com.koduck.config.properties.DataServiceProperties;
 import com.koduck.market.MarketType;
 import com.koduck.market.model.KlineData;
@@ -45,7 +46,7 @@ public class FuturesProvider extends AbstractDataServiceMarketProvider {
     /**
      * Beijing timezone for market hours calculation.
      */
-    private static final ZoneId BEIJING_ZONE = ZoneId.of("Asia/Shanghai");
+    private static final ZoneId BEIJING_ZONE = DateTimePatternConstants.MARKET_ZONE_ID;
 
     /**
      * Base path for futures data service endpoints.

--- a/koduck-backend/src/main/java/com/koduck/service/market/support/AKShareDataMapperSupport.java
+++ b/koduck-backend/src/main/java/com/koduck/service/market/support/AKShareDataMapperSupport.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import com.koduck.common.constants.MapKeyConstants;
 import com.koduck.dto.market.PriceQuoteDto;
 import com.koduck.dto.market.StockIndustryDto;
 import com.koduck.dto.market.StockValuationDto;
@@ -23,10 +24,10 @@ import com.koduck.market.util.DataConverter;
 public final class AKShareDataMapperSupport {
 
     /** The key for symbol field. */
-    private static final String KEY_SYMBOL = "symbol";
+    private static final String KEY_SYMBOL = MapKeyConstants.KEY_SYMBOL;
 
     /** The key for name field. */
-    private static final String KEY_NAME = "name";
+    private static final String KEY_NAME = MapKeyConstants.KEY_NAME;
 
     /** The key for volume field. */
     private static final String KEY_VOLUME = "volume";

--- a/koduck-backend/src/main/java/com/koduck/service/support/AiRecommendationSupport.java
+++ b/koduck-backend/src/main/java/com/koduck/service/support/AiRecommendationSupport.java
@@ -9,6 +9,7 @@ import java.util.Random;
 
 import org.springframework.stereotype.Component;
 
+import com.koduck.common.constants.AiConstants;
 import com.koduck.dto.ai.BacktestInterpretResponse;
 import com.koduck.dto.ai.RiskAssessmentResponse;
 import com.koduck.dto.ai.StrategyRecommendRequest;
@@ -26,9 +27,9 @@ import com.koduck.entity.Strategy;
 public class AiRecommendationSupport {
 
     /** 激进型风险偏好。 */
-    private static final String RISK_AGGRESSIVE = "aggressive";
+    private static final String RISK_AGGRESSIVE = AiConstants.RISK_AGGRESSIVE;
     /** 保守型风险偏好。 */
-    private static final String RISK_CONSERVATIVE = "conservative";
+    private static final String RISK_CONSERVATIVE = AiConstants.RISK_CONSERVATIVE;
     /** 策略类型：均线交叉。 */
     private static final String STRATEGY_TYPE_MA_CROSS = "MA_CROSS";
     /** 美国市场。 */

--- a/koduck-backend/src/main/java/com/koduck/service/support/AiStreamRelaySupport.java
+++ b/koduck-backend/src/main/java/com/koduck/service/support/AiStreamRelaySupport.java
@@ -14,6 +14,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import com.koduck.common.constants.MapKeyConstants;
 import com.koduck.dto.ai.ChatStreamRequest;
 
 import lombok.RequiredArgsConstructor;
@@ -33,7 +34,7 @@ public class AiStreamRelaySupport {
     /** Event name for done. */
     private static final String EVENT_DONE = "done";
     /** Key for content. */
-    private static final String KEY_CONTENT = "content";
+    private static final String KEY_CONTENT = MapKeyConstants.KEY_CONTENT;
     /** Type reference for Map<String, Object>. */
     private static final TypeReference<Map<String, Object>> MAP_TYPE_REFERENCE = new TypeReference<>() {
     };

--- a/koduck-backend/src/main/java/com/koduck/service/support/MarketFallbackSupport.java
+++ b/koduck-backend/src/main/java/com/koduck/service/support/MarketFallbackSupport.java
@@ -38,14 +38,8 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class MarketFallbackSupport {
 
-    /** Default market code. */
-    private static final String DEFAULT_MARKET = MarketConstants.DEFAULT_MARKET;
-
-    /** Daily timeframe constant. */
-    private static final String DAILY_TIMEFRAME = MarketConstants.DEFAULT_TIMEFRAME;
-
     /** Stock type identifier. */
-    private static final String STOCK_TYPE = "STOCK";
+    private static final String STOCK_TYPE = MarketConstants.STOCK_TYPE;
 
     /** Repository for stock basic information. */
     private final StockBasicRepository stockBasicRepository;
@@ -95,7 +89,7 @@ public class MarketFallbackSupport {
             }
             String normalizedSymbol = SymbolUtils.normalize(symbolInfo.symbol());
             String market = symbolInfo.market() == null || symbolInfo.market().isBlank()
-                ? DEFAULT_MARKET
+                ? MarketConstants.DEFAULT_MARKET
                 : symbolInfo.market();
             String name = symbolInfo.name() == null || symbolInfo.name().isBlank()
                 ? normalizedSymbol
@@ -181,13 +175,13 @@ public class MarketFallbackSupport {
                     actualMarket = basicMarket;
                 }
                 else {
-                    actualMarket = DEFAULT_MARKET;
+                    actualMarket = MarketConstants.DEFAULT_MARKET;
                 }
             }
 
             List<com.koduck.dto.market.KlineDataDto> recent =
                 klineService.getKlineData(actualMarket, symbol,
-                        DAILY_TIMEFRAME, 2, null);
+                        MarketConstants.DEFAULT_TIMEFRAME, 2, null);
             recent = marketServiceSupport.normalizeKlineData(recent);
             if (recent.isEmpty()) {
                 return null;
@@ -248,13 +242,13 @@ public class MarketFallbackSupport {
         }
 
         String market = basic.getMarket() != null && !basic.getMarket().isBlank()
-                ? basic.getMarket() : DEFAULT_MARKET;
+                ? basic.getMarket() : MarketConstants.DEFAULT_MARKET;
         PriceQuoteDto quote = buildQuoteFromKline(symbol, basic, market);
         if (quote != null) {
             return quote;
         }
-        if (!DEFAULT_MARKET.equals(market)) {
-            return buildQuoteFromKline(symbol, basic, DEFAULT_MARKET);
+        if (!MarketConstants.DEFAULT_MARKET.equals(market)) {
+            return buildQuoteFromKline(symbol, basic, MarketConstants.DEFAULT_MARKET);
         }
         return null;
     }
@@ -262,7 +256,7 @@ public class MarketFallbackSupport {
     private PriceQuoteDto buildQuoteFromKline(String symbol, StockBasic basic,
             String market) {
         List<com.koduck.dto.market.KlineDataDto> recent =
-            klineService.getKlineData(market, symbol, DAILY_TIMEFRAME, 2, null);
+            klineService.getKlineData(market, symbol, MarketConstants.DEFAULT_TIMEFRAME, 2, null);
         recent = marketServiceSupport.normalizeKlineData(recent);
         if (recent.isEmpty()) {
             return null;

--- a/koduck-backend/src/main/java/com/koduck/service/support/MarketServiceSupport.java
+++ b/koduck-backend/src/main/java/com/koduck/service/support/MarketServiceSupport.java
@@ -14,6 +14,7 @@ import java.util.stream.Collectors;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Component;
 
+import com.koduck.common.constants.MarketConstants;
 import com.koduck.dto.market.MarketIndexDto;
 import com.koduck.dto.market.PriceQuoteDto;
 import com.koduck.dto.market.SectorNetworkDto;
@@ -39,7 +40,7 @@ import lombok.extern.slf4j.Slf4j;
 public class MarketServiceSupport {
 
     /** 股票类型。 */
-    private static final String STOCK_TYPE = "STOCK";
+    private static final String STOCK_TYPE = MarketConstants.STOCK_TYPE;
     /** 除法精度。 */
     private static final int DIVIDE_SCALE = 4;
     /** 板块节点分组1。 */

--- a/koduck-backend/src/main/java/com/koduck/service/support/UserSettingsLlmConfigSupport.java
+++ b/koduck-backend/src/main/java/com/koduck/service/support/UserSettingsLlmConfigSupport.java
@@ -8,6 +8,7 @@ import java.util.Set;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 
+import com.koduck.common.constants.LlmConstants;
 import com.koduck.dto.settings.LlmConfigDto;
 import com.koduck.dto.settings.MemoryConfigDto;
 import com.koduck.dto.settings.ProviderConfigDto;
@@ -30,11 +31,11 @@ import lombok.extern.slf4j.Slf4j;
 public class UserSettingsLlmConfigSupport {
 
     /** Provider: minimax. */
-    private static final String PROVIDER_MINIMAX = "minimax";
+    private static final String PROVIDER_MINIMAX = LlmConstants.PROVIDER_MINIMAX;
     /** Provider: deepseek. */
-    private static final String PROVIDER_DEEPSEEK = "deepseek";
+    private static final String PROVIDER_DEEPSEEK = LlmConstants.PROVIDER_DEEPSEEK;
     /** Provider: openai. */
-    private static final String PROVIDER_OPENAI = "openai";
+    private static final String PROVIDER_OPENAI = LlmConstants.PROVIDER_OPENAI;
     /** Source: credentials. */
     private static final String SOURCE_CREDENTIALS = "credentials";
     /** Source: user settings. */
@@ -46,9 +47,9 @@ public class UserSettingsLlmConfigSupport {
     /** Source env: LLM_API_BASE. */
     private static final String SOURCE_ENV_LLM_API_BASE = "env:LLM_API_BASE";
     /** Env key: LLM_API_KEY. */
-    private static final String ENV_LLM_API_KEY = "LLM_API_KEY";
+    private static final String ENV_LLM_API_KEY = LlmConstants.ENV_LLM_API_KEY;
     /** Env key: LLM_API_BASE. */
-    private static final String ENV_LLM_API_BASE = "LLM_API_BASE";
+    private static final String ENV_LLM_API_BASE = LlmConstants.ENV_LLM_API_BASE;
     /** Default API base for minimax. */
     private static final String DEFAULT_API_BASE_MINIMAX = "https://api.minimax.chat/v1";
     /** Default memory mode. */


### PR DESCRIPTION
## 变更内容

根据 `koduck-backend/docs/constant-redundancy-analysis.md` 分析报告，消除 koduck-backend 中的常量重复定义问题。

### 新增常量类 (4个)

| 常量类 | 包含常量 |
|--------|---------|
| `MapKeyConstants` | KEY_SYMBOL, KEY_NAME, KEY_CONTENT 等 |
| `LlmConstants` | PROVIDER_MINIMAX, ENV_LLM_API_BASE 等 |
| `AiConstants` | RISK_AGGRESSIVE, RISK_CONSERVATIVE 等 |
| `DataServicePathConstants` | A_SHARE_BASE_PATH 等 |

### 扩展现有常量类

- `MarketConstants`: 新增 STOCK_TYPE, A_SHARE_INDEX_SYMBOL, ALL_TIMEFRAMES_LIST
- `DateTimePatternConstants`: 新增 MARKET_ZONE_ID, TIMEZONE_ASIA_SHANGHAI

### 修改的文件 (22个)

- 消除本地常量包装，直接引用 MarketConstants
- 替换重复常量为集中常量引用
- 删除冗余的本地常量定义

### 质量检查结果

- ✅ mvn clean compile: BUILD SUCCESS
- ✅ checkstyle:check: 0 violations  
- ✅ quality-check.sh: 8/8 全绿

Closes #396