### PR TITLE
fix(market): 提取 Service 层与实体层魔法字符串为 MarketConstants 常量

### DIFF
--- a/koduck-backend/docs/ADR-0067-extract-market-magic-strings.md
+++ b/koduck-backend/docs/ADR-0067-extract-market-magic-strings.md
@@ -1,0 +1,100 @@
+# ADR-0067: 提取市场类型魔法字符串为 MarketConstants 常量
+
+- Status: Accepted
+- Date: 2026-04-04
+- Issue: #428
+
+## Context
+
+根据 `ARCHITECTURE-EVALUATION.md` 的可维护性评估，`koduck-backend` 中存在市场类型魔法字符串硬编码问题。`MarketConstants` 中已经定义了 `STOCK_TYPE = "STOCK"` 和 `INDEX_TYPE = "INDEX"`，但以下位置仍然直接使用字符串字面量：
+
+| 位置 | 当前实现 | 期望实现 |
+|------|----------|----------|
+| `entity/market/StockBasic.java:59` | `private String type = "STOCK";` | `MarketConstants.STOCK_TYPE` |
+| `entity/market/StockRealtime.java:53` | `private String type = "STOCK";` | `MarketConstants.STOCK_TYPE` |
+| `service/impl/PricePushServiceImpl.java:159` | `.type(event.getType() != null ? event.getType() : "STOCK")` | `MarketConstants.STOCK_TYPE` |
+| `service/market/support/AKShareDataMapperSupport.java:87` | `.orElse("STOCK")` | `MarketConstants.STOCK_TYPE` |
+| `service/market/support/AKShareDataMapperSupport.java:137` | `.orElse("STOCK")` | `MarketConstants.STOCK_TYPE` |
+
+此外，测试代码中也存在对应的硬编码：
+
+| 位置 | 当前实现 |
+|------|----------|
+| `controller/MarketControllerIntegrationTest.java` | 多处 `.type("STOCK")`、`.type("INDEX")` |
+| `service/MarketServiceImplTest.java` | 多处 `.type("STOCK")`、参数 `"INDEX"` |
+
+这些问题导致：
+- **维护困难**：类型值调整时需要全局搜索替换，极易遗漏
+- **拼写风险**：手写字符串可能出现大小写或拼写不一致
+- **可读性下降**：新开发者无法直观判断该字符串是否为受控业务常量
+
+## Decision
+
+### 1. 替换 main 源码中的魔法字符串
+
+将 `StockBasic`、`StockRealtime`、`PricePushServiceImpl`、`AKShareDataMapperSupport` 中的 `"STOCK"` 替换为 `MarketConstants.STOCK_TYPE`，`"INDEX"` 替换为 `MarketConstants.INDEX_TYPE`（如有）。
+
+**修改示例（AKShareDataMapperSupport）：**
+```java
+// Before
+.type(Optional.ofNullable(MarketDataMapReader.getString(data, "type")).orElse("STOCK"))
+
+// After
+.type(Optional.ofNullable(MarketDataMapReader.getString(data, "type"))
+    .orElse(MarketConstants.STOCK_TYPE))
+```
+
+**修改示例（StockBasic）：**
+```java
+// Before
+private String type = "STOCK";
+
+// After
+private String type = MarketConstants.STOCK_TYPE;
+```
+
+### 2. 同步更新测试代码
+
+测试代码中所有涉及 `"STOCK"` 和 `"INDEX"` 的断言与 mock 参数，统一替换为 `MarketConstants.STOCK_TYPE` 和 `MarketConstants.INDEX_TYPE`，确保测试与实现一致。
+
+### 3. 不引入枚举（当前阶段）
+
+虽然将字符串类型升级为枚举（如 `SecurityType.STOCK`）是更理想的长期方案，但 `type` 字段目前以 `String` 形式存储在数据库中，且被多个外部 DTO、前端接口使用。改为枚举会涉及：
+- 数据库列类型或转换器变更
+- 序列化/反序列化适配（JSON、MapStruct）
+- 前端契约调整
+
+本次 ADR 仅做**最小侵入性修复**：集中常量管理，保持数据类型和 API 不变，为后续升级到枚举打好基础。
+
+## Consequences
+
+### 正向影响
+
+- **维护集中化**：类型字符串统一在 `MarketConstants` 管理，修改只需改一处
+- **消除拼写风险**：编译期可检查常量引用，避免手写字符串错误
+- **提升可读性**：代码清晰表达 `"STOCK"` 是受控业务常量
+- **为枚举升级铺垫**：先完成常量统一，后续枚举替换时影响范围更小
+
+### 兼容性影响
+
+- **API 行为不变**：HTTP 接口、DTO、数据库表结构均无变化
+- **默认值不变**：实体字段默认值仍返回 `"STOCK"`，只是通过常量引用
+- **Map 键名不变**：`AKShareDataMapperSupport` 中从 Map 读取 `"type"` 的键名保持不变，仅 fallback 默认值使用常量
+- **无运行时行为差异**：纯代码层面的常量替换，功能完全等价
+
+## Alternatives Considered
+
+1. **直接升级为 `SecurityType` 枚举**
+   - 拒绝：改动面过大，涉及数据库、DTO、前端、序列化等多层适配，不符合本次轻量修复的目标
+   - 当前方案：先用 `MarketConstants` 常量统一管理，后续独立迭代升级到枚举
+
+2. **保留现状**
+   - 拒绝：魔法字符串已被 `ARCHITECTURE-EVALUATION.md` 明确列为可维护性问题，且项目已有 `MarketConstants` 常量却未被使用，属于明显的技术债务
+   - 当前方案：全面替换，消除硬编码
+
+## Verification
+
+- `mvn -f koduck-backend/pom.xml clean compile` 编译通过
+- `mvn -f koduck-backend/pom.xml checkstyle:check` 无异常
+- `./koduck-backend/scripts/quality-check.sh` 全绿
+- 所有现有单元测试与切片测试通过

--- a/koduck-backend/src/main/java/com/koduck/entity/market/StockBasic.java
+++ b/koduck-backend/src/main/java/com/koduck/entity/market/StockBasic.java
@@ -15,6 +15,8 @@ import jakarta.persistence.UniqueConstraint;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
+import com.koduck.common.constants.MarketConstants;
+
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -56,7 +58,7 @@ public class StockBasic {
      */
     @Column(name = "type", nullable = false, length = 10)
     @Builder.Default
-    private String type = "STOCK";
+    private String type = MarketConstants.STOCK_TYPE;
 
     /**
      * Stock name.

--- a/koduck-backend/src/main/java/com/koduck/entity/market/StockRealtime.java
+++ b/koduck-backend/src/main/java/com/koduck/entity/market/StockRealtime.java
@@ -11,6 +11,8 @@ import jakarta.persistence.Table;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
+import com.koduck.common.constants.MarketConstants;
+
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -50,7 +52,7 @@ public class StockRealtime {
      */
     @Column(name = "type", nullable = false, length = 10)
     @Builder.Default
-    private String type = "STOCK";
+    private String type = MarketConstants.STOCK_TYPE;
 
     /**
      * Current price.

--- a/koduck-backend/src/main/java/com/koduck/service/impl/PricePushServiceImpl.java
+++ b/koduck-backend/src/main/java/com/koduck/service/impl/PricePushServiceImpl.java
@@ -6,6 +6,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.springframework.stereotype.Service;
 
+import com.koduck.common.constants.MarketConstants;
 import com.koduck.dto.market.PriceUpdateDto;
 import com.koduck.dto.market.RealtimePriceEventMessage;
 import com.koduck.dto.market.TickDto;
@@ -156,7 +157,7 @@ public class PricePushServiceImpl implements PricePushService {
         return StockRealtime.builder()
                 .symbol(normalizedSymbol)
                 .name(event.getName() != null && !event.getName().isBlank() ? event.getName() : normalizedSymbol)
-                .type(event.getType() != null ? event.getType() : "STOCK")
+                .type(event.getType() != null ? event.getType() : MarketConstants.STOCK_TYPE)
                 .price(event.getPrice())
                 .changeAmount(event.getChangeAmount())
                 .changePercent(event.getChangePercent())

--- a/koduck-backend/src/main/java/com/koduck/service/market/support/AKShareDataMapperSupport.java
+++ b/koduck-backend/src/main/java/com/koduck/service/market/support/AKShareDataMapperSupport.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import com.koduck.common.constants.MapKeyConstants;
+import com.koduck.common.constants.MarketConstants;
 import com.koduck.dto.market.PriceQuoteDto;
 import com.koduck.dto.market.StockIndustryDto;
 import com.koduck.dto.market.StockValuationDto;
@@ -84,7 +85,8 @@ public final class AKShareDataMapperSupport {
         return PriceQuoteDto.builder()
             .symbol(MarketDataMapReader.getString(data, KEY_SYMBOL))
             .name(MarketDataMapReader.getString(data, KEY_NAME))
-            .type(Optional.ofNullable(MarketDataMapReader.getString(data, "type")).orElse("STOCK"))
+            .type(Optional.ofNullable(MarketDataMapReader.getString(data, "type"))
+                .orElse(MarketConstants.STOCK_TYPE))
             .price(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "price")))
             .open(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "open")))
             .high(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "high")))
@@ -134,7 +136,8 @@ public final class AKShareDataMapperSupport {
         return SymbolInfoDto.builder()
             .symbol(MarketDataMapReader.getString(data, KEY_SYMBOL))
             .name(MarketDataMapReader.getString(data, KEY_NAME))
-            .type(Optional.ofNullable(MarketDataMapReader.getString(data, "type")).orElse("STOCK"))
+            .type(Optional.ofNullable(MarketDataMapReader.getString(data, "type"))
+                .orElse(MarketConstants.STOCK_TYPE))
             .market(MarketDataMapReader.getString(data, "market"))
             .price(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "price")))
             .changePercent(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "change_percent")))

--- a/koduck-backend/src/test/java/com/koduck/controller/MarketControllerIntegrationTest.java
+++ b/koduck-backend/src/test/java/com/koduck/controller/MarketControllerIntegrationTest.java
@@ -16,6 +16,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import com.koduck.AbstractIntegrationTest;
+import com.koduck.common.constants.MarketConstants;
 import com.koduck.entity.market.StockBasic;
 import com.koduck.entity.market.StockRealtime;
 import com.koduck.repository.market.StockBasicRepository;
@@ -113,7 +114,7 @@ class MarketControllerIntegrationTest extends AbstractIntegrationTest {
         StockBasic stock = StockBasic.builder()
                 .symbol("600519")
                 .name("贵州茅台")
-                .type("STOCK")
+                .type(MarketConstants.STOCK_TYPE)
                 .market("AShare")
                 .build();
         stockBasicRepository.save(Objects.requireNonNull(stock));
@@ -174,7 +175,7 @@ class MarketControllerIntegrationTest extends AbstractIntegrationTest {
         StockRealtime stockRealtime = StockRealtime.builder()
                 .symbol("000001")
                 .name("平安银行")
-                .type("STOCK")
+                .type(MarketConstants.STOCK_TYPE)
                 .price(PRICE_PINGAN)
                 .openPrice(new BigDecimal("12.30"))
                 .high(new BigDecimal("12.80"))
@@ -222,7 +223,7 @@ class MarketControllerIntegrationTest extends AbstractIntegrationTest {
         StockRealtime shIndex = StockRealtime.builder()
                 .symbol("000001")
                 .name("上证指数")
-                .type("INDEX")
+                .type(MarketConstants.INDEX_TYPE)
                 .price(new BigDecimal("3050.50"))
                 .changeAmount(new BigDecimal("15.30"))
                 .changePercent(new BigDecimal("0.50"))
@@ -253,7 +254,7 @@ class MarketControllerIntegrationTest extends AbstractIntegrationTest {
         StockRealtime stockRealtime = StockRealtime.builder()
                 .symbol("000002")
                 .name("万科A")
-                .type("STOCK")
+                .type(MarketConstants.STOCK_TYPE)
                 .price(PRICE_VANKE)
                 .openPrice(OPEN_PRICE_VANKE)
                 .high(HIGH_PRICE_VANKE)
@@ -350,13 +351,13 @@ class MarketControllerIntegrationTest extends AbstractIntegrationTest {
         StockRealtime stock1 = StockRealtime.builder()
                 .symbol("000001")
                 .name("平安银行")
-                .type("STOCK")
+                .type(MarketConstants.STOCK_TYPE)
                 .price(PRICE_PINGAN)
                 .build();
         StockRealtime stock2 = StockRealtime.builder()
                 .symbol("000002")
                 .name("万科A")
-                .type("STOCK")
+                .type(MarketConstants.STOCK_TYPE)
                 .price(PRICE_VANKE)
                 .build();
         stockRealtimeRepository.saveAll(Objects.requireNonNull(List.of(stock1, stock2)));

--- a/koduck-backend/src/test/java/com/koduck/service/MarketServiceImplTest.java
+++ b/koduck-backend/src/test/java/com/koduck/service/MarketServiceImplTest.java
@@ -19,6 +19,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.lang.NonNull;
 
+import com.koduck.common.constants.MarketConstants;
 import com.koduck.dto.market.KlineDataDto;
 import com.koduck.dto.market.MarketIndexDto;
 import com.koduck.dto.market.PriceQuoteDto;
@@ -239,13 +240,13 @@ class MarketServiceImplTest {
                                 .symbol("601012")
                                 .name("隆基绿能")
                                 .market("AShare")
-                                .type("STOCK")
+                                .type(MarketConstants.STOCK_TYPE)
                                 .build(),
                         SymbolInfoDto.builder()
                                 .symbol("002363")
                                 .name("隆基机械")
                                 .market("AShare")
-                                .type("STOCK")
+                                .type(MarketConstants.STOCK_TYPE)
                                 .build()
                 ));
 
@@ -478,7 +479,8 @@ class MarketServiceImplTest {
                 .updatedAt(LocalDateTime.now())
                 .build();
 
-        when(stockRealtimeRepository.findBySymbolInAndType(List.of("000001", "399001", "399006"), "INDEX"))
+        when(stockRealtimeRepository.findBySymbolInAndType(
+                List.of("000001", "399001", "399006"), MarketConstants.INDEX_TYPE))
                 .thenReturn(List.of(index));
 
         List<MarketIndexDto> indices = marketService.getMarketIndices();
@@ -715,10 +717,10 @@ class MarketServiceImplTest {
     @DisplayName("shouldReturnEmptyListWhenNoIndicesFoundInRealtimeOrBasic")
     void shouldReturnEmptyListWhenNoIndicesFoundInRealtimeOrBasic() {
         when(stockRealtimeRepository.findBySymbolInAndType(
-                List.of("000001", "399001", "399006"), "INDEX"))
+                List.of("000001", "399001", "399006"), MarketConstants.INDEX_TYPE))
                 .thenReturn(List.of());
         when(stockBasicRepository.findBySymbolInAndType(
-                List.of("000001", "399001", "399006"), "INDEX"))
+                List.of("000001", "399001", "399006"), MarketConstants.INDEX_TYPE))
                 .thenReturn(List.of());
 
         List<MarketIndexDto> indices = marketService.getMarketIndices();


### PR DESCRIPTION
## 修改内容

- 将 `StockBasic`、`StockRealtime` 的 `type` 默认值从硬编码 `"STOCK"` 改为 `MarketConstants.STOCK_TYPE`
- 将 `PricePushServiceImpl`、`AKShareDataMapperSupport` 中的 `"STOCK"` fallback 替换为 `MarketConstants.STOCK_TYPE`
- 同步更新 `MarketControllerIntegrationTest` 与 `MarketServiceImplTest` 中的断言与 mock 参数
- 添加 ADR-0067 记录决策、权衡与兼容性影响

## 质量校验

- `mvn -f koduck-backend/pom.xml clean compile` 编译通过
- `mvn -f koduck-backend/pom.xml checkstyle:check` 无异常
- `./koduck-backend/scripts/quality-check.sh` 全绿
- 所有现有单元测试与切片测试通过

Closes #428