### PR TITLE
fix(backtest): 修复 BacktestServiceImpl 交易记录 symbol 硬编码问题

### DIFF
--- a/koduck-backend/docs/ADR-0066-fix-backtest-symbol-hardcode.md
+++ b/koduck-backend/docs/ADR-0066-fix-backtest-symbol-hardcode.md
@@ -1,0 +1,109 @@
+# ADR-0066: 修复 BacktestServiceImpl 交易记录 symbol 硬编码问题
+
+- Status: Accepted
+- Date: 2026-04-04
+- Issue: #426
+
+## Context
+
+根据 `ARCHITECTURE-EVALUATION.md` 的数据正确性评估，`BacktestServiceImpl` 中存在 symbol 硬编码问题：
+
+| 问题类型 | 位置 | 当前实现 |
+|----------|------|----------|
+| symbol 硬编码 | `executeBuy()` 第 313 行 | `.symbol("SYMBOL")` |
+| symbol 硬编码 | `executeSell()` 第 349 行 | `.symbol("SYMBOL")` |
+
+### 具体问题分析
+
+在 `executeBacktest(BacktestResult result)` 方法中，`result.getSymbol()` 已经保存了用户传入的实际股票代码（如 `000001`、`600519`）。然而，`executeBuy` 和 `executeSell` 在构建 `BacktestTrade` 时，未接收该股票代码，而是直接硬编码为 `"SYMBOL"`：
+
+```java
+return BacktestTrade.builder()
+    .backtestResultId(backtestResultId)
+    .tradeType(TradeType.BUY)
+    // ...
+    .symbol("SYMBOL")  // 硬编码
+    // ...
+    .build();
+```
+
+这导致：
+- **数据正确性缺陷**：所有回测交易记录的 `symbol` 字段都是 `"SYMBOL"`，无法区分不同标的
+- **查询分析失效**：按股票代码筛选、统计、报表时结果混乱
+- **回测结果无意义**：多标的回测数据混在一起，无法用于后续策略优化
+
+## Decision
+
+### 1. 修改 `executeBuy` / `executeSell` 方法签名
+
+为两个方法增加 `String symbol` 参数，使其能够接收实际股票代码：
+
+**修改前：**
+```java
+private BacktestTrade executeBuy(BacktestExecutionContext context, KlineDataDto current,
+                                 Long backtestResultId)
+
+private BacktestTrade executeSell(BacktestExecutionContext context, KlineDataDto current,
+                                  Long backtestResultId)
+```
+
+**修改后：**
+```java
+private BacktestTrade executeBuy(BacktestExecutionContext context, KlineDataDto current,
+                                 Long backtestResultId, String symbol)
+
+private BacktestTrade executeSell(BacktestExecutionContext context, KlineDataDto current,
+                                  Long backtestResultId, String symbol)
+```
+
+### 2. 替换硬编码为传入参数
+
+将 builder 中的 `.symbol("SYMBOL")` 替换为 `.symbol(symbol)`。
+
+### 3. 更新调用点
+
+在 `executeBacktest` 方法中，调用这两个方法时传入 `result.getSymbol()`：
+
+```java
+BacktestTrade trade = executeBuy(context, current, result.getId(), result.getSymbol());
+// ...
+BacktestTrade trade = executeSell(context, current, result.getId(), result.getSymbol());
+```
+
+### 4. 添加回归测试
+
+新增 `BacktestServiceImplTest`：
+- 使用 Mockito 对 `BacktestServiceImpl` 的依赖进行 mock
+- 通过 `ReflectionTestUtils.invokeMethod` 调用私有方法 `executeBuy` / `executeSell`
+- 断言返回的 `BacktestTrade.symbol` 与传入的实际股票代码一致
+
+## Consequences
+
+### 正向影响
+
+- **数据正确性恢复**：交易记录能够正确关联到实际股票代码
+- **多标的回测可用**：支持不同 symbol 的回测结果独立存储和分析
+- **修改范围极小**：仅涉及两个私有方法签名和两处调用点，零外部 API 变更
+
+### 兼容性影响
+
+- **API 行为不变**：HTTP 接口、DTO、数据库表结构均无变化
+- **内部方法签名变更**：`executeBuy` / `executeSell` 增加 `symbol` 参数，但均为私有方法，不影响外部调用方
+- **数据修复**：历史已产生的 `"SYMBOL"` 记录需通过数据修复脚本处理（不在本次范围内）
+
+## Alternatives Considered
+
+1. **将 symbol 放入 `BacktestExecutionContext`**
+   - 拒绝：`BacktestExecutionContext` 的职责是维护资金、仓位、成本等交易状态，股票代码不属于"执行上下文"，放入其中会混淆职责边界
+   - 当前方案：通过方法参数显式传递，职责清晰
+
+2. **保持硬编码，由上游修正**
+   - 拒绝：在 `executeBacktest` 循环结束后遍历 trades 再 setSymbol 是事后补丁，容易遗漏且不符合最小惊讶原则
+   - 当前方案：在构造交易记录时直接使用正确数据
+
+## Verification
+
+- `mvn -f koduck-backend/pom.xml clean compile` 编译通过
+- `mvn -f koduck-backend/pom.xml checkstyle:check` 无异常
+- `./koduck-backend/scripts/quality-check.sh` 全绿
+- 新增单元测试通过，验证 `executeBuy` / `executeSell` 的 `symbol` 字段正确性

--- a/koduck-backend/src/main/java/com/koduck/service/impl/BacktestServiceImpl.java
+++ b/koduck-backend/src/main/java/com/koduck/service/impl/BacktestServiceImpl.java
@@ -225,14 +225,14 @@ public class BacktestServiceImpl implements BacktestService {
             BacktestSignal signal = generateSignal(history);
             if (signal == BacktestSignal.BUY && context.getPosition().compareTo(BigDecimal.ZERO) == 0) {
                 // Execute buy
-                BacktestTrade trade = executeBuy(context, current, result.getId());
+                BacktestTrade trade = executeBuy(context, current, result.getId(), result.getSymbol());
                 if (trade != null) {
                     trades.add(trade);
                 }
             }
             else if (signal == BacktestSignal.SELL && context.getPosition().compareTo(BigDecimal.ZERO) > 0) {
                 // Execute sell
-                BacktestTrade trade = executeSell(context, current, result.getId());
+                BacktestTrade trade = executeSell(context, current, result.getId(), result.getSymbol());
                 trades.add(trade);
             }
             // Record equity
@@ -291,7 +291,7 @@ public class BacktestServiceImpl implements BacktestService {
      * Execute buy order.
      */
     private BacktestTrade executeBuy(BacktestExecutionContext context, KlineDataDto current,
-                                     Long backtestResultId) {
+                                     Long backtestResultId, String symbol) {
         BigDecimal price = current.close().multiply(
             BigDecimal.ONE.add(context.getSlippage())).setScale(SCALE, RoundingMode.HALF_UP);
         // Use 90% of cash for position
@@ -310,7 +310,7 @@ public class BacktestServiceImpl implements BacktestService {
             .backtestResultId(backtestResultId)
             .tradeType(TradeType.BUY)
             .tradeTime(LocalDateTime.ofEpochSecond(current.timestamp(), 0, java.time.ZoneOffset.UTC))
-            .symbol("SYMBOL")
+            .symbol(symbol)
             .price(price)
             .quantity(quantity)
             .amount(amount)
@@ -327,7 +327,7 @@ public class BacktestServiceImpl implements BacktestService {
      * Execute sell order.
      */
     private BacktestTrade executeSell(BacktestExecutionContext context, KlineDataDto current,
-                                      Long backtestResultId) {
+                                      Long backtestResultId, String symbol) {
         BigDecimal price = current.close().multiply(
             BigDecimal.ONE.subtract(context.getSlippage())).setScale(SCALE, RoundingMode.HALF_UP);
         BigDecimal quantity = context.getPosition();
@@ -346,7 +346,7 @@ public class BacktestServiceImpl implements BacktestService {
             .backtestResultId(backtestResultId)
             .tradeType(TradeType.SELL)
             .tradeTime(LocalDateTime.ofEpochSecond(current.timestamp(), 0, java.time.ZoneOffset.UTC))
-            .symbol("SYMBOL")
+            .symbol(symbol)
             .price(price)
             .quantity(quantity)
             .amount(amount)

--- a/koduck-backend/src/test/java/com/koduck/service/BacktestServiceImplTest.java
+++ b/koduck-backend/src/test/java/com/koduck/service/BacktestServiceImplTest.java
@@ -1,0 +1,211 @@
+package com.koduck.service;
+
+import java.math.BigDecimal;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.koduck.dto.market.KlineDataDto;
+import com.koduck.entity.backtest.BacktestTrade;
+import com.koduck.mapper.BacktestTradeMapper;
+import com.koduck.repository.backtest.BacktestResultRepository;
+import com.koduck.repository.backtest.BacktestTradeRepository;
+import com.koduck.repository.strategy.StrategyRepository;
+import com.koduck.repository.strategy.StrategyVersionRepository;
+import com.koduck.service.impl.BacktestServiceImpl;
+import com.koduck.service.support.BacktestExecutionContext;
+import com.koduck.service.support.StrategyAccessSupport;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link BacktestServiceImpl}.
+ *
+ * @author Koduck Team
+ */
+@ExtendWith(MockitoExtension.class)
+class BacktestServiceImplTest {
+
+    /**
+     * Test stock symbol.
+     */
+    private static final String TEST_SYMBOL = "000001";
+
+    /**
+     * Test backtest result id.
+     */
+    private static final Long BACKTEST_RESULT_ID = 1L;
+
+    /**
+     * Commission rate for testing.
+     */
+    private static final BigDecimal COMMISSION_RATE = new BigDecimal("0.001");
+
+    /**
+     * Slippage for testing.
+     */
+    private static final BigDecimal SLIPPAGE = new BigDecimal("0.001");
+
+    /**
+     * Initial capital for testing.
+     */
+    private static final BigDecimal INITIAL_CAPITAL = new BigDecimal("100000");
+
+    /**
+     * Test trade price.
+     */
+    private static final BigDecimal TEST_PRICE = BigDecimal.TEN;
+
+    /**
+     * Test sell trade price.
+     */
+    private static final BigDecimal TEST_SELL_PRICE = new BigDecimal("11");
+
+    /**
+     * Test trade volume.
+     */
+    private static final long TEST_VOLUME = 100L;
+
+    /**
+     * Test trade amount for buy.
+     */
+    private static final BigDecimal TEST_AMOUNT_BUY = new BigDecimal("1000");
+
+    /**
+     * Test trade amount for sell.
+     */
+    private static final BigDecimal TEST_AMOUNT_SELL = new BigDecimal("1100");
+
+    /**
+     * Test position size.
+     */
+    private static final BigDecimal TEST_POSITION = new BigDecimal("1000");
+
+    /**
+     * Test entry price.
+     */
+    private static final BigDecimal TEST_ENTRY_PRICE = BigDecimal.TEN;
+
+    /**
+     * Repository for backtest results.
+     */
+    @Mock
+    private BacktestResultRepository resultRepository;
+
+    /**
+     * Repository for backtest trades.
+     */
+    @Mock
+    private BacktestTradeRepository backtestTradeRepository;
+
+    /**
+     * Repository for strategies.
+     */
+    @Mock
+    private StrategyRepository strategyRepository;
+
+    /**
+     * Repository for strategy versions.
+     */
+    @Mock
+    private StrategyVersionRepository versionRepository;
+
+    /**
+     * Service for kline data.
+     */
+    @Mock
+    private KlineService klineService;
+
+    /**
+     * Mapper for backtest trades.
+     */
+    @Mock
+    private BacktestTradeMapper backtestTradeMapper;
+
+    /**
+     * Support for strategy access validation.
+     */
+    @Mock
+    private StrategyAccessSupport strategyAccessSupport;
+
+    /**
+     * Instance under test.
+     */
+    private BacktestServiceImpl backtestService;
+
+    @BeforeEach
+    void setUp() {
+        backtestService = new BacktestServiceImpl(
+                resultRepository,
+                backtestTradeRepository,
+                strategyRepository,
+                versionRepository,
+                klineService,
+                backtestTradeMapper,
+                strategyAccessSupport);
+    }
+
+    @Test
+    @DisplayName("executeBuy 应使用传入的实际股票代码")
+    void executeBuyShouldUseActualSymbol() {
+        BacktestExecutionContext context = new BacktestExecutionContext(
+                INITIAL_CAPITAL, COMMISSION_RATE, SLIPPAGE);
+        KlineDataDto current = KlineDataDto.builder()
+                .timestamp(1L)
+                .open(TEST_PRICE)
+                .high(TEST_PRICE)
+                .low(TEST_PRICE)
+                .close(TEST_PRICE)
+                .volume(TEST_VOLUME)
+                .amount(TEST_AMOUNT_BUY)
+                .build();
+
+        BacktestTrade trade = (BacktestTrade) ReflectionTestUtils.invokeMethod(
+                backtestService,
+                "executeBuy",
+                context,
+                current,
+                BACKTEST_RESULT_ID,
+                TEST_SYMBOL);
+
+        assertThat(trade).isNotNull();
+        assertThat(trade.getSymbol()).isEqualTo(TEST_SYMBOL);
+        assertThat(trade.getBacktestResultId()).isEqualTo(BACKTEST_RESULT_ID);
+    }
+
+    @Test
+    @DisplayName("executeSell 应使用传入的实际股票代码")
+    void executeSellShouldUseActualSymbol() {
+        BacktestExecutionContext context = new BacktestExecutionContext(
+                INITIAL_CAPITAL, COMMISSION_RATE, SLIPPAGE);
+        ReflectionTestUtils.setField(context, "position", TEST_POSITION);
+        ReflectionTestUtils.setField(context, "entryPrice", TEST_ENTRY_PRICE);
+
+        KlineDataDto current = KlineDataDto.builder()
+                .timestamp(2L)
+                .open(TEST_SELL_PRICE)
+                .high(TEST_SELL_PRICE)
+                .low(TEST_SELL_PRICE)
+                .close(TEST_SELL_PRICE)
+                .volume(TEST_VOLUME)
+                .amount(TEST_AMOUNT_SELL)
+                .build();
+
+        BacktestTrade trade = (BacktestTrade) ReflectionTestUtils.invokeMethod(
+                backtestService,
+                "executeSell",
+                context,
+                current,
+                BACKTEST_RESULT_ID,
+                TEST_SYMBOL);
+
+        assertThat(trade).isNotNull();
+        assertThat(trade.getSymbol()).isEqualTo(TEST_SYMBOL);
+        assertThat(trade.getBacktestResultId()).isEqualTo(BACKTEST_RESULT_ID);
+    }
+}


### PR DESCRIPTION
## 修改内容

- 修复 `BacktestServiceImpl` 中 `executeBuy` / `executeSell` 方法将 `symbol` 硬编码为 `"SYMBOL"` 的问题
- 为两个私有方法新增 `String symbol` 参数，调用点传入 `result.getSymbol()`
- 新增 `BacktestServiceImplTest` 回归测试，验证交易记录使用实际股票代码
- 添加 ADR-0066 记录决策、权衡与兼容性影响

## 质量校验

- `mvn -f koduck-backend/pom.xml clean compile` 编译通过
- `mvn -f koduck-backend/pom.xml checkstyle:check` 无异常
- `./koduck-backend/scripts/quality-check.sh` 全绿
- 新增单元测试通过

Closes #426