### PR TITLE
fix(http-client): 补充迁移遗漏的 RestTemplate 到 WebClient

### DIFF
--- a/koduck-backend/src/main/java/com/koduck/controller/MarketAdvancedController.java
+++ b/koduck-backend/src/main/java/com/koduck/controller/MarketAdvancedController.java
@@ -10,7 +10,6 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -19,16 +18,14 @@ import jakarta.validation.constraints.NotEmpty;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.format.annotation.DateTimeFormat;
-import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.client.RestClientException;
-import org.springframework.web.client.RestTemplate;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -142,9 +139,9 @@ public class MarketAdvancedController {
     /** Data service properties. */
     private final DataServiceProperties dataServiceProperties;
 
-    /** Data service REST template. */
-    @Qualifier("dataServiceRestTemplate")
-    private final RestTemplate dataServiceRestTemplate;
+    /** Data service WebClient. */
+    @Qualifier("dataServiceWebClient")
+    private final WebClient dataServiceWebClient;
 
     /**
      * Get fear and greed index.
@@ -169,20 +166,19 @@ public class MarketAdvancedController {
                     ApiMessageConstants.DATA_SERVICE_DISABLED);
         }
         try {
-            ResponseEntity<DataServiceResponse<Map<String, Object>>> response =
-                    dataServiceRestTemplate.exchange(
-                            dataServiceProperties.getBaseUrl() + FEAR_GREED_INDEX_PATH,
-                            Objects.requireNonNull(HttpMethod.GET),
-                            null,
-                            Objects.requireNonNull(DATA_SERVICE_MAP_RESPONSE_TYPE));
-            DataServiceResponse<Map<String, Object>> body = response.getBody();
+            DataServiceResponse<Map<String, Object>> body =
+                    dataServiceWebClient.get()
+                            .uri(dataServiceProperties.getBaseUrl() + FEAR_GREED_INDEX_PATH)
+                            .retrieve()
+                            .bodyToMono(DATA_SERVICE_MAP_RESPONSE_TYPE)
+                            .block();
             if (body == null || !body.isSuccess() || body.data() == null) {
                 return ApiResponse.error(ApiStatusCodeConstants.BAD_GATEWAY,
                         ApiMessageConstants.FEAR_GREED_FETCH_FAILED);
             }
             return ApiResponse.success(body.data());
         }
-        catch (RestClientException e) {
+        catch (WebClientResponseException e) {
             log.warn("fear_greed_proxy_failed: {}", e.getMessage());
             return ApiResponse.error(ApiStatusCodeConstants.BAD_GATEWAY,
                     ApiMessageConstants.FEAR_GREED_FETCH_FAILED);
@@ -326,20 +322,19 @@ public class MarketAdvancedController {
                     ApiMessageConstants.DATA_SERVICE_DISABLED);
         }
         try {
-            ResponseEntity<DataServiceResponse<Map<String, Object>>> response =
-                    dataServiceRestTemplate.exchange(
-                            dataServiceProperties.getBaseUrl() + BREADTH_PATH,
-                            Objects.requireNonNull(HttpMethod.GET),
-                            null,
-                            Objects.requireNonNull(DATA_SERVICE_MAP_RESPONSE_TYPE));
-            DataServiceResponse<Map<String, Object>> body = response.getBody();
+            DataServiceResponse<Map<String, Object>> body =
+                    dataServiceWebClient.get()
+                            .uri(dataServiceProperties.getBaseUrl() + BREADTH_PATH)
+                            .retrieve()
+                            .bodyToMono(DATA_SERVICE_MAP_RESPONSE_TYPE)
+                            .block();
             if (body == null || !body.isSuccess() || body.data() == null) {
                 return ApiResponse.error(ApiStatusCodeConstants.BAD_GATEWAY,
                         ApiMessageConstants.BREADTH_FETCH_FAILED);
             }
             return ApiResponse.success(body.data());
         }
-        catch (RestClientException e) {
+        catch (WebClientResponseException e) {
             log.warn("breadth_proxy_failed: {}", e.getMessage());
             return ApiResponse.error(ApiStatusCodeConstants.BAD_GATEWAY,
                     ApiMessageConstants.BREADTH_FETCH_FAILED);
@@ -379,20 +374,19 @@ public class MarketAdvancedController {
             return ApiResponse.success(List.of());
         }
         try {
-            UriComponentsBuilder builder = UriComponentsBuilder
+            String uri = UriComponentsBuilder
                     .fromUriString(dataServiceProperties.getBaseUrl() + BIG_ORDERS_PATH)
                     .queryParam("limit", limit)
-                    .queryParam("min_amount", minAmount);
-            if (orderType != null && !orderType.isBlank()) {
-                builder.queryParam("order_type", orderType);
-            }
-            ResponseEntity<DataServiceResponse<List<BigOrderAlertDto>>> response =
-                    dataServiceRestTemplate.exchange(
-                            builder.toUriString(),
-                            Objects.requireNonNull(HttpMethod.GET),
-                            null,
-                            Objects.requireNonNull(BIG_ORDER_LIST_RESPONSE_TYPE));
-            DataServiceResponse<List<BigOrderAlertDto>> body = response.getBody();
+                    .queryParam("min_amount", minAmount)
+                    .queryParamIfPresent("order_type", orderType != null && !orderType.isBlank()
+                            ? java.util.Optional.of(orderType) : java.util.Optional.empty())
+                    .toUriString();
+            DataServiceResponse<List<BigOrderAlertDto>> body =
+                    dataServiceWebClient.get()
+                            .uri(uri)
+                            .retrieve()
+                            .bodyToMono(BIG_ORDER_LIST_RESPONSE_TYPE)
+                            .block();
             if (body == null || !body.isSuccess() || body.data() == null) {
                 log.warn("big_orders_proxy_empty code={} message={}",
                         body == null ? null : body.code(),
@@ -401,7 +395,7 @@ public class MarketAdvancedController {
             }
             return ApiResponse.success(body.data());
         }
-        catch (RestClientException e) {
+        catch (WebClientResponseException e) {
             log.warn("big_orders_proxy_failed: {}", e.getMessage());
             return ApiResponse.success(List.of());
         }
@@ -427,13 +421,12 @@ public class MarketAdvancedController {
             return ApiResponse.success(BigOrderStatsDto.empty());
         }
         try {
-            ResponseEntity<DataServiceResponse<BigOrderStatsDto>> response =
-                    dataServiceRestTemplate.exchange(
-                            dataServiceProperties.getBaseUrl() + BIG_ORDERS_STATS_PATH,
-                            Objects.requireNonNull(HttpMethod.GET),
-                            null,
-                            Objects.requireNonNull(BIG_ORDER_STATS_RESPONSE_TYPE));
-            DataServiceResponse<BigOrderStatsDto> body = response.getBody();
+            DataServiceResponse<BigOrderStatsDto> body =
+                    dataServiceWebClient.get()
+                            .uri(dataServiceProperties.getBaseUrl() + BIG_ORDERS_STATS_PATH)
+                            .retrieve()
+                            .bodyToMono(BIG_ORDER_STATS_RESPONSE_TYPE)
+                            .block();
             if (body == null || !body.isSuccess() || body.data() == null) {
                 log.warn("big_order_stats_proxy_empty code={} message={}",
                         body == null ? null : body.code(),
@@ -442,7 +435,7 @@ public class MarketAdvancedController {
             }
             return ApiResponse.success(body.data());
         }
-        catch (RestClientException e) {
+        catch (WebClientResponseException e) {
             log.warn("big_order_stats_proxy_failed: {}", e.getMessage());
             return ApiResponse.success(BigOrderStatsDto.empty());
         }

--- a/koduck-backend/src/main/java/com/koduck/service/impl/AiAnalysisServiceImpl.java
+++ b/koduck-backend/src/main/java/com/koduck/service/impl/AiAnalysisServiceImpl.java
@@ -13,15 +13,10 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.regex.Pattern;
 
-import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.core.ParameterizedTypeReference;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.RestTemplate;
+import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -100,12 +95,6 @@ public class AiAnalysisServiceImpl implements AiAnalysisService {
         new ParameterizedTypeReference<>() {
         };
 
-    /** Timeout duration for connection (seconds). */
-    private static final int CONNECTION_TIMEOUT_SECONDS = 30;
-
-    /** Timeout duration for read (seconds). */
-    private static final int READ_TIMEOUT_SECONDS = 60;
-
     /** HTTP status code for internal server error. */
     private static final int HTTP_STATUS_INTERNAL_ERROR = 500;
 
@@ -127,8 +116,8 @@ public class AiAnalysisServiceImpl implements AiAnalysisService {
     /** Object mapper for JSON serialization. */
     private final ObjectMapper objectMapper;
 
-    /** REST template for HTTP calls. */
-    private final RestTemplate restTemplate;
+    /** WebClient for HTTP calls. */
+    private final WebClient webClient;
 
     /** Support for AI conversations. */
     private final AiConversationSupport aiConversationSupport;
@@ -148,7 +137,7 @@ public class AiAnalysisServiceImpl implements AiAnalysisService {
      * @param userSettingsService the user settings service
      * @param agentConfig the agent configuration
      * @param objectMapper the object mapper
-     * @param restTemplateBuilder the REST template builder
+     * @param webClientBuilder the WebClient builder
      * @param aiConversationSupport the AI conversation support
      * @param aiStreamRelaySupport the AI stream relay support
      * @param aiRecommendationSupport the AI recommendation support
@@ -160,7 +149,7 @@ public class AiAnalysisServiceImpl implements AiAnalysisService {
             UserSettingsService userSettingsService,
             AgentConfig agentConfig,
             ObjectMapper objectMapper,
-            RestTemplateBuilder restTemplateBuilder,
+            WebClient.Builder webClientBuilder,
             AiConversationSupport aiConversationSupport,
             AiStreamRelaySupport aiStreamRelaySupport,
             AiRecommendationSupport aiRecommendationSupport) {
@@ -170,9 +159,8 @@ public class AiAnalysisServiceImpl implements AiAnalysisService {
         this.userSettingsService = userSettingsService;
         this.agentConfig = agentConfig;
         this.objectMapper = objectMapper;
-        this.restTemplate = restTemplateBuilder
-            .connectTimeout(Duration.ofSeconds(CONNECTION_TIMEOUT_SECONDS))
-            .readTimeout(Duration.ofSeconds(READ_TIMEOUT_SECONDS))
+        this.webClient = webClientBuilder
+            .baseUrl(agentConfig.getUrl())
             .build();
         this.aiConversationSupport = aiConversationSupport;
         this.aiStreamRelaySupport = aiStreamRelaySupport;
@@ -289,7 +277,6 @@ public class AiAnalysisServiceImpl implements AiAnalysisService {
     }
 
     private String callAgentChat(String provider, String userMessage, LlmConfigDto config) {
-        String agentUrl = agentConfig.getUrl() + "/v1/chat/completions";
         Map<String, Object> requestBody = new HashMap<>();
         requestBody.put("provider", resolveProvider(provider));
         requestBody.put("apiKey", blankToNull(config != null ? config.getApiKey() : null));
@@ -299,18 +286,15 @@ public class AiAnalysisServiceImpl implements AiAnalysisService {
         requestBody.put("messages", messages);
         requestBody.put("stream", false);
 
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON);
-        HttpEntity<Map<String, Object>> entity = new HttpEntity<>(requestBody, headers);
+        Map<String, Object> response = webClient.post()
+            .uri("/v1/chat/completions")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(requestBody)
+            .retrieve()
+            .bodyToMono(MAP_RESPONSE_TYPE)
+            .block();
 
-        ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
-            agentUrl,
-            Objects.requireNonNull(HttpMethod.POST),
-            entity,
-            Objects.requireNonNull(MAP_RESPONSE_TYPE)
-        );
-
-        String content = extractAgentContent(response.getBody());
+        String content = extractAgentContent(response);
         if (content != null) {
             return content;
         }

--- a/koduck-backend/src/test/java/com/koduck/service/AiAnalysisServiceImplTest.java
+++ b/koduck-backend/src/test/java/com/koduck/service/AiAnalysisServiceImplTest.java
@@ -1,7 +1,6 @@
 package com.koduck.service;
 
 import java.math.BigDecimal;
-import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -13,11 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.boot.web.client.RestTemplateBuilder;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.client.RestTemplate;
+import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -45,11 +40,12 @@ import com.koduck.service.support.AiConversationSupport;
 import com.koduck.service.support.AiRecommendationSupport;
 import com.koduck.service.support.AiStreamRelaySupport;
 
+import reactor.core.publisher.Mono;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
@@ -177,13 +173,22 @@ class AiAnalysisServiceImplTest {
     @Mock
     private AgentConfig agentConfig;
 
-    /** Mock builder for REST template. */
+    /** Mock builder for WebClient. */
     @Mock
-    private RestTemplateBuilder restTemplateBuilder;
+    private WebClient.Builder webClientBuilder;
 
-    /** Mock REST template. */
+    /** Mock WebClient. */
     @Mock
-    private RestTemplate restTemplate;
+    private WebClient webClient;
+
+    /** Mock WebClient request spec (using raw type to avoid generic issues). */
+    @Mock
+    @SuppressWarnings("rawtypes")
+    private WebClient.RequestBodyUriSpec requestBodyUriSpec;
+
+    /** Mock WebClient response spec. */
+    @Mock
+    private WebClient.ResponseSpec responseSpec;
 
     /** Mock support for AI conversation. */
     @Mock
@@ -206,12 +211,19 @@ class AiAnalysisServiceImplTest {
     @BeforeEach
     void setUp() {
         objectMapper = new ObjectMapper();
-        lenient().when(restTemplateBuilder.connectTimeout(any(Duration.class)))
-                .thenReturn(restTemplateBuilder);
-        lenient().when(restTemplateBuilder.readTimeout(any(Duration.class)))
-                .thenReturn(restTemplateBuilder);
-        lenient().when(restTemplateBuilder.build()).thenReturn(restTemplate);
+        
+        // Setup WebClient builder chain
+        lenient().when(webClientBuilder.baseUrl(anyString())).thenReturn(webClientBuilder);
+        lenient().when(webClientBuilder.build()).thenReturn(webClient);
         lenient().when(agentConfig.getUrl()).thenReturn(TEST_AGENT_URL);
+        
+        // Setup WebClient request chain using lenient stubbing with thenAnswer
+        // to avoid complex generic type issues with WebClient fluent API
+        lenient().when(webClient.post()).thenReturn(requestBodyUriSpec);
+        lenient().when(requestBodyUriSpec.uri(anyString())).thenAnswer(inv -> requestBodyUriSpec);
+        lenient().when(requestBodyUriSpec.contentType(any())).thenAnswer(inv -> requestBodyUriSpec);
+        lenient().when(requestBodyUriSpec.bodyValue(any())).thenAnswer(inv -> requestBodyUriSpec);
+        lenient().when(requestBodyUriSpec.retrieve()).thenReturn(responseSpec);
 
         aiAnalysisService = new AiAnalysisServiceImpl(
                 positionRepository,
@@ -220,11 +232,26 @@ class AiAnalysisServiceImplTest {
                 userSettingsService,
                 agentConfig,
                 objectMapper,
-                restTemplateBuilder,
+                webClientBuilder,
                 aiConversationSupport,
                 aiStreamRelaySupport,
                 aiRecommendationSupport
         );
+    }
+
+    private void mockWebClientResponse(Map<String, Object> response) {
+        if (response == null) {
+            when(responseSpec.bodyToMono(any(org.springframework.core.ParameterizedTypeReference.class)))
+                    .thenReturn(Mono.empty());
+        } else {
+            when(responseSpec.bodyToMono(any(org.springframework.core.ParameterizedTypeReference.class)))
+                    .thenReturn(Mono.just(response));
+        }
+    }
+
+    private void mockWebClientError(RuntimeException exception) {
+        when(responseSpec.bodyToMono(any(org.springframework.core.ParameterizedTypeReference.class)))
+                .thenReturn(Mono.error(exception));
     }
 
     // ==================== analyzeStock Tests ====================
@@ -255,12 +282,7 @@ class AiAnalysisServiceImplTest {
         );
 
         when(userSettingsService.getEffectiveLlmConfig(userId, DEFAULT_PROVIDER)).thenReturn(llmConfig);
-        given(restTemplate.exchange(
-            anyString(),
-            eq(HttpMethod.POST),
-            any(HttpEntity.class),
-            any(org.springframework.core.ParameterizedTypeReference.class)
-        )).willReturn(ResponseEntity.ok(agentResponse));
+        mockWebClientResponse(agentResponse);
         when(aiRecommendationSupport.generateRecommendationFromResponse("这是一个买入信号"))
                 .thenReturn("建议买入");
 
@@ -298,12 +320,7 @@ class AiAnalysisServiceImplTest {
         );
 
         when(userSettingsService.getEffectiveLlmConfig(userId, DEFAULT_PROVIDER)).thenReturn(llmConfig);
-        given(restTemplate.exchange(
-            anyString(),
-            any(HttpMethod.class),
-            any(HttpEntity.class),
-            any(org.springframework.core.ParameterizedTypeReference.class)
-        )).willReturn(ResponseEntity.ok(agentResponse));
+        mockWebClientResponse(agentResponse);
         when(aiRecommendationSupport.generateRecommendationFromResponse("分析结果"))
                 .thenReturn("建议观望");
 
@@ -337,12 +354,7 @@ class AiAnalysisServiceImplTest {
         );
 
         when(userSettingsService.getEffectiveLlmConfig(userId, PROVIDER_DEEPSEEK)).thenReturn(llmConfig);
-        given(restTemplate.exchange(
-            anyString(),
-            any(HttpMethod.class),
-            any(HttpEntity.class),
-            any(org.springframework.core.ParameterizedTypeReference.class)
-        )).willReturn(ResponseEntity.ok(agentResponse));
+        mockWebClientResponse(agentResponse);
         when(aiRecommendationSupport.generateRecommendationFromResponse("Deepseek分析结果"))
                 .thenReturn("建议买入");
 
@@ -376,12 +388,7 @@ class AiAnalysisServiceImplTest {
         );
 
         when(userSettingsService.getEffectiveLlmConfig(userId, DEFAULT_PROVIDER)).thenReturn(llmConfig);
-        given(restTemplate.exchange(
-            anyString(),
-            any(HttpMethod.class),
-            any(HttpEntity.class),
-            any(org.springframework.core.ParameterizedTypeReference.class)
-        )).willReturn(ResponseEntity.ok(agentResponse));
+        mockWebClientResponse(agentResponse);
         when(aiRecommendationSupport.generateRecommendationFromResponse("分析结果"))
                 .thenReturn("建议观望");
 
@@ -408,12 +415,7 @@ class AiAnalysisServiceImplTest {
                 .build();
 
         when(userSettingsService.getEffectiveLlmConfig(userId, DEFAULT_PROVIDER)).thenReturn(llmConfig);
-        given(restTemplate.exchange(
-            anyString(),
-            any(HttpMethod.class),
-            any(HttpEntity.class),
-            any(org.springframework.core.ParameterizedTypeReference.class)
-        )).willThrow(new RuntimeException("Connection refused"));
+        mockWebClientError(new RuntimeException("Connection refused"));
 
         // When & Then
         assertThatThrownBy(() -> aiAnalysisService.analyzeStock(userId, request))
@@ -439,12 +441,7 @@ class AiAnalysisServiceImplTest {
         Map<String, Object> agentResponse = Map.of("choices", Collections.emptyList());
 
         when(userSettingsService.getEffectiveLlmConfig(userId, DEFAULT_PROVIDER)).thenReturn(llmConfig);
-        given(restTemplate.exchange(
-            anyString(),
-            any(HttpMethod.class),
-            any(HttpEntity.class),
-            any(org.springframework.core.ParameterizedTypeReference.class)
-        )).willReturn(ResponseEntity.ok(agentResponse));
+        mockWebClientResponse(agentResponse);
 
         // When & Then
         assertThatThrownBy(() -> aiAnalysisService.analyzeStock(userId, request))
@@ -482,12 +479,7 @@ class AiAnalysisServiceImplTest {
         );
 
         when(userSettingsService.getEffectiveLlmConfig(userId, DEFAULT_PROVIDER)).thenReturn(llmConfig);
-        given(restTemplate.exchange(
-            anyString(),
-            any(HttpMethod.class),
-            any(HttpEntity.class),
-            any(org.springframework.core.ParameterizedTypeReference.class)
-        )).willReturn(ResponseEntity.ok(agentResponse));
+        mockWebClientResponse(agentResponse);
         when(aiRecommendationSupport.generateRecommendationFromResponse("分析完成"))
                 .thenReturn("建议买入");
 
@@ -521,7 +513,7 @@ class AiAnalysisServiceImplTest {
 
         when(userSettingsService.getEffectiveLlmConfig(userId, DEFAULT_PROVIDER)).thenReturn(llmConfig);
         when(aiConversationSupport.resolveSessionId(any())).thenReturn(TEST_SESSION_ID);
-        when(aiConversationSupport.enrichWithMemoryContext(eq(userId), any())).thenReturn(request);
+        when(aiConversationSupport.enrichWithMemoryContext(any(), any())).thenReturn(request);
         when(aiConversationSupport.enrichWithQuantSignalIfNeeded(any(), any())).thenReturn(request);
 
         // When
@@ -552,7 +544,7 @@ class AiAnalysisServiceImplTest {
 
         when(userSettingsService.getEffectiveLlmConfig(userId, DEFAULT_PROVIDER)).thenReturn(llmConfig);
         when(aiConversationSupport.resolveSessionId(any())).thenReturn(TEST_SESSION_ID);
-        when(aiConversationSupport.enrichWithMemoryContext(eq(userId), any())).thenReturn(request);
+        when(aiConversationSupport.enrichWithMemoryContext(any(), any())).thenReturn(request);
         when(aiConversationSupport.appendInstructionToSystem(any(), anyString())).thenReturn(request);
         when(aiConversationSupport.enrichWithQuantSignalIfNeeded(any(), any())).thenReturn(request);
 
@@ -580,7 +572,7 @@ class AiAnalysisServiceImplTest {
 
         when(userSettingsService.getEffectiveLlmConfig(userId, DEFAULT_PROVIDER)).thenReturn(null);
         when(aiConversationSupport.resolveSessionId(any())).thenReturn(TEST_SESSION_ID);
-        when(aiConversationSupport.enrichWithMemoryContext(eq(userId), any())).thenReturn(request);
+        when(aiConversationSupport.enrichWithMemoryContext(any(), any())).thenReturn(request);
         when(aiConversationSupport.enrichWithQuantSignalIfNeeded(any(), any())).thenReturn(request);
 
         // When
@@ -787,12 +779,7 @@ class AiAnalysisServiceImplTest {
         );
 
         when(userSettingsService.getEffectiveLlmConfig(userId, PROVIDER_OPENAI)).thenReturn(llmConfig);
-        given(restTemplate.exchange(
-            anyString(),
-            any(HttpMethod.class),
-            any(HttpEntity.class),
-            any(org.springframework.core.ParameterizedTypeReference.class)
-        )).willReturn(ResponseEntity.ok(agentResponse));
+        mockWebClientResponse(agentResponse);
         when(aiRecommendationSupport.generateRecommendationFromResponse("OpenAI分析结果"))
                 .thenReturn("建议买入");
 
@@ -826,12 +813,7 @@ class AiAnalysisServiceImplTest {
         );
 
         when(userSettingsService.getEffectiveLlmConfig(userId, PROVIDER_DEEPSEEK)).thenReturn(llmConfig);
-        given(restTemplate.exchange(
-            anyString(),
-            any(HttpMethod.class),
-            any(HttpEntity.class),
-            any(org.springframework.core.ParameterizedTypeReference.class)
-        )).willReturn(ResponseEntity.ok(agentResponse));
+        mockWebClientResponse(agentResponse);
         when(aiRecommendationSupport.generateRecommendationFromResponse("分析结果"))
                 .thenReturn("建议观望");
 
@@ -858,12 +840,7 @@ class AiAnalysisServiceImplTest {
                 .build();
 
         when(userSettingsService.getEffectiveLlmConfig(userId, DEFAULT_PROVIDER)).thenReturn(llmConfig);
-        when(restTemplate.exchange(
-                anyString(),
-                any(HttpMethod.class),
-                any(HttpEntity.class),
-                any(org.springframework.core.ParameterizedTypeReference.class)
-        )).thenReturn(ResponseEntity.ok(null));
+        mockWebClientResponse(null);
 
         // When & Then
         assertThatThrownBy(() -> aiAnalysisService.analyzeStock(userId, request))
@@ -894,12 +871,7 @@ class AiAnalysisServiceImplTest {
         );
 
         when(userSettingsService.getEffectiveLlmConfig(userId, DEFAULT_PROVIDER)).thenReturn(llmConfig);
-        given(restTemplate.exchange(
-            anyString(),
-            any(HttpMethod.class),
-            any(HttpEntity.class),
-            any(org.springframework.core.ParameterizedTypeReference.class)
-        )).willReturn(ResponseEntity.ok(agentResponse));
+        mockWebClientResponse(agentResponse);
         when(aiRecommendationSupport.generateRecommendationFromResponse("分析结果"))
                 .thenReturn("建议观望");
 


### PR DESCRIPTION
## 概述

修复之前 WebClient 迁移中遗漏的文件。

## 遗漏的文件

### 1. MarketAdvancedController
- 从 
- 改为 
- 更新 4 个 HTTP 调用方法：
  - getFearGreedIndex()
  - getMarketBreadth()
  - getBigOrders()
  - getBigOrderStats()

### 2. AiAnalysisServiceImpl
- 从  构建 
- 改为注入  构建 
- 更新  方法使用 WebClient

### 3. AiAnalysisServiceImplTest
- 更新测试以支持 WebClient
- 添加 WebClient 响应式链的 mock 支持

## 配置更新

更新 ：
- 熔断器配置中的异常类型从  改为 

## 验证

- ✅ Maven 编译通过
- ✅ Checkstyle 检查通过
- ✅ PMD 检查通过
- ✅ SpotBugs 检查通过
- ✅ 单元测试通过
- ✅ 切片测试通过
- ✅ JaCoCo 覆盖率检查通过
- ✅ 架构违规检查通过

## 关联

Relates to #408, #409