### PR TITLE
feat(ai): Phase 3.3 - koduck-ai 模块优化和清理

### DIFF
--- a/koduck-backend/docs/ADR-0099-introduce-acl-layer-phase3-1.md
+++ b/koduck-backend/docs/ADR-0099-introduce-acl-layer-phase3-1.md
@@ -1,6 +1,6 @@
 # ADR-0099: 引入防腐层解耦 koduck-ai 依赖 (Phase 3.1)
 
-- Status: Accepted
+- Status: Completed
 - Date: 2026-04-05
 - Issue: #493
 

--- a/koduck-backend/docs/ADR-0102-ai-module-phase3-3-cleanup.md
+++ b/koduck-backend/docs/ADR-0102-ai-module-phase3-3-cleanup.md
@@ -1,6 +1,6 @@
 # ADR-0102: Phase 3.3 - 优化和清理
 
-- Status: Accepted
+- Status: Completed
 - Date: 2026-04-05
 - Issue: #502
 

--- a/koduck-backend/docs/ADR-0103-ai-module-phase3-3-cleanup-implementation.md
+++ b/koduck-backend/docs/ADR-0103-ai-module-phase3-3-cleanup-implementation.md
@@ -1,0 +1,82 @@
+# ADR-0103: koduck-ai 模块 Phase 3.3 优化和清理实施
+
+- Status: Accepted
+- Date: 2026-04-05
+- Issue: #531
+
+## Context
+
+根据 AI-MODULE-SPLIT-REASSESSMENT.md 的规划，koduck-ai 模块拆分为三个阶段：
+- Phase 3.1: 引入防腐层（已完成，ADR-0099）
+- Phase 3.2: 迁移 koduck-ai 代码到独立模块（已完成，ADR-0100、ADR-0101）
+- Phase 3.3: 优化和清理（本 ADR）
+
+Phase 3.3 的目标是确保 koduck-ai 模块的代码质量和可维护性，修复代码风格问题，更新文档状态。
+
+## Decision
+
+### 执行优化和清理任务
+
+#### 1. 修复 Checkstyle 警告
+
+koduck-ai 模块存在以下 5 个 checkstyle 警告：
+
+| 文件 | 行号 | 警告类型 | 修复方案 |
+|------|------|----------|----------|
+| AiConversationSupport.java | 21 | ImportOrder | 调整 import 顺序 |
+| MemoryServiceTest.java | 232 | LineLength | 拆分长行 |
+| AiAnalysisServiceImplTest.java | 596 | LineLength | 拆分长行 |
+| AiAnalysisServiceImplTest.java | 597 | LineLength | 拆分长行 |
+| AiAnalysisServiceImplTest.java | 657 | MagicNumber | 提取为常量 |
+
+#### 2. 更新 ADR 状态
+
+将以下 ADR 的状态从 "Accepted" 更新为 "Completed"：
+- ADR-0099: 引入防腐层解耦 koduck-ai 依赖 (Phase 3.1)
+- ADR-0102: Phase 3.3 - 优化和清理
+
+## Consequences
+
+### 正向影响
+
+1. **代码质量保障**: 通过修复 checkstyle 警告，确保代码符合阿里巴巴 Java 编码规范
+2. **可维护性提升**: 统一的代码风格，便于后续维护
+3. **文档完整性**: ADR 状态与实际实施状态保持一致
+
+### 兼容性影响
+
+| 层面 | 影响 | 说明 |
+|------|------|------|
+| API 兼容 | ✅ 无变化 | 仅代码风格修复，无 API 变更 |
+| 功能兼容 | ✅ 无变化 | 所有功能保持不变 |
+| 部署兼容 | ✅ 无变化 | 部署方式不变 |
+
+## Implementation
+
+### 任务清单
+
+- [ ] 修复 AiConversationSupport.java import 顺序
+- [ ] 修复 MemoryServiceTest.java 行长度问题
+- [ ] 修复 AiAnalysisServiceImplTest.java 行长度问题
+- [ ] 修复 AiAnalysisServiceImplTest.java 魔法数字问题
+- [ ] 更新 ADR-0099 状态为 Completed
+- [ ] 更新 ADR-0102 状态为 Completed
+- [ ] mvn clean compile 编译通过
+- [ ] mvn checkstyle:check 无异常
+- [ ] 所有测试通过
+
+## Verification
+
+- [ ] koduck-ai 模块 checkstyle 无警告
+- [ ] 编译通过
+- [ ] 测试通过
+- [ ] ADR 状态已更新
+
+## References
+
+- AI-MODULE-SPLIT-REASSESSMENT.md
+- ADR-0099: 引入防腐层解耦 koduck-ai 依赖 (Phase 3.1)
+- ADR-0100: 迁移 koduck-ai 代码到独立模块 (Phase 3.2)
+- ADR-0101: AiAnalysisServiceImpl 使用防腐层接口
+- ADR-0102: Phase 3.3 - 优化和清理
+- Issue: #531

--- a/koduck-backend/koduck-ai/src/main/java/com/koduck/service/support/AiConversationSupport.java
+++ b/koduck-backend/koduck-ai/src/main/java/com/koduck/service/support/AiConversationSupport.java
@@ -13,12 +13,12 @@ import java.util.regex.Pattern;
 
 import org.springframework.stereotype.Component;
 
+import com.koduck.acl.UserMemoryProfileQueryService.UserMemoryProfileDto;
 import com.koduck.common.constants.MarketConstants;
 import com.koduck.dto.ai.ChatMessageRequest;
 import com.koduck.dto.ai.ChatStreamRequest;
 import com.koduck.dto.indicator.IndicatorResponse;
 import com.koduck.entity.ai.MemoryChatMessage;
-import com.koduck.acl.UserMemoryProfileQueryService.UserMemoryProfileDto;
 import com.koduck.service.MemoryService;
 import com.koduck.service.TechnicalIndicatorService;
 

--- a/koduck-backend/koduck-ai/src/test/java/com/koduck/service/AiAnalysisServiceImplTest.java
+++ b/koduck-backend/koduck-ai/src/test/java/com/koduck/service/AiAnalysisServiceImplTest.java
@@ -144,6 +144,9 @@ class AiAnalysisServiceImplTest {
     /** Test total return value. */
     private static final String TEST_TOTAL_RETURN = "0.15";
 
+    /** Test trade count for backtest. */
+    private static final int TEST_TRADE_COUNT = 10;
+
     /** Test risk score - medium high. */
     private static final int TEST_RISK_SCORE_HIGH = 65;
 
@@ -593,8 +596,10 @@ class AiAnalysisServiceImplTest {
                 .build();
 
         List<StrategyQueryService.StrategySummary> userStrategies = List.of(
-                new StrategyQueryService.StrategySummary(TEST_STRATEGY_ID_1, "MA Cross", "trend", "Moving average crossover strategy"),
-                new StrategyQueryService.StrategySummary(TEST_STRATEGY_ID_2, "RSI Strategy", "momentum", "RSI based strategy")
+                new StrategyQueryService.StrategySummary(
+                    TEST_STRATEGY_ID_1, "MA Cross", "trend", "Moving average crossover strategy"),
+                new StrategyQueryService.StrategySummary(
+                    TEST_STRATEGY_ID_2, "RSI Strategy", "momentum", "RSI based strategy")
         );
 
         StrategyRecommendResponse expectedResponse = StrategyRecommendResponse.builder()
@@ -654,7 +659,7 @@ class AiAnalysisServiceImplTest {
                 "MA Cross",
                 new BigDecimal(TEST_TOTAL_RETURN),
                 new BigDecimal("0.05"),
-                10,
+                TEST_TRADE_COUNT,
                 new BigDecimal("1.2"),
                 new BigDecimal("0.6")
         );

--- a/koduck-backend/koduck-ai/src/test/java/com/koduck/service/MemoryServiceTest.java
+++ b/koduck-backend/koduck-ai/src/test/java/com/koduck/service/MemoryServiceTest.java
@@ -229,7 +229,8 @@ class MemoryServiceTest {
         );
 
         when(userMemoryProfileQueryService.findByUserId(TEST_USER_ID)).thenReturn(Optional.empty());
-        doNothing().when(userMemoryProfileQueryService).updateProfile(eq(TEST_USER_ID), any(UserMemoryProfileDto.class));
+        doNothing().when(userMemoryProfileQueryService)
+            .updateProfile(eq(TEST_USER_ID), any(UserMemoryProfileDto.class));
 
         UserMemoryProfileDto result = memoryService.upsertProfile(
             TEST_USER_ID,


### PR DESCRIPTION
## 功能描述

完成 koduck-ai 模块拆分的 Phase 3.3：优化和清理阶段。

## 变更内容

### 代码质量修复
- 修复 AiConversationSupport.java import 顺序问题（将 ACL import 移到首位）
- 修复 MemoryServiceTest.java 行长度超过 120 字符的问题
- 修复 AiAnalysisServiceImplTest.java 行长度超过 120 字符的问题（2 处）
- 修复 AiAnalysisServiceImplTest.java 魔法数字问题（提取 TEST_TRADE_COUNT 常量）

### 文档更新
- 更新 ADR-0099 状态为 Completed
- 更新 ADR-0102 状态为 Completed
- 创建 ADR-0103 记录 Phase 3.3 实施细节

## 验证结果

- [x] mvn clean compile 编译通过
- [x] mvn checkstyle:check 无异常（所有模块）
- [x] koduck-ai 模块单元测试通过（31 tests）

## 兼容性影响

| 层面 | 影响 | 说明 |
|------|------|------|
| API 兼容 | ✅ 无变化 | 仅代码风格修复，无 API 变更 |
| 功能兼容 | ✅ 无变化 | 所有功能保持不变 |
| 部署兼容 | ✅ 无变化 | 部署方式不变 |

Closes #531