### PR TITLE
fix(service): 细化异常捕获范围，将 catch (Exception) 改为 catch (RuntimeException)

### DIFF
--- a/koduck-backend/docs/ADR-0060-exception-catch-refinement.md
+++ b/koduck-backend/docs/ADR-0060-exception-catch-refinement.md
@@ -1,0 +1,94 @@
+# ADR-0060: Service 层异常捕获精细化
+
+- Status: Accepted
+- Date: 2026-04-04
+- Issue: #414
+
+## Context
+
+根据 `ARCHITECTURE-EVALUATION.md` 的代码质量评估，Service 层存在多处过度使用 `catch (Exception e)` 的情况：
+
+1. **StockSubscriptionServiceImpl**: 订阅/取消订阅/推送价格更新时捕获 Exception
+2. **StockCacheServiceImpl**: 缓存操作时捕获 Exception
+3. **BacktestServiceImpl**: 回测执行时捕获 Exception
+4. **UserCacheServiceImpl**: 用户缓存操作时捕获 Exception
+5. **MarketSentimentServiceImpl**: 市场情绪计算时捕获 Exception
+
+这些问题导致：
+- 吞掉具体异常类型，调用方难以根据异常类型做差异化处理
+- 掩盖本应立即暴露的系统缺陷（如 OOM、InterruptedException）
+- 日志中丢失原始异常类型信息，调试困难
+
+## Decision
+
+### 异常捕获范围收窄
+
+将 Service 层中过于宽泛的 `catch (Exception e)` 统一收窄为 `catch (RuntimeException e)`：
+
+```java
+// 修改前
+catch (Exception e) {
+    log.warn("Failed to ...: {}", e.getMessage());
+    return fallbackValue;
+}
+
+// 修改后
+catch (RuntimeException e) {
+    log.warn("Failed to ...: {}", e.getMessage());
+    return fallbackValue;
+}
+```
+
+### 修改范围
+
+| 文件 | 修改位置 | 说明 |
+|------|----------|------|
+| StockSubscriptionServiceImpl.java | 3 处 | 订阅、取消订阅、价格推送 |
+| StockCacheServiceImpl.java | 6 处 | 缓存读写操作 |
+| BacktestServiceImpl.java | 1 处 | 回测执行 |
+| UserCacheServiceImpl.java | 8 处 | 用户追踪/观察列表缓存 |
+| MarketSentimentServiceImpl.java | 3 处 | 情绪计算、活跃度、波动率 |
+
+### 保留策略
+
+以下场景保持现状，不修改：
+
+1. **DataInitializer**: 启动初始化时的容错处理，需要捕获所有异常防止启动失败
+2. **监控类 (MonitoringServiceImpl)**: 监控检查失败不应影响主流程
+3. **邮件服务 (EmailServiceImpl)**: 邮件发送失败是边缘功能，不应影响主流程
+4. **限流服务 (RateLimiterServiceImpl)**: Redis 异常时需要降级允许请求通过
+5. **工具类 (DataConverter, AKShareDataMapperSupport)**: 数据转换的容错处理
+6. **WebSocket 消息解析**: 消息解析失败不应断开连接
+
+## Consequences
+
+### 正向影响
+
+- 异常捕获范围从 `Exception` 收窄到 `RuntimeException`，避免受检异常被无意义吞掉
+- 系统级错误（如 OOM、InterruptedException）将向上传播，由全局异常处理器处理或导致应用终止
+- 问题定位更精确，日志中保留原始异常类型信息
+
+### 兼容性影响
+
+- 行为变更：原本会被捕获的受检异常（如 IOException）现在会向上传播
+- 风险评估：这些异常原本就是被"意外"捕获的，正确行为应该是向上传播
+- 降级逻辑保留：对于预期的运行时异常（如 Redis 连接失败），仍保留降级处理
+
+## Alternatives Considered
+
+1. **捕获更具体的异常（如 DataAccessException、RedisConnectionFailureException）**
+   - 拒绝：需要引入额外的依赖和类型检查，复杂度较高
+   - 当前方案：使用 RuntimeException 作为合理折中，涵盖所有业务/数据访问异常
+
+2. **完全移除 try-catch，所有异常向上传播**
+   - 拒绝：缓存、订阅等场景需要合理的降级逻辑，不能直接失败
+   - 当前方案：保留降级逻辑，仅收窄异常捕获范围
+
+3. **使用 @SneakyThrows 或异常包装**
+   - 拒绝：不符合项目编码规范，会增加调试复杂度
+
+## Verification
+
+- `mvn -f koduck-backend/pom.xml clean compile` 编译通过
+- `mvn -f koduck-backend/pom.xml checkstyle:check` 无异常
+- `./koduck-backend/scripts/quality-check.sh` 全绿

--- a/koduck-backend/src/main/java/com/koduck/service/impl/BacktestServiceImpl.java
+++ b/koduck-backend/src/main/java/com/koduck/service/impl/BacktestServiceImpl.java
@@ -147,7 +147,7 @@ public class BacktestServiceImpl implements BacktestService {
             resultRepository.save(savedResult);
             log.info("Backtest completed: id={}, user={}", savedResult.getId(), userId);
         }
-        catch (Exception e) {
+        catch (RuntimeException e) {
             log.error("Backtest failed: id={}, error={}", savedResult.getId(), e.getMessage(), e);
             savedResult.setStatus(BacktestResult.BacktestStatus.FAILED);
             savedResult.setErrorMessage(e.getMessage());

--- a/koduck-backend/src/main/java/com/koduck/service/impl/MarketSentimentServiceImpl.java
+++ b/koduck-backend/src/main/java/com/koduck/service/impl/MarketSentimentServiceImpl.java
@@ -213,7 +213,7 @@ public class MarketSentimentServiceImpl implements MarketSentimentService {
                             .build())
                     .build();
         }
-        catch (Exception e) {
+        catch (RuntimeException e) {
             log.error("Failed to calculate market sentiment for {}", marketType, e);
             // Return fallback data
             return createFallbackSentiment(marketType);
@@ -249,7 +249,7 @@ public class MarketSentimentServiceImpl implements MarketSentimentService {
             }
             return score;
         }
-        catch (Exception e) {
+        catch (RuntimeException e) {
             log.warn("Failed to calculate activity score", e);
             return DEFAULT_NEUTRAL_SCORE;
         }
@@ -291,7 +291,7 @@ public class MarketSentimentServiceImpl implements MarketSentimentService {
             int score = (int) Math.min(SCORE_SCALE, Math.max(0, volatilityPct * VOLATILITY_SCALE));
             return score;
         }
-        catch (Exception e) {
+        catch (RuntimeException e) {
             log.warn("Failed to calculate volatility score", e);
             return DEFAULT_LOW_SCORE;
         }

--- a/koduck-backend/src/main/java/com/koduck/service/impl/StockCacheServiceImpl.java
+++ b/koduck-backend/src/main/java/com/koduck/service/impl/StockCacheServiceImpl.java
@@ -74,7 +74,7 @@ public class StockCacheServiceImpl implements StockCacheService {
             );
             log.debug("Cached stock track: symbol={}", symbol);
         }
-        catch (Exception e) {
+        catch (RuntimeException e) {
             log.warn("Failed to cache stock track: symbol={}, error={}", symbol, e.getMessage());
         }
     }
@@ -94,7 +94,7 @@ public class StockCacheServiceImpl implements StockCacheService {
                 return convertToPriceQuoteDto(cached);
             }
         }
-        catch (Exception e) {
+        catch (RuntimeException e) {
             log.warn("Failed to get cached stock track: symbol={}, error={}", symbol, e.getMessage());
         }
         return null;
@@ -124,7 +124,7 @@ public class StockCacheServiceImpl implements StockCacheService {
             cacheLayer.replaceList(nonNullKey, symbols, RedisKeyConstants.TTL_HOT_STOCKS);
             log.debug("Cached hot stocks: type={}, count={}", type, symbols != null ? symbols.size() : 0);
         }
-        catch (Exception e) {
+        catch (RuntimeException e) {
             log.warn("Failed to cache hot stocks: type={}, error={}", type, e.getMessage());
         }
     }
@@ -141,7 +141,7 @@ public class StockCacheServiceImpl implements StockCacheService {
                         .toList();
             }
         }
-        catch (Exception e) {
+        catch (RuntimeException e) {
             log.warn("Failed to get cached hot stocks: type={}, error={}", type, e.getMessage());
         }
         return List.of();
@@ -169,7 +169,7 @@ public class StockCacheServiceImpl implements StockCacheService {
         try {
             return cacheLayer.hasKey(requireNonNullString(key, KEY_NULL_MESSAGE));
         }
-        catch (Exception e) {
+        catch (RuntimeException e) {
             log.warn("Failed to check stock track cache: symbol={}, error={}", symbol, e.getMessage());
             return false;
         }
@@ -195,7 +195,7 @@ public class StockCacheServiceImpl implements StockCacheService {
             try {
                 return buildPriceQuoteFromMap(map);
             }
-            catch (Exception e) {
+            catch (RuntimeException e) {
                 log.warn("Failed to convert cached object: error={}", e.getMessage());
             }
         }

--- a/koduck-backend/src/main/java/com/koduck/service/impl/StockSubscriptionServiceImpl.java
+++ b/koduck-backend/src/main/java/com/koduck/service/impl/StockSubscriptionServiceImpl.java
@@ -90,7 +90,7 @@ public class StockSubscriptionServiceImpl implements StockSubscriptionService {
                 successList.add(normalizedSymbol);
                 log.debug("User {} subscribed to stock {}", userId, normalizedSymbol);
             }
-            catch (Exception e) {
+            catch (RuntimeException e) {
                 failedMap.put(symbol, e.getMessage());
                 log.warn("Failed to subscribe user {} to stock {}: {}", userId, symbol, e.getMessage());
             }
@@ -162,7 +162,7 @@ public class StockSubscriptionServiceImpl implements StockSubscriptionService {
                 successList.add(normalizedSymbol);
                 log.debug("User {} unsubscribed from stock {}", userId, normalizedSymbol);
             }
-            catch (Exception e) {
+            catch (RuntimeException e) {
                 failedMap.put(symbol, e.getMessage());
                 log.warn("Failed to unsubscribe user {} from stock {}: {}", userId, symbol, e.getMessage());
             }
@@ -275,7 +275,7 @@ public class StockSubscriptionServiceImpl implements StockSubscriptionService {
                 );
                 log.debug("Sent price update for {} to user {}", symbol, userId);
             }
-            catch (Exception e) {
+            catch (RuntimeException e) {
                 log.error("Failed to send price update to user {}: {}", userId, e.getMessage());
             }
         }

--- a/koduck-backend/src/main/java/com/koduck/service/impl/UserCacheServiceImpl.java
+++ b/koduck-backend/src/main/java/com/koduck/service/impl/UserCacheServiceImpl.java
@@ -34,7 +34,7 @@ public class UserCacheServiceImpl implements UserCacheService {
         try {
             cacheLayer.addSetMember(key, symbol);
             log.debug("Added to user track list: userId={}, symbol={}", userId, symbol);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             log.warn("Failed to add to user track list: userId={}, symbol={}, error={}", 
                     userId, symbol, e.getMessage());
         }
@@ -46,7 +46,7 @@ public class UserCacheServiceImpl implements UserCacheService {
         try {
             cacheLayer.removeSetMember(key, symbol);
             log.debug("Removed from user track list: userId={}, symbol={}", userId, symbol);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             log.warn("Failed to remove from user track list: userId={}, symbol={}, error={}", 
                     userId, symbol, e.getMessage());
         }
@@ -63,7 +63,7 @@ public class UserCacheServiceImpl implements UserCacheService {
                         .map(Object::toString)
                         .collect(Collectors.toSet());
             }
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             log.warn("Failed to get user track list: userId={}, error={}", userId, e.getMessage());
         }
         return Set.of();
@@ -75,7 +75,7 @@ public class UserCacheServiceImpl implements UserCacheService {
         try {
             Set<Object> members = cacheLayer.getSetMembers(key);
             return members != null && members.contains(symbol);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             log.warn("Failed to check user track list: userId={}, symbol={}, error={}", 
                     userId, symbol, e.getMessage());
             return false;
@@ -90,7 +90,7 @@ public class UserCacheServiceImpl implements UserCacheService {
         try {
             cacheLayer.addSetMember(key, symbol);
             log.debug("Added to user watch list: userId={}, symbol={}", userId, symbol);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             log.warn("Failed to add to user watch list: userId={}, symbol={}, error={}", 
                     userId, symbol, e.getMessage());
         }
@@ -102,7 +102,7 @@ public class UserCacheServiceImpl implements UserCacheService {
         try {
             cacheLayer.removeSetMember(key, symbol);
             log.debug("Removed from user watch list: userId={}, symbol={}", userId, symbol);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             log.warn("Failed to remove from user watch list: userId={}, symbol={}, error={}", 
                     userId, symbol, e.getMessage());
         }
@@ -119,7 +119,7 @@ public class UserCacheServiceImpl implements UserCacheService {
                         .map(Object::toString)
                         .collect(Collectors.toSet());
             }
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             log.warn("Failed to get user watch list: userId={}, error={}", userId, e.getMessage());
         }
         return Set.of();
@@ -133,7 +133,7 @@ public class UserCacheServiceImpl implements UserCacheService {
         try {
             cacheLayer.replaceSet(key, symbols);
             log.debug("Cached user track list: userId={}, count={}", userId, symbols != null ? symbols.size() : 0);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             log.warn("Failed to cache user track list: userId={}, error={}", userId, e.getMessage());
         }
     }
@@ -144,7 +144,7 @@ public class UserCacheServiceImpl implements UserCacheService {
         try {
             cacheLayer.replaceSet(key, symbols);
             log.debug("Cached user watch list: userId={}, count={}", userId, symbols != null ? symbols.size() : 0);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             log.warn("Failed to cache user watch list: userId={}, error={}", userId, e.getMessage());
         }
     }
@@ -157,7 +157,7 @@ public class UserCacheServiceImpl implements UserCacheService {
             cacheLayer.delete(trackKey);
             cacheLayer.delete(watchKey);
             log.debug("Invalidated user cache: userId={}", userId);
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             log.warn("Failed to invalidate user cache: userId={}, error={}", userId, e.getMessage());
         }
     }


### PR DESCRIPTION
## 问题描述

根据 ARCHITECTURE-EVALUATION.md 的代码质量评估，Service 层存在多处过度使用 `catch (Exception e)` 的情况。

## 修改内容

将以下 5 个 Service 实现类中的异常捕获范围从 `Exception` 收窄为 `RuntimeException`：

| 文件 | 修改处 | 说明 |
|------|--------|------|
| StockSubscriptionServiceImpl.java | 3 处 | 订阅、取消订阅、价格推送 |
| StockCacheServiceImpl.java | 6 处 | 缓存读写操作 |
| BacktestServiceImpl.java | 1 处 | 回测执行 |
| UserCacheServiceImpl.java | 10 处 | 用户追踪/观察列表缓存 |
| MarketSentimentServiceImpl.java | 3 处 | 情绪计算、活跃度、波动率 |

## 影响分析

- **正向影响**：避免吞掉系统级异常（OOM、InterruptedException），问题定位更精确
- **兼容性**：原本被意外捕获的受检异常现在会正确向上传播
- **降级逻辑保留**：对于预期的运行时异常（如 Redis 连接失败），仍保留降级处理

## 质量检查

- [x] mvn clean compile 编译通过
- [x] mvn checkstyle:check 无异常
- [x] quality-check.sh 全绿

## ADR

已创建 ADR-0060 记录决策详情。

Closes #414