### PR TITLE
feat(cache): externalize cache TTL via CacheProperties

### DIFF
--- a/koduck-backend/docs/ADR-0056-cache-ttl-externalization.md
+++ b/koduck-backend/docs/ADR-0056-cache-ttl-externalization.md
@@ -1,0 +1,70 @@
+# ADR-0056: 缓存 TTL 外部化配置
+
+- Status: Accepted
+- Date: 2026-04-04
+- Issue: #404
+
+## Context
+
+当前 `CacheConfig.java` 将各缓存名称（`price`、`kline`、`marketSearch` 等）的 TTL 以 `private static final Duration` 硬编码在 Java 代码中：
+
+```java
+private static final Duration TTL_30_SECONDS = Duration.ofSeconds(30);
+private static final Duration TTL_1_MINUTE = Duration.ofMinutes(1);
+// ...
+```
+
+这导致：
+- 无法在不修改代码、不重新编译部署的情况下调整缓存过期时间
+- 开发/测试环境无法快速缩短 TTL 验证缓存失效逻辑
+- 生产环境无法根据市场时段或负载动态调整策略
+
+ARCHITECTURE-EVALUATION.md 将其列为可扩展性缺陷之一。
+
+## Decision
+
+引入 `CacheProperties` 配置类，将 TTL 从 `CacheConfig` 迁移到 `application.yml`（`koduck.cache.*` 前缀），采用 Spring Boot `@ConfigurationProperties` 机制：
+
+1. 新建 `CacheProperties`（`@ConfigurationProperties(prefix = "koduck.cache")`）
+2. `CacheConfig` 通过构造器注入 `CacheProperties`，替代原有硬编码常量
+3. 在 `application.yml` 中声明默认值，保持与改造前完全一致
+4. 不引入 Apollo/Nacos 等外部配置中心，避免当前阶段基础设施过重
+
+## Consequences
+
+正向影响：
+
+- TTL 可通过 `application.yml`、环境变量或 profile 覆盖，无需改代码
+- 默认行为不变，对现有 Service 层 `@Cacheable` 注解零侵入
+- 为后续动态策略（如 Redis 策略表、规则引擎）预留扩展点
+
+代价：
+
+- 增加一个 `CacheProperties` 类，配置链路略变长
+- 修改配置后需要重启服务（对当前阶段可接受）
+
+## Alternatives Considered
+
+1. 引入 Apollo / Nacos 配置中心
+   - 拒绝：仅为解决 TTL 硬编码问题引入整套配置中心基础设施，运维成本和架构复杂度过高。
+
+2. 使用 Redis 策略表实现运行时热更新
+   - 暂不采用：当前阶段重启更新足够，热更新可在后续有明确需求时叠加。
+
+3. 保持现状，继续硬编码
+   - 拒绝：不符合 ARCHITECTURE-EVALUATION.md 的优化方向，可扩展性受限。
+
+## Compatibility
+
+- **默认行为完全一致**：`application.yml` 中默认值与改造前相同
+- **Service 层零改动**：`@Cacheable` 注解、cache name、`CacheConfig` 常量均保持不变
+- **API 兼容**：无外部接口变更
+- **测试兼容**：`CacheConfigTest` 更新为注入 `CacheProperties`，断言逻辑不变
+
+## Verification
+
+- `CacheProperties` 编译通过并注册为 Spring Bean
+- `CacheConfigTest` 验证各 cache 的 TTL 与预期一致
+- `mvn -f koduck-backend/pom.xml clean compile` 通过
+- `mvn -f koduck-backend/pom.xml checkstyle:check` 通过
+- `./koduck-backend/scripts/quality-check.sh` 全绿

--- a/koduck-backend/src/main/java/com/koduck/config/CacheConfig.java
+++ b/koduck-backend/src/main/java/com/koduck/config/CacheConfig.java
@@ -1,6 +1,5 @@
 package com.koduck.config;
 
-import java.time.Duration;
 import java.util.Objects;
 
 import org.springframework.cache.annotation.EnableCaching;
@@ -15,13 +14,14 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.koduck.config.properties.CacheProperties;
 
 /**
  * Configuration for Redis-backed caching.
  * <p>
  * Defines multiple named caches with tailored time-to-live settings
  * and JSON serialization support.  Null-safety guards are applied to
- * durations, serializers, and the connection factory to satisfy
+ * serializers and the connection factory to satisfy
  * {@code @NonNull} contracts and suppress static analysis warnings.
  *
  * @author Koduck
@@ -63,25 +63,16 @@ public class CacheConfig {
      */
     public static final String CACHE_PORTFOLIO_SUMMARY = "portfolioSummary";
 
-    /**
-     * Default time-to-live for short-lived caches (30 seconds).
-     */
-    private static final Duration TTL_30_SECONDS = Duration.ofSeconds(30);
+    private final CacheProperties cacheProperties;
 
     /**
-     * Time-to-live representing one minute; used for hot-stock and kline caches.
+     * Constructs {@link CacheConfig} with injected cache properties.
+     *
+     * @param cacheProperties cache TTL configuration properties
      */
-    private static final Duration TTL_1_MINUTE = Duration.ofMinutes(1);
-
-    /**
-     * Time-to-live representing five minutes; used for market search caches.
-     */
-    private static final Duration TTL_5_MINUTES = Duration.ofMinutes(5);
-
-    /**
-     * Time-to-live representing one hour; used for portfolio summary cache.
-     */
-    private static final Duration TTL_1_HOUR = Duration.ofHours(1);
+    public CacheConfig(CacheProperties cacheProperties) {
+        this.cacheProperties = Objects.requireNonNull(cacheProperties);
+    }
 
     /**
      * Construct a JSON serializer that understands Java time types.
@@ -109,7 +100,7 @@ public class CacheConfig {
      * @return configured cache configuration instance
      */
     private static RedisCacheConfiguration buildCacheConfiguration(
-                    Duration ttl,
+                    java.time.Duration ttl,
                     GenericJackson2JsonRedisSerializer jsonSerializer,
                     boolean disableCachingNullValues) {
         RedisCacheConfiguration configuration = RedisCacheConfiguration.defaultCacheConfig()
@@ -128,7 +119,7 @@ public class CacheConfig {
     /**
      * Spring bean that constructs the {@link RedisCacheManager} used by the
      * application for caching.  Several named cache configurations are
-     * registered with different TTLs.
+     * registered with different TTLs driven by {@link CacheProperties}.
      *
      * @param connectionFactory Redis connection factory (injected by Spring,
      *                          must not be {@code null})
@@ -138,15 +129,24 @@ public class CacheConfig {
     public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
         GenericJackson2JsonRedisSerializer jsonSerializer = createJsonSerializer();
 
-        RedisCacheConfiguration defaultConfig = buildCacheConfiguration(TTL_5_MINUTES, jsonSerializer, true);
-        RedisCacheConfiguration klineConfig = buildCacheConfiguration(TTL_1_MINUTE, jsonSerializer, false);
-        RedisCacheConfiguration priceConfig = buildCacheConfiguration(TTL_30_SECONDS, jsonSerializer, false);
-        RedisCacheConfiguration marketSearchConfig = buildCacheConfiguration(TTL_5_MINUTES, jsonSerializer, false);
-        RedisCacheConfiguration stockDetailConfig = buildCacheConfiguration(TTL_30_SECONDS, jsonSerializer, false);
-        RedisCacheConfiguration marketIndicesConfig = buildCacheConfiguration(TTL_30_SECONDS, jsonSerializer, false);
-        RedisCacheConfiguration stockIndustryConfig = buildCacheConfiguration(TTL_5_MINUTES, jsonSerializer, false);
-        RedisCacheConfiguration hotStocksConfig = buildCacheConfiguration(TTL_1_MINUTE, jsonSerializer, false);
-        RedisCacheConfiguration portfolioSummaryConfig = buildCacheConfiguration(TTL_1_HOUR, jsonSerializer, false);
+        RedisCacheConfiguration defaultConfig = buildCacheConfiguration(
+                cacheProperties.getDefaultTtl(), jsonSerializer, true);
+        RedisCacheConfiguration klineConfig = buildCacheConfiguration(
+                cacheProperties.getKlineTtl(), jsonSerializer, false);
+        RedisCacheConfiguration priceConfig = buildCacheConfiguration(
+                cacheProperties.getPriceTtl(), jsonSerializer, false);
+        RedisCacheConfiguration marketSearchConfig = buildCacheConfiguration(
+                cacheProperties.getMarketSearchTtl(), jsonSerializer, false);
+        RedisCacheConfiguration stockDetailConfig = buildCacheConfiguration(
+                cacheProperties.getStockDetailTtl(), jsonSerializer, false);
+        RedisCacheConfiguration marketIndicesConfig = buildCacheConfiguration(
+                cacheProperties.getMarketIndicesTtl(), jsonSerializer, false);
+        RedisCacheConfiguration stockIndustryConfig = buildCacheConfiguration(
+                cacheProperties.getStockIndustryTtl(), jsonSerializer, false);
+        RedisCacheConfiguration hotStocksConfig = buildCacheConfiguration(
+                cacheProperties.getHotStocksTtl(), jsonSerializer, false);
+        RedisCacheConfiguration portfolioSummaryConfig = buildCacheConfiguration(
+                cacheProperties.getPortfolioSummaryTtl(), jsonSerializer, false);
 
         return RedisCacheManager.builder(Objects.requireNonNull(connectionFactory))
             .cacheDefaults(Objects.requireNonNull(defaultConfig))

--- a/koduck-backend/src/main/java/com/koduck/config/properties/CacheProperties.java
+++ b/koduck-backend/src/main/java/com/koduck/config/properties/CacheProperties.java
@@ -1,0 +1,242 @@
+package com.koduck.config.properties;
+
+import java.time.Duration;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.validation.annotation.Validated;
+
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Configuration properties for Redis cache TTL settings.
+ * <p>
+ * Values are populated from application configuration with prefix
+ * {@code koduck.cache} and can be overridden per environment.
+ * </p>
+ *
+ * @author Koduck Team
+ */
+@Configuration
+@ConfigurationProperties(prefix = "koduck.cache")
+@Validated
+@Slf4j
+public class CacheProperties {
+
+    /**
+     * Default TTL for caches when no specific value is configured.
+     */
+    private Duration defaultTtl = Duration.ofMinutes(5);
+
+    /**
+     * TTL for K-line data snapshots.
+     */
+    private Duration klineTtl = Duration.ofMinutes(1);
+
+    /**
+     * TTL for latest price lookups.
+     */
+    private Duration priceTtl = Duration.ofSeconds(30);
+
+    /**
+     * TTL for market search results.
+     */
+    private Duration marketSearchTtl = Duration.ofMinutes(5);
+
+    /**
+     * TTL for stock detail payloads.
+     */
+    private Duration stockDetailTtl = Duration.ofSeconds(30);
+
+    /**
+     * TTL for major market index quotes.
+     */
+    private Duration marketIndicesTtl = Duration.ofSeconds(30);
+
+    /**
+     * TTL for stock industry metadata lookups.
+     */
+    private Duration stockIndustryTtl = Duration.ofMinutes(5);
+
+    /**
+     * TTL for hot stocks list responses.
+     */
+    private Duration hotStocksTtl = Duration.ofMinutes(1);
+
+    /**
+     * TTL for portfolio summary.
+     */
+    private Duration portfolioSummaryTtl = Duration.ofHours(1);
+
+    /**
+     * Logs the effective cache TTL configuration after construction.
+     */
+    @PostConstruct
+    public void init() {
+        log.info("[CacheProperties] defaultTtl={}, klineTtl={}, priceTtl={}, marketSearchTtl={}",
+                defaultTtl, klineTtl, priceTtl, marketSearchTtl);
+    }
+
+    /**
+     * Gets the default cache TTL.
+     *
+     * @return default TTL
+     */
+    public Duration getDefaultTtl() {
+        return defaultTtl;
+    }
+
+    /**
+     * Sets the default cache TTL.
+     *
+     * @param defaultTtl default TTL value
+     */
+    public void setDefaultTtl(Duration defaultTtl) {
+        this.defaultTtl = defaultTtl;
+    }
+
+    /**
+     * Gets the K-line cache TTL.
+     *
+     * @return K-line TTL
+     */
+    public Duration getKlineTtl() {
+        return klineTtl;
+    }
+
+    /**
+     * Sets the K-line cache TTL.
+     *
+     * @param klineTtl K-line TTL value
+     */
+    public void setKlineTtl(Duration klineTtl) {
+        this.klineTtl = klineTtl;
+    }
+
+    /**
+     * Gets the latest price cache TTL.
+     *
+     * @return price TTL
+     */
+    public Duration getPriceTtl() {
+        return priceTtl;
+    }
+
+    /**
+     * Sets the latest price cache TTL.
+     *
+     * @param priceTtl price TTL value
+     */
+    public void setPriceTtl(Duration priceTtl) {
+        this.priceTtl = priceTtl;
+    }
+
+    /**
+     * Gets the market search cache TTL.
+     *
+     * @return market search TTL
+     */
+    public Duration getMarketSearchTtl() {
+        return marketSearchTtl;
+    }
+
+    /**
+     * Sets the market search cache TTL.
+     *
+     * @param marketSearchTtl market search TTL value
+     */
+    public void setMarketSearchTtl(Duration marketSearchTtl) {
+        this.marketSearchTtl = marketSearchTtl;
+    }
+
+    /**
+     * Gets the stock detail cache TTL.
+     *
+     * @return stock detail TTL
+     */
+    public Duration getStockDetailTtl() {
+        return stockDetailTtl;
+    }
+
+    /**
+     * Sets the stock detail cache TTL.
+     *
+     * @param stockDetailTtl stock detail TTL value
+     */
+    public void setStockDetailTtl(Duration stockDetailTtl) {
+        this.stockDetailTtl = stockDetailTtl;
+    }
+
+    /**
+     * Gets the market indices cache TTL.
+     *
+     * @return market indices TTL
+     */
+    public Duration getMarketIndicesTtl() {
+        return marketIndicesTtl;
+    }
+
+    /**
+     * Sets the market indices cache TTL.
+     *
+     * @param marketIndicesTtl market indices TTL value
+     */
+    public void setMarketIndicesTtl(Duration marketIndicesTtl) {
+        this.marketIndicesTtl = marketIndicesTtl;
+    }
+
+    /**
+     * Gets the stock industry cache TTL.
+     *
+     * @return stock industry TTL
+     */
+    public Duration getStockIndustryTtl() {
+        return stockIndustryTtl;
+    }
+
+    /**
+     * Sets the stock industry cache TTL.
+     *
+     * @param stockIndustryTtl stock industry TTL value
+     */
+    public void setStockIndustryTtl(Duration stockIndustryTtl) {
+        this.stockIndustryTtl = stockIndustryTtl;
+    }
+
+    /**
+     * Gets the hot stocks cache TTL.
+     *
+     * @return hot stocks TTL
+     */
+    public Duration getHotStocksTtl() {
+        return hotStocksTtl;
+    }
+
+    /**
+     * Sets the hot stocks cache TTL.
+     *
+     * @param hotStocksTtl hot stocks TTL value
+     */
+    public void setHotStocksTtl(Duration hotStocksTtl) {
+        this.hotStocksTtl = hotStocksTtl;
+    }
+
+    /**
+     * Gets the portfolio summary cache TTL.
+     *
+     * @return portfolio summary TTL
+     */
+    public Duration getPortfolioSummaryTtl() {
+        return portfolioSummaryTtl;
+    }
+
+    /**
+     * Sets the portfolio summary cache TTL.
+     *
+     * @param portfolioSummaryTtl portfolio summary TTL value
+     */
+    public void setPortfolioSummaryTtl(Duration portfolioSummaryTtl) {
+        this.portfolioSummaryTtl = portfolioSummaryTtl;
+    }
+}

--- a/koduck-backend/src/main/resources/application.yml
+++ b/koduck-backend/src/main/resources/application.yml
@@ -111,6 +111,16 @@ spring:
 
 # Koduck 自定义配置
 koduck:
+  cache:
+    default-ttl: 5m
+    kline-ttl: 1m
+    price-ttl: 30s
+    market-search-ttl: 5m
+    stock-detail-ttl: 30s
+    market-indices-ttl: 30s
+    stock-industry-ttl: 5m
+    hot-stocks-ttl: 1m
+    portfolio-summary-ttl: 1h
   pagination:
     default-page-size: 20
     max-page-size: 100

--- a/koduck-backend/src/test/java/com/koduck/config/CacheConfigTest.java
+++ b/koduck-backend/src/test/java/com/koduck/config/CacheConfigTest.java
@@ -10,6 +10,8 @@ import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.cache.RedisCacheWriter;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 
+import com.koduck.config.properties.CacheProperties;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
@@ -55,7 +57,8 @@ class CacheConfigTest {
     @Test
     @DisplayName("shouldRegisterExpectedCacheNamesAndTtlSettings")
     void shouldRegisterExpectedCacheNamesAndTtlSettings() {
-        CacheConfig cacheConfig = new CacheConfig();
+        CacheProperties cacheProperties = new CacheProperties();
+        CacheConfig cacheConfig = new CacheConfig(cacheProperties);
         RedisConnectionFactory connectionFactory = mock(RedisConnectionFactory.class);
 
         RedisCacheManager cacheManager = cacheConfig.cacheManager(connectionFactory);


### PR DESCRIPTION
## Summary
将 Redis 缓存 TTL 从  的硬编码常量迁移到  外部化配置中，支持通过  按环境调整缓存过期时间。

## Changes
- 新增 （）
-  通过构造器注入 ，替代原有  常量
- 在  中声明默认值，保持与改造前行为完全一致
- 更新  以注入 
- 新增 ADR-0056 记录决策与兼容性影响

## Verification
- [INFO] Scanning for projects...
[INFO] 
[INFO] ---------------------< com.koduck:koduck-backend >----------------------
[INFO] Building Koduck Backend 0.1.0-SNAPSHOT
[INFO]   from pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- clean:3.4.0:clean (default-clean) @ koduck-backend ---
[INFO] Deleting /Users/guhailin/Git/worktree-cache-ttl/koduck-backend/target
[INFO] 
[INFO] --- checkstyle:3.6.0:check (checkstyle-validate) @ koduck-backend ---
[INFO] Starting audit...
[WARN] /Users/guhailin/Git/worktree-cache-ttl/koduck-backend/src/main/java/com/koduck/config/CacheConfig.java:17:1: 'com.koduck.config.properties.CacheProperties' should be separated from previous imports. [ImportOrder]
[WARN] /Users/guhailin/Git/worktree-cache-ttl/koduck-backend/src/main/java/com/koduck/config/CacheConfig.java:66:5: Missing a Javadoc comment. [JavadocVariable]
[WARN] /Users/guhailin/Git/worktree-cache-ttl/koduck-backend/src/main/java/com/koduck/config/properties/CacheProperties.java:9:1: Wrong order for 'jakarta.annotation.PostConstruct' import. [ImportOrder]
[WARN] /Users/guhailin/Git/worktree-cache-ttl/koduck-backend/src/main/java/com/koduck/config/properties/CacheProperties.java:10:1: 'lombok.extern.slf4j.Slf4j' should be separated from previous imports. [ImportOrder]
[WARN] /Users/guhailin/Git/worktree-cache-ttl/koduck-backend/src/main/java/com/koduck/config/properties/CacheProperties.java:30:54: '5' is a magic number. [MagicNumber]
[WARN] /Users/guhailin/Git/worktree-cache-ttl/koduck-backend/src/main/java/com/koduck/config/properties/CacheProperties.java:40:52: '30' is a magic number. [MagicNumber]
[WARN] /Users/guhailin/Git/worktree-cache-ttl/koduck-backend/src/main/java/com/koduck/config/properties/CacheProperties.java:45:59: '5' is a magic number. [MagicNumber]
[WARN] /Users/guhailin/Git/worktree-cache-ttl/koduck-backend/src/main/java/com/koduck/config/properties/CacheProperties.java:50:58: '30' is a magic number. [MagicNumber]
[WARN] /Users/guhailin/Git/worktree-cache-ttl/koduck-backend/src/main/java/com/koduck/config/properties/CacheProperties.java:55:60: '30' is a magic number. [MagicNumber]
[WARN] /Users/guhailin/Git/worktree-cache-ttl/koduck-backend/src/main/java/com/koduck/config/properties/CacheProperties.java:60:60: '5' is a magic number. [MagicNumber]
[WARN] /Users/guhailin/Git/worktree-cache-ttl/koduck-backend/src/main/java/com/koduck/config/properties/StompRelayProperties.java:39:24: '61613' is a magic number. [MagicNumber]
[WARN] /Users/guhailin/Git/worktree-cache-ttl/koduck-backend/src/main/java/com/koduck/config/properties/StompRelayProperties.java:71:48: '10000' is a magic number. [MagicNumber]
[WARN] /Users/guhailin/Git/worktree-cache-ttl/koduck-backend/src/main/java/com/koduck/config/properties/StompRelayProperties.java:76:51: '10000' is a magic number. [MagicNumber]
[WARN] /Users/guhailin/Git/worktree-cache-ttl/koduck-backend/src/main/java/com/koduck/config/WebSocketConfig.java:65: Line is longer than 120 characters (found 122). [LineLength]
[WARN] /Users/guhailin/Git/worktree-cache-ttl/koduck-backend/src/main/java/com/koduck/config/WebSocketConfig.java:85:9: '}' at column 9 should be alone on a line. [RightCurly]
[WARN] /Users/guhailin/Git/worktree-cache-ttl/koduck-backend/src/test/java/com/koduck/config/WebSocketConfigTest.java:6:1: Wrong order for 'org.junit.jupiter.api.DisplayName' import. [ImportOrder]
[WARN] /Users/guhailin/Git/worktree-cache-ttl/koduck-backend/src/test/java/com/koduck/config/WebSocketConfigTest.java:58:38: '61613' is a magic number. [MagicNumber]
[WARN] /Users/guhailin/Git/worktree-cache-ttl/koduck-backend/src/test/java/com/koduck/config/properties/StompRelayPropertiesTest.java:29:52: '61613' is a magic number. [MagicNumber]
[WARN] /Users/guhailin/Git/worktree-cache-ttl/koduck-backend/src/test/java/com/koduck/config/properties/StompRelayPropertiesTest.java:34:75: '10000L' is a magic number. [MagicNumber]
[WARN] /Users/guhailin/Git/worktree-cache-ttl/koduck-backend/src/test/java/com/koduck/config/properties/StompRelayPropertiesTest.java:35:78: '10000L' is a magic number. [MagicNumber]
[WARN] /Users/guhailin/Git/worktree-cache-ttl/koduck-backend/src/test/java/com/koduck/config/properties/StompRelayPropertiesTest.java:108:28: '61614' is a magic number. [MagicNumber]
[WARN] /Users/guhailin/Git/worktree-cache-ttl/koduck-backend/src/test/java/com/koduck/config/properties/StompRelayPropertiesTest.java:115:51: '5000L' is a magic number. [MagicNumber]
[WARN] /Users/guhailin/Git/worktree-cache-ttl/koduck-backend/src/test/java/com/koduck/config/properties/StompRelayPropertiesTest.java:116:54: '5000L' is a magic number. [MagicNumber]
[WARN] /Users/guhailin/Git/worktree-cache-ttl/koduck-backend/src/test/java/com/koduck/config/properties/StompRelayPropertiesTest.java:121:52: '61614' is a magic number. [MagicNumber]
[WARN] /Users/guhailin/Git/worktree-cache-ttl/koduck-backend/src/test/java/com/koduck/config/properties/StompRelayPropertiesTest.java:128:75: '5000L' is a magic number. [MagicNumber]
[WARN] /Users/guhailin/Git/worktree-cache-ttl/koduck-backend/src/test/java/com/koduck/config/properties/StompRelayPropertiesTest.java:129:78: '5000L' is a magic number. [MagicNumber]
Audit done.
[INFO] You have 0 Checkstyle violations.
[INFO] 
[INFO] --- jacoco:0.8.12:prepare-agent (prepare-agent) @ koduck-backend ---
[INFO] argLine set to -javaagent:/Users/guhailin/.m2/repository/org/jacoco/org.jacoco.agent/0.8.12/org.jacoco.agent-0.8.12-runtime.jar=destfile=/Users/guhailin/Git/worktree-cache-ttl/koduck-backend/target/jacoco.exec,includes=**/market/application/MarketServiceImpl.class:**/trading/application/PortfolioServiceImpl.class:**/shared/application/AiAnalysisServiceImpl.class,excludes=**/entity/**:**/dto/**:**/config/**:**/exception/**:**/KoduckApplication.class:**/*MapperImpl.class
[INFO] 
[INFO] --- resources:3.3.1:resources (default-resources) @ koduck-backend ---
[INFO] Copying 4 resources from src/main/resources to target/classes
[INFO] Copying 3 resources from src/main/resources to target/classes
[INFO] 
[INFO] --- compiler:3.13.0:compile (default-compile) @ koduck-backend ---
[INFO] Recompiling the module because of changed source code.
[INFO] Compiling 356 source files with javac [debug deprecation parameters release 23] to target/classes
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  5.813 s
[INFO] Finished at: 2026-04-04T01:00:46+08:00
[INFO] ------------------------------------------------------------------------ ✅
- [INFO] Scanning for projects...
[INFO] 
[INFO] ---------------------< com.koduck:koduck-backend >----------------------
[INFO] Building Koduck Backend 0.1.0-SNAPSHOT
[INFO]   from pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- checkstyle:3.6.0:check (default-cli) @ koduck-backend ---
[INFO] Starting audit...
[WARN] /Users/guhailin/Git/worktree-cache-ttl/koduck-backend/src/main/java/com/koduck/config/CacheConfig.java:17:1: 'com.koduck.config.properties.CacheProperties' should be separated from previous imports. [ImportOrder]
[WARN] /Users/guhailin/Git/worktree-cache-ttl/koduck-backend/src/main/java/com/koduck/config/CacheConfig.java:66:5: Missing a Javadoc comment. [JavadocVariable]
[WARN] /Users/guhailin/Git/worktree-cache-ttl/koduck-backend/src/main/java/com/koduck/config/properties/CacheProperties.java:9:1: Wrong order for 'jakarta.annotation.PostConstruct' import. [ImportOrder]
[WARN] /Users/guhailin/Git/worktree-cache-ttl/koduck-backend/src/main/java/com/koduck/config/properties/CacheProperties.java:10:1: 'lombok.extern.slf4j.Slf4j' should be separated from previous imports. [ImportOrder]
[WARN] /Users/guhailin/Git/worktree-cache-ttl/koduck-backend/src/main/java/com/koduck/config/properties/CacheProperties.java:30:54: '5' is a magic number. [MagicNumber]
[WARN] /Users/guhailin/Git/worktree-cache-ttl/koduck-backend/src/main/java/com/koduck/config/properties/CacheProperties.java:40:52: '30' is a magic number. [MagicNumber]
[WARN] /Users/guhailin/Git/worktree-cache-ttl/koduck-backend/src/main/java/com/koduck/config/properties/CacheProperties.java:45:59: '5' is a magic number. [MagicNumber]
[WARN] /Users/guhailin/Git/worktree-cache-ttl/koduck-backend/src/main/java/com/koduck/config/properties/CacheProperties.java:50:58: '30' is a magic number. [MagicNumber]
[WARN] /Users/guhailin/Git/worktree-cache-ttl/koduck-backend/src/main/java/com/koduck/config/properties/CacheProperties.java:55:60: '30' is a magic number. [MagicNumber]
[WARN] /Users/guhailin/Git/worktree-cache-ttl/koduck-backend/src/main/java/com/koduck/config/properties/CacheProperties.java:60:60: '5' is a magic number. [MagicNumber]
[WARN] /Users/guhailin/Git/worktree-cache-ttl/koduck-backend/src/main/java/com/koduck/config/properties/StompRelayProperties.java:39:24: '61613' is a magic number. [MagicNumber]
[WARN] /Users/guhailin/Git/worktree-cache-ttl/koduck-backend/src/main/java/com/koduck/config/properties/StompRelayProperties.java:71:48: '10000' is a magic number. [MagicNumber]
[WARN] /Users/guhailin/Git/worktree-cache-ttl/koduck-backend/src/main/java/com/koduck/config/properties/StompRelayProperties.java:76:51: '10000' is a magic number. [MagicNumber]
[WARN] /Users/guhailin/Git/worktree-cache-ttl/koduck-backend/src/main/java/com/koduck/config/WebSocketConfig.java:65: Line is longer than 120 characters (found 122). [LineLength]
[WARN] /Users/guhailin/Git/worktree-cache-ttl/koduck-backend/src/main/java/com/koduck/config/WebSocketConfig.java:85:9: '}' at column 9 should be alone on a line. [RightCurly]
[WARN] /Users/guhailin/Git/worktree-cache-ttl/koduck-backend/src/test/java/com/koduck/config/WebSocketConfigTest.java:6:1: Wrong order for 'org.junit.jupiter.api.DisplayName' import. [ImportOrder]
[WARN] /Users/guhailin/Git/worktree-cache-ttl/koduck-backend/src/test/java/com/koduck/config/WebSocketConfigTest.java:58:38: '61613' is a magic number. [MagicNumber]
[WARN] /Users/guhailin/Git/worktree-cache-ttl/koduck-backend/src/test/java/com/koduck/config/properties/StompRelayPropertiesTest.java:29:52: '61613' is a magic number. [MagicNumber]
[WARN] /Users/guhailin/Git/worktree-cache-ttl/koduck-backend/src/test/java/com/koduck/config/properties/StompRelayPropertiesTest.java:34:75: '10000L' is a magic number. [MagicNumber]
[WARN] /Users/guhailin/Git/worktree-cache-ttl/koduck-backend/src/test/java/com/koduck/config/properties/StompRelayPropertiesTest.java:35:78: '10000L' is a magic number. [MagicNumber]
[WARN] /Users/guhailin/Git/worktree-cache-ttl/koduck-backend/src/test/java/com/koduck/config/properties/StompRelayPropertiesTest.java:108:28: '61614' is a magic number. [MagicNumber]
[WARN] /Users/guhailin/Git/worktree-cache-ttl/koduck-backend/src/test/java/com/koduck/config/properties/StompRelayPropertiesTest.java:115:51: '5000L' is a magic number. [MagicNumber]
[WARN] /Users/guhailin/Git/worktree-cache-ttl/koduck-backend/src/test/java/com/koduck/config/properties/StompRelayPropertiesTest.java:116:54: '5000L' is a magic number. [MagicNumber]
[WARN] /Users/guhailin/Git/worktree-cache-ttl/koduck-backend/src/test/java/com/koduck/config/properties/StompRelayPropertiesTest.java:121:52: '61614' is a magic number. [MagicNumber]
[WARN] /Users/guhailin/Git/worktree-cache-ttl/koduck-backend/src/test/java/com/koduck/config/properties/StompRelayPropertiesTest.java:128:75: '5000L' is a magic number. [MagicNumber]
[WARN] /Users/guhailin/Git/worktree-cache-ttl/koduck-backend/src/test/java/com/koduck/config/properties/StompRelayPropertiesTest.java:129:78: '5000L' is a magic number. [MagicNumber]
Audit done.
[INFO] You have 0 Checkstyle violations.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  0.716 s
[INFO] Finished at: 2026-04-04T01:00:48+08:00
[INFO] ------------------------------------------------------------------------ ✅
- ╔════════════════════════════════════════════════════════════════════════════╗
║                    Koduck Backend 质量检查脚本                             ║
╚════════════════════════════════════════════════════════════════════════════╝

项目路径: /Users/guhailin/Git/worktree-cache-ttl/koduck-backend


📦 阶段 1: 代码格式检查

════════════════════════════════════════════════════════════════════════════
🔍 [1] PMD 代码格式检查
════════════════════════════════════════════════════════════════════════════
[0;32m✅ PMD 代码格式检查 通过[0m
════════════════════════════════════════════════════════════════════════════
🔍 [2] PMD 存量非回退检查
════════════════════════════════════════════════════════════════════════════
PMD baseline violations : 0
PMD current violations  : 0
PMD debt guard passed.
[0;32m✅ PMD 存量非回退检查 通过[0m

📦 阶段 2: 静态分析检查

════════════════════════════════════════════════════════════════════════════
🔍 [3] SpotBugs 安全漏洞检查
════════════════════════════════════════════════════════════════════════════
[0;32m✅ SpotBugs 安全漏洞检查 通过[0m

📦 阶段 3: 编译检查

════════════════════════════════════════════════════════════════════════════
🔍 [4] Maven 编译
════════════════════════════════════════════════════════════════════════════
[0;32m✅ Maven 编译 通过[0m

📦 阶段 4: 测试执行

════════════════════════════════════════════════════════════════════════════
🔍 [5] 单元测试
════════════════════════════════════════════════════════════════════════════
[0;32m✅ 单元测试 通过[0m
════════════════════════════════════════════════════════════════════════════
🔍 [6] 切片测试
════════════════════════════════════════════════════════════════════════════
[0;32m✅ 切片测试 通过[0m

📦 阶段 5: 覆盖率检查

════════════════════════════════════════════════════════════════════════════
🔍 [7] JaCoCo 覆盖率 (60%阈值)
════════════════════════════════════════════════════════════════════════════
[0;32m✅ JaCoCo 覆盖率 (60%阈值) 通过[0m

📦 阶段 6: 架构检查

════════════════════════════════════════════════════════════════════════════
🔍 [8] 架构违规检查
════════════════════════════════════════════════════════════════════════════
╔════════════════════════════════════════════════════════════╗
║              模块边界与依赖违规检查                        ║
╚════════════════════════════════════════════════════════════╝

📋 检查 1: Repository → Service 违规
✅ Repository 层干净

📋 检查 2: Service → Controller 违规
✅ Service 层干净

📋 检查 3: Entity → DTO 违规
✅ Entity 层干净

📋 检查 4: Mapper → Service 违规
✅ Mapper 层干净

📊 模块统计:
  Controller:       20 个文件
  Service:          82 个文件
  Repository:       37 个文件
  Entity:           39 个文件
  DTO:             107 个文件

📋 检查 5: 潜在循环依赖（Service 互相导入）
✅ 未发现复杂 Service 间依赖

════════════════════════════════════════════════════════════
✅ 检查通过，未发现架构违规
[0;32m✅ 架构违规检查 通过[0m

╔════════════════════════════════════════════════════════════════════════════╗
║                          检查结果汇总                                      ║
╚════════════════════════════════════════════════════════════════════════════╝

总检查项: 8
通过: [0;32m8[0m
失败: [0;31m0[0m

[0;32m🎉 所有检查通过！可以提交代码。[0m

建议操作:
  git add .
  git commit -m 'feat: your change'
  git push origin your-branch 全绿 ✅

Closes #404