### PR TITLE
feat(module): 迁移 AuthService 接口和 JWT 组件到 koduck-auth

### DIFF
--- a/koduck-backend/docs/ADR-0092-migrate-auth-service-controller.md
+++ b/koduck-backend/docs/ADR-0092-migrate-auth-service-controller.md
@@ -1,0 +1,67 @@
+# ADR-0092: 迁移 Auth 相关组件到 koduck-auth 模块
+
+- Status: Accepted
+- Date: 2026-04-04
+- Issue: #478
+
+## Context
+
+在之前的 ADR 中，我们已经迁移了 auth 的 entity、repository、dto 和 UserPrincipal 接口到 koduck-auth 模块。本次继续迁移其他 auth 相关组件。
+
+## Decision
+
+迁移以下组件到 koduck-auth 模块：
+
+| 组件 | 原位置 | 新位置 | 说明 |
+|------|--------|--------|------|
+| AuthService 接口 | koduck-core | koduck-auth | 泛型化改造 |
+| JwtConfig | koduck-core | koduck-auth | JWT 配置 |
+| JwtUtil | koduck-core | koduck-auth | JWT 工具 |
+
+### 未迁移组件（保留在 koduck-core）
+
+| 组件 | 保留原因 |
+|------|----------|
+| AuthServiceImpl | 依赖 EmailService、RateLimiterService 等 koduck-core 服务 |
+| AuthController | 依赖 koduck-core 的多个服务 |
+| 异常类 | 依赖 Spring HttpStatus，koduck-common 无 Spring 依赖 |
+
+### AuthService 泛型化
+
+```java
+// Before
+public interface AuthService {
+    TokenResponse login(LoginRequest request, String ipAddress, String userAgent);
+}
+
+// After
+public interface AuthService<U extends UserPrincipal> {
+    TokenResponse<U> login(LoginRequest request, String ipAddress, String userAgent);
+}
+```
+
+## Consequences
+
+### 正向影响
+
+1. **JWT 组件归位**：JwtConfig、JwtUtil 属于认证领域，归到 koduck-auth
+2. **接口泛型化**：AuthService 支持泛型，为后续完整迁移做准备
+3. **逐步迁移**：避免一次性大规模变更，降低风险
+
+### 代价与风险
+
+1. **部分代码分散**：AuthServiceImpl 和 Controller 仍在 koduck-core
+2. **需要后续工作**：待基础设施（EmailService、RateLimiterService）下沉后，再迁移 ServiceImpl
+
+## Implementation Plan
+
+1. ✅ 迁移 AuthService 接口（泛型化）
+2. ✅ 迁移 JwtConfig
+3. ✅ 迁移 JwtUtil
+4. ⏳ 待后续：迁移 AuthServiceImpl（需先下沉 EmailService、RateLimiterService）
+5. ⏳ 待后续：迁移 AuthController
+
+## Verification
+
+- `mvn -f koduck-backend/pom.xml clean compile` 通过
+- `mvn -f koduck-backend/pom.xml checkstyle:check` 无异常

--- a/koduck-backend/koduck-auth/src/main/java/com/koduck/config/JwtConfig.java
+++ b/koduck-backend/koduck-auth/src/main/java/com/koduck/config/JwtConfig.java
@@ -1,0 +1,74 @@
+package com.koduck.config;
+
+import jakarta.validation.constraints.NotBlank;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.validation.annotation.Validated;
+
+import com.koduck.common.constants.HttpHeaderConstants;
+
+import lombok.Data;
+
+/**
+ * JSON Web Token (JWT) 处理的配置属性。
+ * <p>
+ * Bound from application properties with prefix {@code jwt}. Contains
+ * secret key, expiration settings, and header/token prefix values used by
+ * the security filters.
+ * </p>
+ *
+ * @author GitHub Copilot
+ */
+@Data
+@Configuration
+@ConfigurationProperties(prefix = "jwt")
+@Validated
+public class JwtConfig {
+
+    /**
+     * Default access token expiration: 24 hours in milliseconds.
+     */
+    private static final long DEFAULT_ACCESS_TOKEN_EXPIRATION_MS = 86_400_000L;
+
+    /**
+     * Default refresh token expiration: 7 days in milliseconds.
+     */
+    private static final long DEFAULT_REFRESH_TOKEN_EXPIRATION_MS = 604_800_000L;
+
+    /**
+     * Default token prefix (Bearer).
+     */
+    private static final String DEFAULT_TOKEN_PREFIX = HttpHeaderConstants.BEARER_PREFIX;
+
+    /**
+     * Default header name for authorization.
+     */
+    private static final String DEFAULT_HEADER_NAME = HttpHeaderConstants.AUTHORIZATION;
+
+    /**
+     * Secret key used to sign JWT tokens. Should be a secure random string.
+     */
+    @NotBlank
+    private String secret;
+
+    /**
+     * Access token lifespan in milliseconds (default 24 hours).
+     */
+    private Long accessTokenExpiration = DEFAULT_ACCESS_TOKEN_EXPIRATION_MS;
+
+    /**
+     * Refresh token lifespan in milliseconds (default 7 days).
+     */
+    private Long refreshTokenExpiration = DEFAULT_REFRESH_TOKEN_EXPIRATION_MS;
+
+    /**
+     * Prefix applied to JWT in the Authorization header (default "Bearer ").
+     */
+    private String tokenPrefix = DEFAULT_TOKEN_PREFIX;
+
+    /**
+     * HTTP header name where the JWT is expected (default "Authorization").
+     */
+    private String headerName = DEFAULT_HEADER_NAME;
+}

--- a/koduck-backend/koduck-auth/src/main/java/com/koduck/service/AuthService.java
+++ b/koduck-backend/koduck-auth/src/main/java/com/koduck/service/AuthService.java
@@ -1,0 +1,79 @@
+package com.koduck.service;
+
+import com.koduck.dto.auth.ForgotPasswordRequest;
+import com.koduck.dto.auth.LoginRequest;
+import com.koduck.dto.auth.RefreshTokenRequest;
+import com.koduck.dto.auth.RegisterRequest;
+import com.koduck.dto.auth.ResetPasswordRequest;
+import com.koduck.dto.auth.SecurityConfigResponse;
+import com.koduck.dto.auth.TokenResponse;
+import com.koduck.security.UserPrincipal;
+
+/**
+ * 认证服务接口。
+ *
+ * <p>Token 管理、用户认证与密码重置。</p>
+ *
+ * @param <U> 用户类型，必须实现 UserPrincipal
+ * @author Koduck Team
+ */
+public interface AuthService<U extends UserPrincipal> {
+
+    /**
+     * 用户登录（支持用户名或邮箱登录）。
+     *
+     * @param request   登录请求
+     * @param ipAddress IP 地址
+     * @param userAgent 用户代理
+     * @return Token 响应
+     */
+    TokenResponse<U> login(LoginRequest request, String ipAddress, String userAgent);
+
+    /**
+     * 用户注册。
+     *
+     * @param request 注册请求
+     * @return Token 响应
+     */
+    TokenResponse<U> register(RegisterRequest request);
+
+    /**
+     * 刷新 Token。
+     *
+     * @param request 刷新 Token 请求
+     * @return Token 响应
+     */
+    TokenResponse<U> refreshToken(RefreshTokenRequest request);
+
+    /**
+     * 用户登出。
+     *
+     * @param refreshTokenValue 刷新 Token
+     */
+    void logout(String refreshTokenValue);
+
+    /**
+     * 获取安全配置。
+     *
+     * @return 安全配置响应
+     */
+    SecurityConfigResponse getSecurityConfig();
+
+    /**
+     * 忘记密码。
+     *
+     * <p>无论邮箱是否存在都返回成功（防止枚举攻击）。</p>
+     * <p>对同一邮箱/IP 进行限流。</p>
+     *
+     * @param request   忘记密码请求
+     * @param ipAddress IP 地址
+     */
+    void forgotPassword(ForgotPasswordRequest request, String ipAddress);
+
+    /**
+     * 重置密码。
+     *
+     * @param request 重置密码请求
+     */
+    void resetPassword(ResetPasswordRequest request);
+}

--- a/koduck-backend/koduck-auth/src/main/java/com/koduck/util/JwtUtil.java
+++ b/koduck-backend/koduck-auth/src/main/java/com/koduck/util/JwtUtil.java
@@ -1,0 +1,211 @@
+package com.koduck.util;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+
+import javax.crypto.SecretKey;
+
+import org.springframework.stereotype.Component;
+
+import com.koduck.config.JwtConfig;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * JWT utility for token generation, parsing, and validation.
+ *
+ * @author GitHub Copilot
+ */
+@Slf4j
+@Component
+public class JwtUtil {
+
+    /**
+     * JWT configuration properties.
+     */
+    private final JwtConfig jwtConfig;
+
+    /**
+     * Creates the JWT helper.
+     *
+     * @param jwtConfig JWT configuration properties
+     */
+    public JwtUtil(final JwtConfig jwtConfig) {
+        this.jwtConfig = Objects.requireNonNull(jwtConfig, "jwtConfig must not be null");
+    }
+
+    /**
+     * Returns the signing key derived from the configured secret.
+     *
+     * @return signing key
+     */
+    private SecretKey getSigningKey() {
+        return Keys.hmacShaKeyFor(jwtConfig.getSecret().getBytes(StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Generates an access token.
+     *
+     * @param userId user id
+     * @param username username
+     * @param email email
+     * @return signed access token
+     */
+    public String generateAccessToken(final Long userId, final String username, final String email) {
+        final Map<String, Object> claims = new HashMap<>();
+        final Instant issuedAt = Instant.now();
+        claims.put("userId", userId);
+        claims.put("username", username);
+        claims.put("email", email);
+        claims.put("type", "access");
+        return Jwts.builder()
+                .claims(claims)
+                .subject(String.valueOf(userId))
+                .issuedAt(Date.from(issuedAt))
+                .expiration(Date.from(issuedAt.plusMillis(jwtConfig.getAccessTokenExpiration())))
+                .id(UUID.randomUUID().toString())
+                .signWith(getSigningKey(), Jwts.SIG.HS256)
+                .compact();
+    }
+
+    /**
+     * Generates a refresh token.
+     *
+     * @param userId user id
+     * @return signed refresh token
+     */
+    public String generateRefreshToken(final Long userId) {
+        final Map<String, Object> claims = new HashMap<>();
+        final Instant issuedAt = Instant.now();
+        claims.put("userId", userId);
+        claims.put("type", "refresh");
+        return Jwts.builder()
+                .claims(claims)
+                .subject(String.valueOf(userId))
+                .issuedAt(Date.from(issuedAt))
+                .expiration(Date.from(issuedAt.plusMillis(jwtConfig.getRefreshTokenExpiration())))
+                .id(UUID.randomUUID().toString())
+                .signWith(getSigningKey(), Jwts.SIG.HS256)
+                .compact();
+    }
+
+    /**
+     * Parses a signed JWT token.
+     *
+     * @param token token to parse
+     * @return parsed claims
+     */
+    public Claims parseToken(final String token) {
+        return Jwts.parser()
+                .verifyWith(getSigningKey())
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+
+    /**
+     * Validates a signed JWT token.
+     *
+     * @param token token to validate
+     * @return true when token is valid
+     */
+    public boolean validateToken(final String token) {
+        boolean valid = false;
+        try {
+            parseToken(token);
+            valid = true;
+        }
+        catch (ExpiredJwtException ex) {
+            warnIfEnabled("JWT token is expired: {}", ex.getMessage());
+        }
+        catch (UnsupportedJwtException ex) {
+            warnIfEnabled("JWT token is unsupported: {}", ex.getMessage());
+        }
+        catch (MalformedJwtException ex) {
+            warnIfEnabled("JWT token is malformed: {}", ex.getMessage());
+        }
+        catch (SignatureException ex) {
+            warnIfEnabled("JWT signature validation failed: {}", ex.getMessage());
+        }
+        catch (IllegalArgumentException ex) {
+            warnIfEnabled("JWT token is empty or null: {}", ex.getMessage());
+        }
+        return valid;
+    }
+
+    /**
+     * Returns the user id stored in the token subject.
+     *
+     * @param token token to inspect
+     * @return user id from token subject
+     */
+    public Long getUserIdFromToken(final String token) {
+        final Claims claims = parseToken(token);
+        return Long.valueOf(claims.getSubject());
+    }
+
+    /**
+     * Returns whether a token is expired.
+     *
+     * @param token token to inspect
+     * @return true when the token is expired
+     */
+    public boolean isTokenExpired(final String token) {
+        boolean expired;
+        try {
+            final Claims claims = parseToken(token);
+            expired = claims.getExpiration().toInstant().isBefore(Instant.now());
+        }
+        catch (ExpiredJwtException ex) {
+            expired = true;
+        }
+        return expired;
+    }
+
+    /**
+     * Returns the expiration time of a token.
+     *
+     * @param token token to inspect
+     * @return expiration time
+     */
+    public Date getExpirationDateFromToken(final String token) {
+        return parseToken(token).getExpiration();
+    }
+
+    /**
+     * Returns whether the token is a refresh token.
+     *
+     * @param token token to inspect
+     * @return true when the token type is refresh
+     */
+    public boolean isRefreshToken(final String token) {
+        boolean refreshToken;
+        try {
+            final Claims claims = parseToken(token);
+            refreshToken = "refresh".equals(claims.get("type"));
+        }
+        catch (JwtException | IllegalArgumentException ex) {
+            refreshToken = false;
+        }
+        return refreshToken;
+    }
+
+    private void warnIfEnabled(final String message, final String detail) {
+        if (log.isWarnEnabled()) {
+            log.warn(message, detail);
+        }
+    }
+}


### PR DESCRIPTION
## 变更内容

迁移 AuthService 接口和 JWT 相关组件到 koduck-auth 模块。

### 迁移的组件

| 组件 | 说明 |
|------|------|
| AuthService | 泛型化接口，支持 UserPrincipal 扩展 |
| JwtConfig | JWT 配置类 |
| JwtUtil | JWT 工具类 |

### AuthService 泛型化



### 保留在 koduck-core（后续迁移）

- AuthServiceImpl: 依赖 EmailService、RateLimiterService
- AuthController: 依赖多个 koduck-core 服务

### 质量验证

- checkstyle:check 通过
- spotbugs:check 通过

### ADR

- ADR-0092-migrate-auth-service-controller.md

Closes #478