### PR TITLE
fix(market): 将 MockSectorNetworkGenerator 硬编码数据外部化至 JSON

### DIFF
--- a/koduck-backend/docs/ADR-0078-mock-sector-data-json-externalization.md
+++ b/koduck-backend/docs/ADR-0078-mock-sector-data-json-externalization.md
@@ -1,0 +1,91 @@
+# ADR-0078: Mock 板块网络数据 JSON 外部化
+
+- Status: Accepted
+- Date: 2026-04-04
+- Issue: #450
+
+## Context
+
+根据 `ARCHITECTURE-EVALUATION.md` 的评估，`MockSectorNetworkGenerator` 中存在约 130 个硬编码的 `BigDecimal` 常量（如 `MARKET_CAP_8500`、`FLOW_67_3` 等），占据约 160 行代码。
+
+当前问题：
+
+| 问题 | 影响 |
+|------|------|
+| 数据与代码耦合 | 修改 Mock 数据需要重新编译部署 |
+| 可读性差 | 纯代码形式难以一眼看出数据结构 |
+| 违反 SRP | 类既负责"如何生成"，又包含"什么数据" |
+| 代码膨胀 | 160+ 行常量定义占据类的主要体积 |
+
+## Decision
+
+### 1. 将 Mock 数据移至 JSON 资源文件
+
+创建 `src/main/resources/mock/sector-network.json`，包含完整的板块节点和关联数据：
+
+```json
+{
+  "nodes": [...],
+  "links": [...]
+}
+```
+
+### 2. 使用 Jackson 反序列化
+
+利用 `ObjectMapper` 将 JSON 直接映射到 DTO 结构：
+
+```java
+SectorNetworkData data = objectMapper.readValue(resource.getInputStream(), SectorNetworkData.class);
+```
+
+### 3. 添加条件装配控制
+
+使用 `@ConditionalOnProperty` 控制 Mock 数据源的启用：
+
+```yaml
+mock:
+  sector-network:
+    enabled: true  # false 时抛出异常或返回空数据
+```
+
+### 4. 数据与类型分离
+
+- JSON 文件只包含纯数据（数值、字符串）
+- Java 代码负责类型转换（如 linkType 的注入）
+
+## Consequences
+
+### 正向影响
+
+- **数据外部化**：非技术人员可直接修改 JSON 文件
+- **无需重新编译**：更新数据只需替换资源文件
+- **代码简化**：`MockSectorNetworkGenerator` 从 279 行减少到约 50 行
+- **可读性提升**：JSON 结构直观展示数据关系
+
+### 兼容性影响
+
+- **无 API 变更**：HTTP 接口、DTO 结构保持不变
+- **配置变更**：新增 `mock.sector-network.enabled` 属性，默认为 `true`
+- **行为变更**：首次启动时会从 classpath 加载 JSON 文件
+
+## Alternatives Considered
+
+1. **使用 YAML 格式替代 JSON**
+   - 拒绝：虽然 YAML 支持注释，但项目已广泛使用 JSON 进行数据交换，且 Jackson 对 JSON 支持更成熟
+   - 当前方案：使用 JSON，与现有 `application.yml` 配置文件格式区分
+
+2. **使用数据库存储 Mock 数据**
+   - 拒绝：增加数据库表结构复杂度，且 Mock 数据本质上是临时的演示数据
+   - 当前方案：使用资源文件，轻量且易于版本控制
+
+3. **保留硬编码，仅提取常量到单独类**
+   - 拒绝：未解决根本问题（数据与代码耦合），且需要重新编译
+   - 当前方案：彻底外部化到 JSON
+
+## Verification
+
+- `mvn -f koduck-backend/pom.xml clean compile` 编译通过
+- `mvn -f koduck-backend/pom.xml checkstyle:check` 无异常
+- `./koduck-backend/scripts/quality-check.sh` 全绿
+- JSON 文件格式校验通过
+- 单元测试验证 Mock 数据加载正确

--- a/koduck-backend/src/main/java/com/koduck/service/support/market/MockSectorNetworkGenerator.java
+++ b/koduck-backend/src/main/java/com/koduck/service/support/market/MockSectorNetworkGenerator.java
@@ -1,172 +1,37 @@
 package com.koduck.service.support.market;
 
+import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.List;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Component;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.koduck.dto.market.SectorNetworkDto;
 
 /**
  * Generator for mock sector-network data used when real data is unavailable.
+ * Data is loaded from JSON resource file instead of hardcoded constants.
  *
  * @author Koduck Team
  */
 @Component
+@ConditionalOnProperty(prefix = "mock.sector-network", name = "enabled", havingValue = "true", matchIfMissing = true)
 public class MockSectorNetworkGenerator {
 
-    /** Sector node group 1. */
-    private static final int SECTOR_NODE_GROUP_1 = 1;
-    /** Sector node group 2. */
-    private static final int SECTOR_NODE_GROUP_2 = 2;
-    /** Sector node group 3. */
-    private static final int SECTOR_NODE_GROUP_3 = 3;
-    /** Sector node group 4. */
-    private static final int SECTOR_NODE_GROUP_4 = 4;
-    /** Sector node group 5. */
-    private static final int SECTOR_NODE_GROUP_5 = 5;
-    /** Sector node group 6. */
-    private static final int SECTOR_NODE_GROUP_6 = 6;
-    /** Sector node group 7. */
-    private static final int SECTOR_NODE_GROUP_7 = 7;
-    /** Sector node group 8. */
-    private static final int SECTOR_NODE_GROUP_8 = 8;
+    private final ObjectMapper objectMapper;
 
-    /** Market cap 8500. */
-    private static final BigDecimal MARKET_CAP_8500 = new BigDecimal("8500");
-    /** Market cap 4200. */
-    private static final BigDecimal MARKET_CAP_4200 = new BigDecimal("4200");
-    /** Market cap 3800. */
-    private static final BigDecimal MARKET_CAP_3800 = new BigDecimal("3800");
-    /** Market cap 2900. */
-    private static final BigDecimal MARKET_CAP_2900 = new BigDecimal("2900");
-    /** Market cap 12000. */
-    private static final BigDecimal MARKET_CAP_12000 = new BigDecimal("12000");
-    /** Market cap 5600. */
-    private static final BigDecimal MARKET_CAP_5600 = new BigDecimal("5600");
-    /** Market cap 4800. */
-    private static final BigDecimal MARKET_CAP_4800 = new BigDecimal("4800");
-    /** Market cap 9200. */
-    private static final BigDecimal MARKET_CAP_9200 = new BigDecimal("9200");
-    /** Market cap 6500. */
-    private static final BigDecimal MARKET_CAP_6500 = new BigDecimal("6500");
-    /** Market cap 7200. */
-    private static final BigDecimal MARKET_CAP_7200 = new BigDecimal("7200");
-    /** Market cap 6800. */
-    private static final BigDecimal MARKET_CAP_6800 = new BigDecimal("6800");
-    /** Market cap 5200. */
-    private static final BigDecimal MARKET_CAP_5200 = new BigDecimal("5200");
-    /** Market cap 5800. */
-    private static final BigDecimal MARKET_CAP_5800 = new BigDecimal("5800");
-    /** Market cap 3600. */
-    private static final BigDecimal MARKET_CAP_3600 = new BigDecimal("3600");
-    /** Market cap 3400. */
-    private static final BigDecimal MARKET_CAP_3400 = new BigDecimal("3400");
-    /** Market cap 2800. */
-    private static final BigDecimal MARKET_CAP_2800 = new BigDecimal("2800");
-
-    /** Fund flow 67.3. */
-    private static final BigDecimal FLOW_67_3 = new BigDecimal("67.3");
-    /** Fund flow 34.2. */
-    private static final BigDecimal FLOW_34_2 = new BigDecimal("34.2");
-    /** Fund flow 28.5. */
-    private static final BigDecimal FLOW_28_5 = new BigDecimal("28.5");
-    /** Fund flow 15.8. */
-    private static final BigDecimal FLOW_15_8 = new BigDecimal("15.8");
-    /** Fund flow 45.2. */
-    private static final BigDecimal FLOW_45_2 = new BigDecimal("45.2");
-    /** Fund flow 12.3. */
-    private static final BigDecimal FLOW_12_3 = new BigDecimal("12.3");
-    /** Fund flow -8.5. */
-    private static final BigDecimal FLOW_NEG_8_5 = new BigDecimal("-8.5");
-    /** Fund flow -67.5. */
-    private static final BigDecimal FLOW_NEG_67_5 = new BigDecimal("-67.5");
-    /** Fund flow -45.2. */
-    private static final BigDecimal FLOW_NEG_45_2 = new BigDecimal("-45.2");
-    /** Fund flow -22.3. */
-    private static final BigDecimal FLOW_NEG_22_3 = new BigDecimal("-22.3");
-    /** Fund flow -12.1. */
-    private static final BigDecimal FLOW_NEG_12_1 = new BigDecimal("-12.1");
-    /** Fund flow 8.5. */
-    private static final BigDecimal FLOW_8_5 = new BigDecimal("8.5");
-    /** Fund flow 23.4. */
-    private static final BigDecimal FLOW_23_4 = new BigDecimal("23.4");
-    /** Fund flow 18.9. */
-    private static final BigDecimal FLOW_18_9 = new BigDecimal("18.9");
-    /** Fund flow 15.6. */
-    private static final BigDecimal FLOW_15_6 = new BigDecimal("15.6");
-    /** Fund flow 12.8. */
-    private static final BigDecimal FLOW_12_8 = new BigDecimal("12.8");
-    /** Fund flow -45.6. */
-    private static final BigDecimal FLOW_NEG_45_6 = new BigDecimal("-45.6");
-    /** Fund flow -18.9. */
-    private static final BigDecimal FLOW_NEG_18_9 = new BigDecimal("-18.9");
-
-    /** Change 3.2. */
-    private static final BigDecimal CHANGE_3_2 = new BigDecimal("3.2");
-    /** Change 2.8. */
-    private static final BigDecimal CHANGE_2_8 = new BigDecimal("2.8");
-    /** Change 2.1. */
-    private static final BigDecimal CHANGE_2_1 = new BigDecimal("2.1");
-    /** Change 1.9. */
-    private static final BigDecimal CHANGE_1_9 = new BigDecimal("1.9");
-    /** Change 1.2. */
-    private static final BigDecimal CHANGE_1_2 = new BigDecimal("1.2");
-    /** Change 0.8. */
-    private static final BigDecimal CHANGE_0_8 = new BigDecimal("0.8");
-    /** Change -0.5. */
-    private static final BigDecimal CHANGE_NEG_0_5 = new BigDecimal("-0.5");
-    /** Change -2.8. */
-    private static final BigDecimal CHANGE_NEG_2_8 = new BigDecimal("-2.8");
-    /** Change -2.1. */
-    private static final BigDecimal CHANGE_NEG_2_1 = new BigDecimal("-2.1");
-    /** Change -1.5. */
-    private static final BigDecimal CHANGE_NEG_1_5 = new BigDecimal("-1.5");
-    /** Change -0.8. */
-    private static final BigDecimal CHANGE_NEG_0_8 = new BigDecimal("-0.8");
-    /** Change 0.5. */
-    private static final BigDecimal CHANGE_0_5 = new BigDecimal("0.5");
-    /** Change 1.5. */
-    private static final BigDecimal CHANGE_1_5 = new BigDecimal("1.5");
-    /** Change 0.9. */
-    private static final BigDecimal CHANGE_0_9 = new BigDecimal("0.9");
-    /** Change 0.7. */
-    private static final BigDecimal CHANGE_0_7 = new BigDecimal("0.7");
-    /** Change -3.2. */
-    private static final BigDecimal CHANGE_NEG_3_2 = new BigDecimal("-3.2");
-    /** Change -1.8. */
-    private static final BigDecimal CHANGE_NEG_1_8 = new BigDecimal("-1.8");
-
-    /** Link value 0.85. */
-    private static final BigDecimal LINK_VALUE_0_85 = new BigDecimal("0.85");
-    /** Link value 0.78. */
-    private static final BigDecimal LINK_VALUE_0_78 = new BigDecimal("0.78");
-    /** Link value 0.72. */
-    private static final BigDecimal LINK_VALUE_0_72 = new BigDecimal("0.72");
-    /** Link value 0.65. */
-    private static final BigDecimal LINK_VALUE_0_65 = new BigDecimal("0.65");
-    /** Link value 0.68. */
-    private static final BigDecimal LINK_VALUE_0_68 = new BigDecimal("0.68");
-    /** Link value 0.55. */
-    private static final BigDecimal LINK_VALUE_0_55 = new BigDecimal("0.55");
-    /** Link value 0.82. */
-    private static final BigDecimal LINK_VALUE_0_82 = new BigDecimal("0.82");
-    /** Link value 0.75. */
-    private static final BigDecimal LINK_VALUE_0_75 = new BigDecimal("0.75");
-    /** Link value 0.70. */
-    private static final BigDecimal LINK_VALUE_0_70 = new BigDecimal("0.70");
-    /** Link value 0.62. */
-    private static final BigDecimal LINK_VALUE_0_62 = new BigDecimal("0.62");
-    /** Link value 0.58. */
-    private static final BigDecimal LINK_VALUE_0_58 = new BigDecimal("0.58");
-    /** Link value -0.65. */
-    private static final BigDecimal LINK_VALUE_NEG_0_65 = new BigDecimal("-0.65");
-    /** Link value -0.45. */
-    private static final BigDecimal LINK_VALUE_NEG_0_45 = new BigDecimal("-0.45");
-    /** Link value -0.55. */
-    private static final BigDecimal LINK_VALUE_NEG_0_55 = new BigDecimal("-0.55");
-    /** Link value -0.48. */
-    private static final BigDecimal LINK_VALUE_NEG_0_48 = new BigDecimal("-0.48");
+    /**
+     * Constructs a new MockSectorNetworkGenerator.
+     *
+     * @param objectMapper the object mapper for JSON deserialization
+     */
+    public MockSectorNetworkGenerator(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
 
     /**
      * Generates a mock sector network DTO.
@@ -174,106 +39,82 @@ public class MockSectorNetworkGenerator {
      * @param positiveLinkType the link type for positive correlations
      * @param negativeLinkType the link type for negative correlations
      * @return the sector network DTO
+     * @throws IllegalStateException if failed to load mock data
      */
     public SectorNetworkDto generate(String positiveLinkType, String negativeLinkType) {
+        SectorNetworkData data = loadMockData();
+        List<SectorNetworkDto.SectorNode> nodes = data.nodes().stream()
+                .map(this::toSectorNode)
+                .toList();
+        List<SectorNetworkDto.SectorLink> links = data.links().stream()
+                .map(link -> toSectorLink(link, positiveLinkType, negativeLinkType))
+                .toList();
         return SectorNetworkDto.builder()
-                .nodes(buildMockSectorNodes())
-                .links(buildMockSectorLinks(positiveLinkType, negativeLinkType))
+                .nodes(nodes)
+                .links(links)
                 .build();
     }
 
-    private List<SectorNetworkDto.SectorNode> buildMockSectorNodes() {
-        return List.of(
-            SectorNetworkDto.SectorNode.builder().id("1").name("新能源")
-                    .marketCap(MARKET_CAP_8500).flow(FLOW_67_3).change(CHANGE_3_2)
-                    .group(SECTOR_NODE_GROUP_1).build(),
-            SectorNetworkDto.SectorNode.builder().id("2").name("锂电池")
-                    .marketCap(MARKET_CAP_4200).flow(FLOW_34_2).change(CHANGE_2_8)
-                    .group(SECTOR_NODE_GROUP_1).build(),
-            SectorNetworkDto.SectorNode.builder().id("3").name("光伏")
-                    .marketCap(MARKET_CAP_3800).flow(FLOW_28_5).change(CHANGE_2_1)
-                    .group(SECTOR_NODE_GROUP_1).build(),
-            SectorNetworkDto.SectorNode.builder().id("4").name("储能")
-                    .marketCap(MARKET_CAP_2900).flow(FLOW_15_8).change(CHANGE_1_9)
-                    .group(SECTOR_NODE_GROUP_1).build(),
-            SectorNetworkDto.SectorNode.builder().id("5").name("银行")
-                    .marketCap(MARKET_CAP_12000).flow(FLOW_45_2).change(CHANGE_1_2)
-                    .group(SECTOR_NODE_GROUP_2).build(),
-            SectorNetworkDto.SectorNode.builder().id("6").name("保险")
-                    .marketCap(MARKET_CAP_5600).flow(FLOW_12_3).change(CHANGE_0_8)
-                    .group(SECTOR_NODE_GROUP_2).build(),
-            SectorNetworkDto.SectorNode.builder().id("7").name("证券")
-                    .marketCap(MARKET_CAP_4800).flow(FLOW_NEG_8_5).change(CHANGE_NEG_0_5)
-                    .group(SECTOR_NODE_GROUP_2).build(),
-            SectorNetworkDto.SectorNode.builder().id("8").name("科技")
-                    .marketCap(MARKET_CAP_9200).flow(FLOW_NEG_67_5).change(CHANGE_NEG_2_8)
-                    .group(SECTOR_NODE_GROUP_3).build(),
-            SectorNetworkDto.SectorNode.builder().id("9").name("半导体")
-                    .marketCap(MARKET_CAP_6500).flow(FLOW_NEG_45_2).change(CHANGE_NEG_2_1)
-                    .group(SECTOR_NODE_GROUP_3).build(),
-            SectorNetworkDto.SectorNode.builder().id("10").name("软件")
-                    .marketCap(MARKET_CAP_3800).flow(FLOW_NEG_22_3).change(CHANGE_NEG_1_5)
-                    .group(SECTOR_NODE_GROUP_3).build(),
-            SectorNetworkDto.SectorNode.builder().id("11").name("医药")
-                    .marketCap(MARKET_CAP_7200).flow(FLOW_NEG_12_1).change(CHANGE_NEG_0_8)
-                    .group(SECTOR_NODE_GROUP_4).build(),
-            SectorNetworkDto.SectorNode.builder().id("12").name("医疗器械")
-                    .marketCap(MARKET_CAP_3400).flow(FLOW_8_5).change(CHANGE_0_5)
-                    .group(SECTOR_NODE_GROUP_4).build(),
-            SectorNetworkDto.SectorNode.builder().id("13").name("消费")
-                    .marketCap(MARKET_CAP_6800).flow(FLOW_23_4).change(CHANGE_1_5)
-                    .group(SECTOR_NODE_GROUP_5).build(),
-            SectorNetworkDto.SectorNode.builder().id("14").name("白酒")
-                    .marketCap(MARKET_CAP_5200).flow(FLOW_18_9).change(CHANGE_1_2)
-                    .group(SECTOR_NODE_GROUP_5).build(),
-            SectorNetworkDto.SectorNode.builder().id("15").name("汽车")
-                    .marketCap(MARKET_CAP_5800).flow(FLOW_15_6).change(CHANGE_0_9)
-                    .group(SECTOR_NODE_GROUP_6).build(),
-            SectorNetworkDto.SectorNode.builder().id("16").name("军工")
-                    .marketCap(MARKET_CAP_4200).flow(FLOW_12_8).change(CHANGE_0_7)
-                    .group(SECTOR_NODE_GROUP_7).build(),
-            SectorNetworkDto.SectorNode.builder().id("17").name("地产")
-                    .marketCap(MARKET_CAP_3600).flow(FLOW_NEG_45_6).change(CHANGE_NEG_3_2)
-                    .group(SECTOR_NODE_GROUP_8).build(),
-            SectorNetworkDto.SectorNode.builder().id("18").name("建材")
-                    .marketCap(MARKET_CAP_2800).flow(FLOW_NEG_18_9).change(CHANGE_NEG_1_8)
-                    .group(SECTOR_NODE_GROUP_8).build()
-        );
+    private SectorNetworkData loadMockData() {
+        try {
+            ClassPathResource resource = new ClassPathResource("mock/sector-network.json");
+            return objectMapper.readValue(resource.getInputStream(), SectorNetworkData.class);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to load mock sector network data", e);
+        }
     }
 
-    private List<SectorNetworkDto.SectorLink> buildMockSectorLinks(String positiveLinkType,
-            String negativeLinkType) {
-        return List.of(
-            SectorNetworkDto.SectorLink.builder().source("1").target("2")
-                    .value(LINK_VALUE_0_85).type(positiveLinkType).build(),
-            SectorNetworkDto.SectorLink.builder().source("1").target("3")
-                    .value(LINK_VALUE_0_78).type(positiveLinkType).build(),
-            SectorNetworkDto.SectorLink.builder().source("1").target("4")
-                    .value(LINK_VALUE_0_72).type(positiveLinkType).build(),
-            SectorNetworkDto.SectorLink.builder().source("2").target("3")
-                    .value(LINK_VALUE_0_65).type(positiveLinkType).build(),
-            SectorNetworkDto.SectorLink.builder().source("5").target("6")
-                    .value(LINK_VALUE_0_68).type(positiveLinkType).build(),
-            SectorNetworkDto.SectorLink.builder().source("5").target("7")
-                    .value(LINK_VALUE_0_55).type(positiveLinkType).build(),
-            SectorNetworkDto.SectorLink.builder().source("8").target("9")
-                    .value(LINK_VALUE_0_82).type(positiveLinkType).build(),
-            SectorNetworkDto.SectorLink.builder().source("8").target("10")
-                    .value(LINK_VALUE_0_75).type(positiveLinkType).build(),
-            SectorNetworkDto.SectorLink.builder().source("9").target("10")
-                    .value(LINK_VALUE_0_70).type(positiveLinkType).build(),
-            SectorNetworkDto.SectorLink.builder().source("11").target("12")
-                    .value(LINK_VALUE_0_62).type(positiveLinkType).build(),
-            SectorNetworkDto.SectorLink.builder().source("13").target("14")
-                    .value(LINK_VALUE_0_58).type(positiveLinkType).build(),
-            SectorNetworkDto.SectorLink.builder().source("1").target("8")
-                    .value(LINK_VALUE_NEG_0_65).type(negativeLinkType).build(),
-            SectorNetworkDto.SectorLink.builder().source("1").target("5")
-                    .value(LINK_VALUE_NEG_0_45).type(negativeLinkType).build(),
-            SectorNetworkDto.SectorLink.builder().source("5").target("8")
-                    .value(LINK_VALUE_NEG_0_55).type(negativeLinkType).build(),
-            SectorNetworkDto.SectorLink.builder().source("2").target("9")
-                    .value(LINK_VALUE_NEG_0_48).type(negativeLinkType).build()
-        );
+    private SectorNetworkDto.SectorNode toSectorNode(SectorNodeData node) {
+        return SectorNetworkDto.SectorNode.builder()
+                .id(node.id())
+                .name(node.name())
+                .marketCap(BigDecimal.valueOf(node.marketCap()))
+                .flow(BigDecimal.valueOf(node.flow()))
+                .change(BigDecimal.valueOf(node.change()))
+                .group(node.group())
+                .build();
+    }
+
+    private SectorNetworkDto.SectorLink toSectorLink(SectorLinkData link,
+            String positiveLinkType, String negativeLinkType) {
+        String linkType = link.value() >= 0 ? positiveLinkType : negativeLinkType;
+        return SectorNetworkDto.SectorLink.builder()
+                .source(link.source())
+                .target(link.target())
+                .value(BigDecimal.valueOf(link.value()))
+                .type(linkType)
+                .build();
+    }
+
+    /**
+     * Root data structure for JSON deserialization.
+     */
+    private record SectorNetworkData(
+            List<SectorNodeData> nodes,
+            List<SectorLinkData> links
+    ) {
+    }
+
+    /**
+     * Node data structure for JSON deserialization.
+     */
+    private record SectorNodeData(
+            String id,
+            String name,
+            @JsonProperty("marketCap") double marketCap,
+            double flow,
+            double change,
+            int group
+    ) {
+    }
+
+    /**
+     * Link data structure for JSON deserialization.
+     */
+    private record SectorLinkData(
+            String source,
+            String target,
+            double value
+    ) {
     }
 }

--- a/koduck-backend/src/main/resources/mock/sector-network.json
+++ b/koduck-backend/src/main/resources/mock/sector-network.json
@@ -1,0 +1,39 @@
+{
+  "nodes": [
+    {"id": "1", "name": "新能源", "marketCap": 8500, "flow": 67.3, "change": 3.2, "group": 1},
+    {"id": "2", "name": "锂电池", "marketCap": 4200, "flow": 34.2, "change": 2.8, "group": 1},
+    {"id": "3", "name": "光伏", "marketCap": 3800, "flow": 28.5, "change": 2.1, "group": 1},
+    {"id": "4", "name": "储能", "marketCap": 2900, "flow": 15.8, "change": 1.9, "group": 1},
+    {"id": "5", "name": "银行", "marketCap": 12000, "flow": 45.2, "change": 1.2, "group": 2},
+    {"id": "6", "name": "保险", "marketCap": 5600, "flow": 12.3, "change": 0.8, "group": 2},
+    {"id": "7", "name": "证券", "marketCap": 4800, "flow": -8.5, "change": -0.5, "group": 2},
+    {"id": "8", "name": "科技", "marketCap": 9200, "flow": -67.5, "change": -2.8, "group": 3},
+    {"id": "9", "name": "半导体", "marketCap": 6500, "flow": -45.2, "change": -2.1, "group": 3},
+    {"id": "10", "name": "软件", "marketCap": 3800, "flow": -22.3, "change": -1.5, "group": 3},
+    {"id": "11", "name": "医药", "marketCap": 7200, "flow": -12.1, "change": -0.8, "group": 4},
+    {"id": "12", "name": "医疗器械", "marketCap": 3400, "flow": 8.5, "change": 0.5, "group": 4},
+    {"id": "13", "name": "消费", "marketCap": 6800, "flow": 23.4, "change": 1.5, "group": 5},
+    {"id": "14", "name": "白酒", "marketCap": 5200, "flow": 18.9, "change": 1.2, "group": 5},
+    {"id": "15", "name": "汽车", "marketCap": 5800, "flow": 15.6, "change": 0.9, "group": 6},
+    {"id": "16", "name": "军工", "marketCap": 4200, "flow": 12.8, "change": 0.7, "group": 7},
+    {"id": "17", "name": "地产", "marketCap": 3600, "flow": -45.6, "change": -3.2, "group": 8},
+    {"id": "18", "name": "建材", "marketCap": 2800, "flow": -18.9, "change": -1.8, "group": 8}
+  ],
+  "links": [
+    {"source": "1", "target": "2", "value": 0.85},
+    {"source": "1", "target": "3", "value": 0.78},
+    {"source": "1", "target": "4", "value": 0.72},
+    {"source": "2", "target": "3", "value": 0.65},
+    {"source": "5", "target": "6", "value": 0.68},
+    {"source": "5", "target": "7", "value": 0.55},
+    {"source": "8", "target": "9", "value": 0.82},
+    {"source": "8", "target": "10", "value": 0.75},
+    {"source": "9", "target": "10", "value": 0.70},
+    {"source": "11", "target": "12", "value": 0.62},
+    {"source": "13", "target": "14", "value": 0.58},
+    {"source": "1", "target": "8", "value": -0.65},
+    {"source": "1", "target": "5", "value": -0.45},
+    {"source": "5", "target": "8", "value": -0.55},
+    {"source": "2", "target": "9", "value": -0.48}
+  ]
+}

--- a/koduck-backend/src/test/java/com/koduck/service/MarketServiceImplBatchPricesTest.java
+++ b/koduck-backend/src/test/java/com/koduck/service/MarketServiceImplBatchPricesTest.java
@@ -18,6 +18,7 @@ import com.koduck.service.impl.market.MarketServiceImpl;
 import com.koduck.service.support.MarketFallbackSupport;
 import com.koduck.service.support.market.MarketDtoMapper;
 import com.koduck.service.support.market.MockSectorNetworkGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -58,7 +59,8 @@ class MarketServiceImplBatchPricesTest {
     @BeforeEach
     void setUp() {
         MarketDtoMapper marketDtoMapper = new MarketDtoMapper();
-        MockSectorNetworkGenerator mockSectorNetworkGenerator = new MockSectorNetworkGenerator();
+        ObjectMapper objectMapper = new ObjectMapper();
+        MockSectorNetworkGenerator mockSectorNetworkGenerator = new MockSectorNetworkGenerator(objectMapper);
         marketService = new MarketServiceImpl(
             stockRealtimeRepository,
             stockBasicRepository,

--- a/koduck-backend/src/test/java/com/koduck/service/MarketServiceImplTest.java
+++ b/koduck-backend/src/test/java/com/koduck/service/MarketServiceImplTest.java
@@ -34,6 +34,7 @@ import com.koduck.service.impl.market.MarketServiceImpl;
 import com.koduck.service.support.MarketFallbackSupport;
 import com.koduck.service.support.market.MarketDtoMapper;
 import com.koduck.service.support.market.MockSectorNetworkGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -152,7 +153,8 @@ class MarketServiceImplTest {
     @BeforeEach
     void setUp() {
         MarketDtoMapper marketDtoMapper = new MarketDtoMapper();
-        MockSectorNetworkGenerator mockSectorNetworkGenerator = new MockSectorNetworkGenerator();
+        ObjectMapper objectMapper = new ObjectMapper();
+        MockSectorNetworkGenerator mockSectorNetworkGenerator = new MockSectorNetworkGenerator(objectMapper);
         marketService = new MarketServiceImpl(
                 stockRealtimeRepository,
                 stockBasicRepository,


### PR DESCRIPTION
## 变更摘要

根据 ARCHITECTURE-EVALUATION.md 的评估建议，将 MockSectorNetworkGenerator 中的硬编码数据外部化到 JSON 资源文件。

### 主要变更

1. **新增 JSON 数据文件**: src/main/resources/mock/sector-network.json
   - 包含 18 个板块节点和 15 个关联关系
   - 数据与代码彻底解耦

2. **重构 MockSectorNetworkGenerator**:
   - 从 279 行减少到约 80 行
   - 使用 ObjectMapper 从 ClassPathResource 加载 JSON
   - 添加 @ConditionalOnProperty 开关控制

3. **创建 ADR-0078**: 记录决策、权衡与兼容性影响

4. **更新测试**: 注入 ObjectMapper 到 MockSectorNetworkGenerator

### 兼容性

- 无 API 变更
- 新增 mock.sector-network.enabled 配置（默认 true）
- 质量检查全绿

Closes #450