### PR TITLE
fix(config): 更新熔断器配置使用 WebClientResponseException

### DIFF
--- a/koduck-backend/src/main/resources/application.yml
+++ b/koduck-backend/src/main/resources/application.yml
@@ -202,7 +202,7 @@ resilience4j:
         permittedNumberOfCallsInHalfOpenState: ${DATA_SERVICE_CB_HALF_OPEN_CALLS:3}
         automaticTransitionFromOpenToHalfOpenEnabled: true
         recordExceptions:
-          - org.springframework.web.client.RestClientException
+          - org.springframework.web.reactive.function.client.WebClientResponseException
           - java.lang.RuntimeException
 
 # SpringDoc OpenAPI 配置


### PR DESCRIPTION
更新 Resilience4j 熔断器配置，将 recordExceptions 从 RestClientException 改为 WebClientResponseException，与 WebClient 迁移保持一致。

Relates to #408, #409, #410