### PR TITLE
feat(market): 迁移 Market Service 和 Provider 到 koduck-market-impl

### DIFF
--- a/koduck-backend/koduck-market/koduck-market-api/src/main/java/com/koduck/market/MarketType.java
+++ b/koduck-backend/koduck-market/koduck-market-api/src/main/java/com/koduck/market/MarketType.java
@@ -1,0 +1,105 @@
+package com.koduck.market;
+
+/**
+ * Enumeration of supported market types.
+ * Used to identify different financial markets.
+ *
+ * @author GitHub Copilot
+ */
+public enum MarketType {
+    /**
+     * A-Share market (China mainland)
+     */
+    A_SHARE("a_share", "A股", "CNY"),
+
+    /**
+     * US stock market
+     */
+    US_STOCK("us_stock", "美股", "USD"),
+
+    /**
+     * Hong Kong stock market
+     */
+    HK_STOCK("hk_stock", "港股", "HKD"),
+
+    /**
+     * Cryptocurrency market
+     */
+    CRYPTO("crypto", "加密货币", "USDT"),
+
+    /**
+     * Futures market
+     */
+    FUTURES("futures", "期货", "CNY"),
+
+    /**
+     * Forex market
+     */
+    FOREX("forex", "外汇", "USD");
+
+    /**
+     * Market code identifier.
+     */
+    private final String code;
+
+    /**
+     * Market display name.
+     */
+    private final String name;
+
+    /**
+     * Default currency for this market.
+     */
+    private final String defaultCurrency;
+    
+    MarketType(String code, String name, String defaultCurrency) {
+        this.code = code;
+        this.name = name;
+        this.defaultCurrency = defaultCurrency;
+    }
+    
+    public String getCode() {
+        return code;
+    }
+    
+    public String getName() {
+        return name;
+    }
+    
+    public String getDefaultCurrency() {
+        return defaultCurrency;
+    }
+    
+    /**
+     * Get MarketType from code string.
+     *
+     * @param code the market code
+     * @return MarketType or null if not found
+     */
+    public static MarketType fromCode(String code) {
+        for (MarketType type : values()) {
+            if (type.code.equalsIgnoreCase(code)) {
+                return type;
+            }
+        }
+        return null;
+    }
+    
+    /**
+     * Check if this market supports pre/post market trading.
+     *
+     * @return true if extended hours trading is supported
+     */
+    public boolean supportsExtendedHours() {
+        return this == US_STOCK;
+    }
+    
+    /**
+     * Check if this market trades 24/7.
+     *
+     * @return true if market trades 24/7
+     */
+    public boolean is24HourMarket() {
+        return this == CRYPTO || this == FOREX;
+    }
+}

--- a/koduck-backend/koduck-market/koduck-market-api/src/main/java/com/koduck/market/dto/indicator/IndicatorListResponse.java
+++ b/koduck-backend/koduck-market/koduck-market-api/src/main/java/com/koduck/market/dto/indicator/IndicatorListResponse.java
@@ -1,0 +1,99 @@
+package com.koduck.market.dto.indicator;
+
+import java.util.List;
+
+import com.koduck.util.CollectionCopyUtils;
+
+/**
+ * 可用指标列表响应。
+ *
+ * @author Koduck Team
+ * @param indicators the list of indicator information
+ */
+public record IndicatorListResponse(
+    List<IndicatorInfo> indicators
+) {
+
+    /**
+ * 紧凑构造函数，用于创建指标的防御性拷贝。
+     *
+     * @param indicators the indicators list
+     */
+    public IndicatorListResponse {
+        indicators = CollectionCopyUtils.copyList(indicators);
+    }
+
+    @Override
+    public List<IndicatorInfo> indicators() {
+        return CollectionCopyUtils.copyList(indicators);
+    }
+
+    /**
+     * 单个指标的信息。
+     *
+     * @param code the indicator code
+     * @param name the indicator name
+     * @param description the indicator description
+     * @param defaultPeriods the default periods for this indicator
+     * @param category the indicator category
+     */
+    public record IndicatorInfo(
+        String code,
+        String name,
+        String description,
+        List<Integer> defaultPeriods,
+        String category
+    ) {
+
+        /**
+ * 紧凑构造函数，用于创建默认周期的防御性拷贝。
+         *
+         * @param defaultPeriods the default periods list
+         */
+        public IndicatorInfo {
+            defaultPeriods = CollectionCopyUtils.copyList(defaultPeriods);
+        }
+
+        @Override
+        public List<Integer> defaultPeriods() {
+            return CollectionCopyUtils.copyList(defaultPeriods);
+        }
+    }
+
+    /**
+     * Creates a new builder instance.
+     *
+     * @return a new Builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * IndicatorListResponse 的构建器类。
+     */
+    public static class Builder {
+        /** 指标信息列表。 */
+        private List<IndicatorInfo> indicators;
+
+        /**
+ * 设置指标列表。
+         *
+         * @param indicators the indicators
+         * @return this builder
+         */
+        public Builder indicators(List<IndicatorInfo> indicators) {
+            this.indicators = CollectionCopyUtils.copyList(indicators);
+            return this;
+        }
+
+        /**
+ * 构建 IndicatorListResponse 实例。
+         *
+         * @return 构建的 IndicatorListResponse
+         */
+        public IndicatorListResponse build() {
+            return new IndicatorListResponse(indicators);
+        }
+    }
+}

--- a/koduck-backend/koduck-market/koduck-market-api/src/main/java/com/koduck/market/dto/indicator/IndicatorResponse.java
+++ b/koduck-backend/koduck-market/koduck-market-api/src/main/java/com/koduck/market/dto/indicator/IndicatorResponse.java
@@ -1,0 +1,168 @@
+package com.koduck.market.dto.indicator;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Map;
+
+import com.koduck.util.CollectionCopyUtils;
+
+/**
+ * 技术指标响应数据传输对象。
+ *
+ * @param symbol 股票代码
+ * @param market 市场标识符
+ * @param indicator 指标名称
+ * @param period 指标周期
+ * @param values 指标值映射
+ * @param trend 趋势方向
+ * @param timestamp 指标数据的时间戳
+ * @author Koduck Team
+ */
+public record IndicatorResponse(
+    // 股票代码。
+    String symbol,
+    // 市场标识符。
+    String market,
+    // 指标名称。
+    String indicator,
+    // 指标周期。
+    Integer period,
+    // 指标值映射。
+    Map<String, BigDecimal> values,
+    // 趋势方向。
+    String trend,
+    // 指标数据的时间戳。
+    LocalDateTime timestamp
+) {
+
+    /**
+ * 紧凑构造函数，用于创建值的防御性拷贝。
+     *
+     * @param values 值映射
+     */
+    public IndicatorResponse {
+        values = CollectionCopyUtils.copyMap(values);
+    }
+
+    @Override
+    public Map<String, BigDecimal> values() {
+        return CollectionCopyUtils.copyMap(values);
+    }
+
+    /**
+     * Creates a new builder instance.
+     *
+     * @return a new Builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * IndicatorResponse 的构建器类。
+     */
+    public static class Builder {
+        /** 股票代码。 */
+        private String symbol;
+        /** 市场标识符。 */
+        private String market;
+        /** 指标名称。 */
+        private String indicator;
+        /** 指标周期。 */
+        private Integer period;
+        /** 指标值映射。 */
+        private Map<String, BigDecimal> values;
+        /** 趋势方向。 */
+        private String trend;
+        /** 指标数据的时间戳。 */
+        private LocalDateTime timestamp;
+
+        /**
+ * 设置股票代码。
+         *
+         * @param symbol 品种代码
+         * @return this builder
+         */
+        public Builder symbol(String symbol) {
+            this.symbol = symbol;
+            return this;
+        }
+
+        /**
+ * 设置市场标识符。
+         *
+         * @param market the market
+         * @return this builder
+         */
+        public Builder market(String market) {
+            this.market = market;
+            return this;
+        }
+
+        /**
+ * 设置指标名称。
+         *
+         * @param indicator the indicator
+         * @return this builder
+         */
+        public Builder indicator(String indicator) {
+            this.indicator = indicator;
+            return this;
+        }
+
+        /**
+ * 设置指标周期。
+         *
+         * @param period the period
+         * @return this builder
+         */
+        public Builder period(Integer period) {
+            this.period = period;
+            return this;
+        }
+
+        /**
+ * 设置指标值。
+         *
+         * @param values 值映射
+         * @return this builder
+         */
+        public Builder values(Map<String, BigDecimal> values) {
+            this.values = CollectionCopyUtils.copyMap(values);
+            return this;
+        }
+
+        /**
+ * 设置趋势方向。
+         *
+         * @param trend the trend
+         * @return this builder
+         */
+        public Builder trend(String trend) {
+            this.trend = trend;
+            return this;
+        }
+
+        /**
+ * 设置时间戳。
+         *
+         * @param timestamp 时间戳
+         * @return this builder
+         */
+        public Builder timestamp(LocalDateTime timestamp) {
+            this.timestamp = timestamp;
+            return this;
+        }
+
+        /**
+ * 构建 IndicatorResponse 实例。
+         *
+         * @return 构建的 IndicatorResponse
+         */
+        public IndicatorResponse build() {
+            return new IndicatorResponse(
+                symbol, market, indicator, period, values, trend, timestamp
+            );
+        }
+    }
+}

--- a/koduck-backend/koduck-market/koduck-market-impl/src/main/java/com/koduck/market/model/KlineData.java
+++ b/koduck-backend/koduck-market/koduck-market-impl/src/main/java/com/koduck/market/model/KlineData.java
@@ -1,0 +1,252 @@
+package com.koduck.market.model;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.Instant;
+
+/**
+ * Unified K-line data model across all markets.
+ * This is the standard format that all providers must convert their data to.
+ *
+ * @author Koduck Team
+ * @param symbol the stock symbol
+ * @param market the market code
+ * @param timestamp the timestamp of the kline
+ * @param open the opening price
+ * @param high the highest price
+ * @param low the lowest price
+ * @param close the closing price
+ * @param volume the trading volume
+ * @param amount the trading amount
+ * @param timeframe the timeframe of the kline
+ */
+public record KlineData(
+    String symbol,
+
+    String market,
+
+    Instant timestamp,
+
+    BigDecimal open,
+
+    BigDecimal high,
+
+    BigDecimal low,
+
+    BigDecimal close,
+
+    Long volume,
+
+    BigDecimal amount,
+
+    String timeframe
+) {
+
+    /** Scale for price change percentage calculation. */
+    private static final int PRICE_CHANGE_SCALE = 4;
+
+    /** Multiplier for percentage conversion. */
+    private static final int PERCENT_MULTIPLIER = 100;
+
+    public KlineData {
+        if (amount == null) {
+            amount = BigDecimal.ZERO;
+        }
+    }
+
+    /**
+     * Calculate price change.
+     *
+     * @return the price change (close - open)
+     */
+    public BigDecimal getPriceChange() {
+        return close.subtract(open);
+    }
+
+    /**
+     * Calculate price change percentage.
+     *
+     * @return the price change percentage
+     */
+    public BigDecimal getPriceChangePercent() {
+        if (open.compareTo(BigDecimal.ZERO) == 0) {
+            return BigDecimal.ZERO;
+        }
+        return close.subtract(open)
+                   .divide(open, PRICE_CHANGE_SCALE, RoundingMode.HALF_UP)
+                   .multiply(BigDecimal.valueOf(PERCENT_MULTIPLIER));
+    }
+
+    /**
+     * Check if this is a rising k-line.
+     *
+     * @return true if close >= open
+     */
+    public boolean isRising() {
+        return close.compareTo(open) >= 0;
+    }
+
+    /**
+     * Builder for KlineData.
+     *
+     * @return a new Builder instance
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder for KlineData.
+     */
+    public static class Builder {
+        /** The stock symbol. */
+        private String symbol;
+
+        /** The market code. */
+        private String market;
+
+        /** The timestamp. */
+        private Instant timestamp;
+
+        /** The opening price. */
+        private BigDecimal open;
+
+        /** The highest price. */
+        private BigDecimal high;
+
+        /** The lowest price. */
+        private BigDecimal low;
+
+        /** The closing price. */
+        private BigDecimal close;
+
+        /** The trading volume. */
+        private Long volume;
+
+        /** The trading amount. */
+        private BigDecimal amount;
+
+        /** The timeframe. */
+        private String timeframe;
+
+        /**
+         * Set the symbol.
+         *
+         * @param symbol the stock symbol
+         * @return this builder
+         */
+        public Builder symbol(String symbol) {
+            this.symbol = symbol;
+            return this;
+        }
+
+        /**
+         * Set the market.
+         *
+         * @param market the market code
+         * @return this builder
+         */
+        public Builder market(String market) {
+            this.market = market;
+            return this;
+        }
+
+        /**
+         * Set the timestamp.
+         *
+         * @param timestamp the timestamp
+         * @return this builder
+         */
+        public Builder timestamp(Instant timestamp) {
+            this.timestamp = timestamp;
+            return this;
+        }
+
+        /**
+         * Set the open price.
+         *
+         * @param open the opening price
+         * @return this builder
+         */
+        public Builder open(BigDecimal open) {
+            this.open = open;
+            return this;
+        }
+
+        /**
+         * Set the high price.
+         *
+         * @param high the highest price
+         * @return this builder
+         */
+        public Builder high(BigDecimal high) {
+            this.high = high;
+            return this;
+        }
+
+        /**
+         * Set the low price.
+         *
+         * @param low the lowest price
+         * @return this builder
+         */
+        public Builder low(BigDecimal low) {
+            this.low = low;
+            return this;
+        }
+
+        /**
+         * Set the close price.
+         *
+         * @param close the closing price
+         * @return this builder
+         */
+        public Builder close(BigDecimal close) {
+            this.close = close;
+            return this;
+        }
+
+        /**
+         * Set the volume.
+         *
+         * @param volume the trading volume
+         * @return this builder
+         */
+        public Builder volume(Long volume) {
+            this.volume = volume;
+            return this;
+        }
+
+        /**
+         * Set the amount.
+         *
+         * @param amount the trading amount
+         * @return this builder
+         */
+        public Builder amount(BigDecimal amount) {
+            this.amount = amount;
+            return this;
+        }
+
+        /**
+         * Set the timeframe.
+         *
+         * @param timeframe the timeframe
+         * @return this builder
+         */
+        public Builder timeframe(String timeframe) {
+            this.timeframe = timeframe;
+            return this;
+        }
+
+        /**
+         * Build the KlineData.
+         *
+         * @return a new KlineData instance
+         */
+        public KlineData build() {
+            return new KlineData(symbol, market, timestamp, open, high, low,
+                                close, volume, amount, timeframe);
+        }
+    }
+}

--- a/koduck-backend/koduck-market/koduck-market-impl/src/main/java/com/koduck/market/model/TickData.java
+++ b/koduck-backend/koduck-market/koduck-market-impl/src/main/java/com/koduck/market/model/TickData.java
@@ -1,0 +1,340 @@
+package com.koduck.market.model;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+/**
+ * Real-time tick data model.
+ * Represents a single trade/tick in the market.
+ *
+ * @author Koduck Team
+ * @param symbol the stock symbol
+ * @param market the market code
+ * @param timestamp the timestamp of the tick
+ * @param price the current price
+ * @param change the price change
+ * @param changePercent the price change percentage
+ * @param volume the trading volume
+ * @param amount the trading amount
+ * @param bidPrice the bid price
+ * @param bidVolume the bid volume
+ * @param askPrice the ask price
+ * @param askVolume the ask volume
+ * @param dayHigh the day's highest price
+ * @param dayLow the day's lowest price
+ * @param open the opening price
+ * @param prevClose the previous close price
+ */
+public record TickData(
+    String symbol,
+
+    String market,
+
+    Instant timestamp,
+
+    BigDecimal price,
+
+    BigDecimal change,
+
+    BigDecimal changePercent,
+
+    Long volume,
+
+    BigDecimal amount,
+
+    BigDecimal bidPrice,
+
+    Long bidVolume,
+
+    BigDecimal askPrice,
+
+    Long askVolume,
+
+    BigDecimal dayHigh,
+
+    BigDecimal dayLow,
+
+    BigDecimal open,
+
+    BigDecimal prevClose
+) {
+
+    /**
+     * Check if price is rising.
+     *
+     * @return true if price is rising
+     */
+    public boolean isRising() {
+        return change != null && change.compareTo(BigDecimal.ZERO) > 0;
+    }
+
+    /**
+     * Check if price is falling.
+     *
+     * @return true if price is falling
+     */
+    public boolean isFalling() {
+        return change != null && change.compareTo(BigDecimal.ZERO) < 0;
+    }
+
+    /**
+     * Get spread between ask and bid.
+     *
+     * @return the spread value
+     */
+    public BigDecimal getSpread() {
+        if (askPrice == null || bidPrice == null) {
+            return BigDecimal.ZERO;
+        }
+        return askPrice.subtract(bidPrice);
+    }
+
+    /**
+     * Builder for TickData.
+     *
+     * @return a new Builder instance
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder class for TickData.
+     */
+    public static class Builder {
+        /** The stock symbol. */
+        private String symbol;
+
+        /** The market code. */
+        private String market;
+
+        /** The timestamp. */
+        private Instant timestamp;
+
+        /** The current price. */
+        private BigDecimal price;
+
+        /** The price change. */
+        private BigDecimal change;
+
+        /** The price change percentage. */
+        private BigDecimal changePercent;
+
+        /** The trading volume. */
+        private Long volume;
+
+        /** The trading amount. */
+        private BigDecimal amount;
+
+        /** The bid price. */
+        private BigDecimal bidPrice;
+
+        /** The bid volume. */
+        private Long bidVolume;
+
+        /** The ask price. */
+        private BigDecimal askPrice;
+
+        /** The ask volume. */
+        private Long askVolume;
+
+        /** The day's highest price. */
+        private BigDecimal dayHigh;
+
+        /** The day's lowest price. */
+        private BigDecimal dayLow;
+
+        /** The opening price. */
+        private BigDecimal open;
+
+        /** The previous close price. */
+        private BigDecimal prevClose;
+
+        /**
+         * Set the symbol.
+         *
+         * @param symbol the stock symbol
+         * @return the Builder instance
+         */
+        public Builder symbol(String symbol) {
+            this.symbol = symbol;
+            return this;
+        }
+
+        /**
+         * Set the market.
+         *
+         * @param market the market code
+         * @return the Builder instance
+         */
+        public Builder market(String market) {
+            this.market = market;
+            return this;
+        }
+
+        /**
+         * Set the timestamp.
+         *
+         * @param timestamp the timestamp
+         * @return the Builder instance
+         */
+        public Builder timestamp(Instant timestamp) {
+            this.timestamp = timestamp;
+            return this;
+        }
+
+        /**
+         * Set the price.
+         *
+         * @param price the current price
+         * @return the Builder instance
+         */
+        public Builder price(BigDecimal price) {
+            this.price = price;
+            return this;
+        }
+
+        /**
+         * Set the change.
+         *
+         * @param change the price change
+         * @return the Builder instance
+         */
+        public Builder change(BigDecimal change) {
+            this.change = change;
+            return this;
+        }
+
+        /**
+         * Set the change percent.
+         *
+         * @param changePercent the price change percentage
+         * @return the Builder instance
+         */
+        public Builder changePercent(BigDecimal changePercent) {
+            this.changePercent = changePercent;
+            return this;
+        }
+
+        /**
+         * Set the volume.
+         *
+         * @param volume the trading volume
+         * @return the Builder instance
+         */
+        public Builder volume(Long volume) {
+            this.volume = volume;
+            return this;
+        }
+
+        /**
+         * Set the amount.
+         *
+         * @param amount the trading amount
+         * @return the Builder instance
+         */
+        public Builder amount(BigDecimal amount) {
+            this.amount = amount;
+            return this;
+        }
+
+        /**
+         * Set the bid price.
+         *
+         * @param bidPrice the bid price
+         * @return the Builder instance
+         */
+        public Builder bidPrice(BigDecimal bidPrice) {
+            this.bidPrice = bidPrice;
+            return this;
+        }
+
+        /**
+         * Set the bid volume.
+         *
+         * @param bidVolume the bid volume
+         * @return the Builder instance
+         */
+        public Builder bidVolume(Long bidVolume) {
+            this.bidVolume = bidVolume;
+            return this;
+        }
+
+        /**
+         * Set the ask price.
+         *
+         * @param askPrice the ask price
+         * @return the Builder instance
+         */
+        public Builder askPrice(BigDecimal askPrice) {
+            this.askPrice = askPrice;
+            return this;
+        }
+
+        /**
+         * Set the ask volume.
+         *
+         * @param askVolume the ask volume
+         * @return the Builder instance
+         */
+        public Builder askVolume(Long askVolume) {
+            this.askVolume = askVolume;
+            return this;
+        }
+
+        /**
+         * Set the day high.
+         *
+         * @param dayHigh the day's highest price
+         * @return the Builder instance
+         */
+        public Builder dayHigh(BigDecimal dayHigh) {
+            this.dayHigh = dayHigh;
+            return this;
+        }
+
+        /**
+         * Set the day low.
+         *
+         * @param dayLow the day's lowest price
+         * @return the Builder instance
+         */
+        public Builder dayLow(BigDecimal dayLow) {
+            this.dayLow = dayLow;
+            return this;
+        }
+
+        /**
+         * Set the open price.
+         *
+         * @param open the opening price
+         * @return the Builder instance
+         */
+        public Builder open(BigDecimal open) {
+            this.open = open;
+            return this;
+        }
+
+        /**
+         * Set the previous close.
+         *
+         * @param prevClose the previous close price
+         * @return the Builder instance
+         */
+        public Builder prevClose(BigDecimal prevClose) {
+            this.prevClose = prevClose;
+            return this;
+        }
+
+        /**
+         * Build the TickData instance.
+         *
+         * @return the TickData instance
+         */
+        public TickData build() {
+            return new TickData(symbol, market, timestamp, price, change, changePercent,
+                              volume, amount, bidPrice, bidVolume, askPrice, askVolume,
+                              dayHigh, dayLow, open, prevClose);
+        }
+    }
+}

--- a/koduck-backend/koduck-market/koduck-market-impl/src/main/java/com/koduck/market/provider/AKShareDataProvider.java
+++ b/koduck-backend/koduck-market/koduck-market-impl/src/main/java/com/koduck/market/provider/AKShareDataProvider.java
@@ -1,0 +1,586 @@
+package com.koduck.market.provider;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import com.koduck.common.constants.DataServicePathConstants;
+import com.koduck.common.constants.MapKeyConstants;
+import com.koduck.infrastructure.config.properties.DataServiceProperties;
+import com.koduck.market.dto.DataServiceResponse;
+import com.koduck.market.dto.PriceQuoteDto;
+import com.koduck.market.dto.StockIndustryDto;
+import com.koduck.market.dto.StockValuationDto;
+import com.koduck.market.dto.SymbolInfoDto;
+import com.koduck.exception.ExternalServiceException;
+import com.koduck.market.MarketType;
+import com.koduck.market.model.KlineData;
+import com.koduck.market.model.TickData;
+import com.koduck.market.provider.MarketDataProvider;
+import com.koduck.market.service.support.AKShareDataMapperSupport;
+
+/**
+ * AKShare A股数据提供者实现。
+ * 从 Python 数据服务获取市场数据。
+ * 实现新的 MarketDataProvider 接口。
+ *
+ * @author Koduck Team
+ */
+@Component
+public class AKShareDataProvider implements MarketDataProvider {
+
+    /** The logger. */
+    private static final Logger LOG = LoggerFactory.getLogger(AKShareDataProvider.class);
+    /** Data service disabled message. */
+    private static final String DATA_SERVICE_DISABLED_MESSAGE = "Data service is disabled";
+    /** A-share base path. */
+    private static final String A_SHARE_BASE_PATH = DataServicePathConstants.A_SHARE_BASE_PATH;
+    /** Key symbol. */
+    private static final String KEY_SYMBOL = MapKeyConstants.KEY_SYMBOL;
+    /** Key limit. */
+    private static final String KEY_LIMIT = "limit";
+    /** Response type message. */
+    private static final String RESPONSE_TYPE_MESSAGE = "responseType must not be null";
+    /** HTTP GET message. */
+    private static final String HTTP_GET_MESSAGE = "HTTP GET must not be null";
+    /** HTTP POST message. */
+    private static final String HTTP_POST_MESSAGE = "HTTP POST must not be null";
+    /** Provider name. */
+    private static final String PROVIDER_NAME = "akshare-a-share";
+    /** Health score when disabled. */
+    private static final int HEALTH_SCORE_DISABLED = 0;
+    /** Full health score. */
+    private static final int HEALTH_SCORE_FULL = 100;
+    /** Morning open hour. */
+    private static final int OPEN_MORNING_HOUR = 9;
+    /** Morning open minute. */
+    private static final int OPEN_MORNING_MINUTE = 30;
+    /** Morning close hour. */
+    private static final int CLOSE_MORNING_HOUR = 11;
+    /** Morning close minute. */
+    private static final int CLOSE_MORNING_MINUTE = 30;
+    /** Afternoon open hour. */
+    private static final int OPEN_AFTERNOON_HOUR = 13;
+    /** Afternoon close hour. */
+    private static final int CLOSE_AFTERNOON_HOUR = 15;
+    /** Minutes per hour. */
+    private static final int MINUTES_PER_HOUR = 60;
+    /** Asia/Shanghai timezone. */
+    private static final String TIMEZONE_ASIA_SHANGHAI = "Asia/Shanghai";
+
+    /** List data response type. */
+    private static final ParameterizedTypeReference<
+        DataServiceResponse<List<Map<String, Object>>>>
+        LIST_DATA_RESPONSE_TYPE =
+        new ParameterizedTypeReference<DataServiceResponse<List<Map<String, Object>>>>() {
+        };
+    /** Map data response type. */
+    private static final ParameterizedTypeReference<DataServiceResponse<Map<String, Object>>>
+        MAP_DATA_RESPONSE_TYPE =
+        new ParameterizedTypeReference<DataServiceResponse<Map<String, Object>>>() {
+        };
+
+    /** The WebClient. */
+    private final WebClient webClient;
+    /** The data service properties. */
+    private final DataServiceProperties properties;
+    /** Subscribed symbols set. */
+    private final Set<String> subscribedSymbols = ConcurrentHashMap.newKeySet();
+    /** Provider availability flag. */
+    private volatile boolean available = true;
+    /** Provider health score. */
+    private volatile int healthScore = HEALTH_SCORE_FULL;
+
+    /**
+     * 构造函数。
+     *
+     * @param webClient WebClient
+     * @param properties 配置属性
+     */
+    public AKShareDataProvider(
+        @Qualifier("dataServiceWebClient") WebClient webClient,
+        DataServiceProperties properties) {
+        this.webClient = Objects.requireNonNull(webClient,
+            "webClient must not be null");
+        this.properties = Objects.requireNonNull(properties,
+            "properties must not be null");
+    }
+
+    @Override
+    public String getProviderName() {
+        return PROVIDER_NAME;
+    }
+
+    @Override
+    public MarketType getMarketType() {
+        return MarketType.A_SHARE;
+    }
+
+    @Override
+    public boolean isAvailable() {
+        return available && properties.isEnabled();
+    }
+
+    @Override
+    public int getHealthScore() {
+        if (!properties.isEnabled()) {
+            return HEALTH_SCORE_DISABLED;
+        }
+        return healthScore;
+    }
+
+    @Override
+    public List<KlineData> getKlineData(String symbol, String timeframe, int limit,
+        Instant startTime, Instant endTime) throws MarketDataException {
+
+        if (!isAvailable()) {
+            throw new MarketDataException("Provider is not available");
+        }
+
+        try {
+            UriComponentsBuilder builder = UriComponentsBuilder
+                .fromUriString(properties.getBaseUrl() + A_SHARE_BASE_PATH + "/kline")
+                .queryParam(KEY_SYMBOL, symbol)
+                .queryParam("timeframe", timeframe)
+                .queryParam(KEY_LIMIT, limit);
+
+            if (startTime != null) {
+                builder.queryParam("startTime", startTime.toEpochMilli());
+            }
+            if (endTime != null) {
+                builder.queryParam("endTime", endTime.toEpochMilli());
+            }
+
+            String url = builder.toUriString();
+
+            LOG.debug("Getting kline data: symbol={}, timeframe={}, limit={}",
+                symbol, timeframe, limit);
+
+            DataServiceResponse<List<Map<String, Object>>> body = webClient
+                .method(getHttpGet())
+                .uri(url)
+                .retrieve()
+                .bodyToMono(getListDataResponseType())
+                .block();
+
+            return AKShareDataMapperSupport.parseKlineResponse(
+                body == null ? null : body.data());
+
+        }
+        catch (WebClientResponseException e) {
+            throw new MarketDataException("Failed to get kline data", e);
+        }
+    }
+
+    @Override
+    public Optional<TickData> getRealTimeTick(String symbol) throws MarketDataException {
+        PriceQuoteDto priceQuote = getPrice(symbol);
+        if (priceQuote == null) {
+            return Optional.empty();
+        }
+
+        TickData tickData = TickData.builder()
+            .symbol(priceQuote.symbol())
+            .market(MarketType.A_SHARE.getCode())
+            .timestamp(priceQuote.timestamp() != null ? priceQuote.timestamp() : Instant.now())
+            .price(priceQuote.price())
+            .change(priceQuote.change())
+            .changePercent(priceQuote.changePercent())
+            .volume(priceQuote.volume())
+            .amount(priceQuote.amount())
+            .bidPrice(priceQuote.bidPrice())
+            .bidVolume(priceQuote.bidVolume())
+            .askPrice(priceQuote.askPrice())
+            .askVolume(priceQuote.askVolume())
+            .open(priceQuote.open())
+            .dayHigh(priceQuote.high())
+            .dayLow(priceQuote.low())
+            .prevClose(priceQuote.prevClose())
+            .build();
+
+        return Optional.of(tickData);
+    }
+
+    @Override
+    public void subscribeRealTime(List<String> symbols, RealTimeDataCallback callback)
+        throws MarketDataException {
+
+        if (!isAvailable()) {
+            throw new MarketDataException("Provider is not available");
+        }
+
+        subscribedSymbols.addAll(symbols);
+        LOG.info("Subscribed to {} symbols for real-time data", symbols.size());
+
+        // 生产环境中应建立 WebSocket 连接到数据服务
+        // 目前仅跟踪订阅
+    }
+
+    @Override
+    public void unsubscribeRealTime(List<String> symbols) {
+        subscribedSymbols.removeAll(symbols);
+        LOG.info("Unsubscribed from {} symbols", symbols.size());
+    }
+
+    @Override
+    public MarketStatus getMarketStatus() {
+        // A股交易时间：9:30-11:30, 13:00-15:00（北京时间）
+        java.time.ZonedDateTime now = java.time.ZonedDateTime.now(
+            java.time.ZoneId.of(TIMEZONE_ASIA_SHANGHAI));
+        int hour = now.getHour();
+        int minute = now.getMinute();
+        java.time.DayOfWeek dayOfWeek = now.getDayOfWeek();
+
+        // 周末
+        if (dayOfWeek == java.time.DayOfWeek.SATURDAY
+            || dayOfWeek == java.time.DayOfWeek.SUNDAY) {
+            return MarketStatus.CLOSED;
+        }
+
+        int timeInMinutes = hour * MINUTES_PER_HOUR + minute;
+        int openMorning = OPEN_MORNING_HOUR * MINUTES_PER_HOUR + OPEN_MORNING_MINUTE;
+        int closeMorning = CLOSE_MORNING_HOUR * MINUTES_PER_HOUR + CLOSE_MORNING_MINUTE;
+        int openAfternoon = OPEN_AFTERNOON_HOUR * MINUTES_PER_HOUR;
+        int closeAfternoon = CLOSE_AFTERNOON_HOUR * MINUTES_PER_HOUR;
+
+        if (timeInMinutes >= openMorning && timeInMinutes <= closeMorning) {
+            return MarketStatus.OPEN;
+        }
+        else if (timeInMinutes > closeMorning && timeInMinutes < openAfternoon) {
+            return MarketStatus.BREAK;
+        }
+        else if (timeInMinutes >= openAfternoon && timeInMinutes <= closeAfternoon) {
+            return MarketStatus.OPEN;
+        }
+        else {
+            return MarketStatus.CLOSED;
+        }
+    }
+
+    @Override
+    public List<SymbolInfo> searchSymbols(String keyword, int limit) {
+        if (!isAvailable()) {
+            LOG.warn(DATA_SERVICE_DISABLED_MESSAGE);
+            return Collections.emptyList();
+        }
+
+        try {
+            String url = UriComponentsBuilder
+                .fromUriString(properties.getBaseUrl() + A_SHARE_BASE_PATH + "/search")
+                .queryParam("keyword", keyword)
+                .queryParam(KEY_LIMIT, limit)
+                .toUriString();
+
+            LOG.debug("Searching symbols: keyword={}, limit={}", keyword, limit);
+
+            DataServiceResponse<List<Map<String, Object>>> body = webClient
+                .method(getHttpGet())
+                .uri(url)
+                .retrieve()
+                .bodyToMono(getListDataResponseType())
+                .block();
+
+            return AKShareDataMapperSupport.parseSymbolInfoResponse(
+                body == null ? null : body.data());
+
+        }
+        catch (WebClientResponseException e) {
+            LOG.error("Failed to search symbols: {}", e.getMessage());
+            return Collections.emptyList();
+        }
+    }
+
+    // 向后兼容的旧方法
+
+    /**
+     * 获取价格。
+     *
+     * @param symbol 股票代码
+     * @return 价格报价
+     */
+    public PriceQuoteDto getPrice(String symbol) {
+        if (!isAvailable()) {
+            throw new ExternalServiceException("DataService",
+                "Data service is not available");
+        }
+
+        try {
+            String url = UriComponentsBuilder
+                .fromUriString(properties.getBaseUrl() + A_SHARE_BASE_PATH
+                    + "/price/{symbol}")
+                .buildAndExpand(symbol)
+                .toUriString();
+
+            LOG.debug("Getting price for symbol: {}", symbol);
+
+            DataServiceResponse<Map<String, Object>> body = webClient
+                .method(getHttpGet())
+                .uri(url)
+                .retrieve()
+                .bodyToMono(getMapDataResponseType())
+                .block();
+
+            return AKShareDataMapperSupport.parsePriceQuoteResponse(
+                body == null ? null : body.data());
+
+        }
+        catch (WebClientResponseException e) {
+            throw new ExternalServiceException("DataService",
+                "Failed to get price for " + symbol, e);
+        }
+    }
+
+    /**
+     * 批量获取价格。
+     *
+     * @param symbols 股票代码列表
+     * @return 价格报价列表
+     */
+    public List<PriceQuoteDto> getBatchPrices(List<String> symbols) {
+        if (!isAvailable()) {
+            LOG.warn(DATA_SERVICE_DISABLED_MESSAGE);
+            return Collections.emptyList();
+        }
+
+        if (symbols == null || symbols.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        try {
+            String url = properties.getBaseUrl() + A_SHARE_BASE_PATH + "/price/batch";
+
+            Map<String, List<String>> request = Map.of("symbols", symbols);
+
+            LOG.debug("Getting batch prices for {} symbols", symbols.size());
+
+            DataServiceResponse<List<Map<String, Object>>> body = webClient
+                .method(getHttpPost())
+                .uri(url)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(request)
+                .retrieve()
+                .bodyToMono(getListDataResponseType())
+                .block();
+
+            if (body == null || body.data() == null) {
+                return Collections.emptyList();
+            }
+
+            return body.data().stream()
+                .map(AKShareDataMapperSupport::mapToPriceQuoteDto)
+                .toList();
+
+        }
+        catch (WebClientResponseException e) {
+            LOG.error("Failed to get batch prices: {}", e.getMessage());
+            return Collections.emptyList();
+        }
+    }
+
+    /**
+     * 获取热门股票。
+     *
+     * @param limit 限制数量
+     * @return 股票信息列表
+     */
+    public List<SymbolInfoDto> getHotSymbols(int limit) {
+        if (!isAvailable()) {
+            LOG.warn(DATA_SERVICE_DISABLED_MESSAGE);
+            return Collections.emptyList();
+        }
+
+        try {
+            String url = UriComponentsBuilder
+                .fromUriString(properties.getBaseUrl() + A_SHARE_BASE_PATH + "/hot")
+                .queryParam(KEY_LIMIT, limit)
+                .toUriString();
+
+            LOG.debug("Getting hot symbols with limit={}", limit);
+
+            DataServiceResponse<List<Map<String, Object>>> body = webClient
+                .method(getHttpGet())
+                .uri(url)
+                .retrieve()
+                .bodyToMono(getListDataResponseType())
+                .block();
+
+            return AKShareDataMapperSupport.parseSymbolListResponse(
+                body == null ? null : body.data());
+
+        }
+        catch (WebClientResponseException e) {
+            LOG.error("Failed to get hot symbols: {}", e.getMessage());
+            return Collections.emptyList();
+        }
+    }
+
+    /**
+     * 获取股票估值。
+     *
+     * @param symbol 股票代码
+     * @return 股票估值
+     */
+    public StockValuationDto getStockValuation(String symbol) {
+        if (!isAvailable()) {
+            throw new ExternalServiceException("DataService",
+                "Data service is not available");
+        }
+
+        try {
+            String url = UriComponentsBuilder
+                .fromUriString(properties.getBaseUrl() + A_SHARE_BASE_PATH
+                    + "/valuation/{symbol}")
+                .buildAndExpand(symbol)
+                .toUriString();
+
+            LOG.debug("Getting valuation for symbol: {}", symbol);
+
+            DataServiceResponse<Map<String, Object>> body = webClient
+                .method(getHttpGet())
+                .uri(url)
+                .retrieve()
+                .bodyToMono(getMapDataResponseType())
+                .block();
+
+            return AKShareDataMapperSupport.parseStockValuationResponse(
+                body == null ? null : body.data());
+
+        }
+        catch (WebClientResponseException e) {
+            throw new ExternalServiceException("DataService",
+                "Failed to get valuation for " + symbol, e);
+        }
+    }
+
+    /**
+     * 获取股票行业信息。
+     *
+     * @param symbol 股票代码
+     * @return 行业信息
+     */
+    public StockIndustryDto getStockIndustry(String symbol) {
+        if (!isAvailable()) {
+            throw new ExternalServiceException("DataService",
+                "Data service is not available");
+        }
+
+        try {
+            String url = UriComponentsBuilder
+                .fromUriString(properties.getBaseUrl() + "/market/stocks/{symbol}/industry")
+                .buildAndExpand(symbol)
+                .toUriString();
+
+            LOG.debug("Getting industry for symbol: {}", symbol);
+
+            DataServiceResponse<Map<String, Object>> body = webClient
+                .method(getHttpGet())
+                .uri(url)
+                .retrieve()
+                .bodyToMono(getMapDataResponseType())
+                .block();
+
+            return AKShareDataMapperSupport.parseStockIndustryResponse(
+                body == null ? null : body.data());
+
+        }
+        catch (WebClientResponseException e) {
+            throw new ExternalServiceException("DataService",
+                "Failed to get industry for " + symbol, e);
+        }
+    }
+
+    /**
+     * 批量获取股票行业信息。
+     *
+     * @param symbols 股票代码列表
+     * @return 代码到行业信息的映射
+     */
+    public Map<String, StockIndustryDto> getStockIndustries(List<String> symbols) {
+        if (!isAvailable()) {
+            LOG.warn(DATA_SERVICE_DISABLED_MESSAGE);
+            return Collections.emptyMap();
+        }
+
+        if (symbols == null || symbols.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        try {
+            String url = properties.getBaseUrl() + "/market/stocks/industries";
+
+            Map<String, List<String>> request = Map.of("symbols", symbols);
+
+            LOG.debug("Getting batch industries for {} symbols", symbols.size());
+
+            // 使用LIST_DATA_RESPONSE_TYPE批量获取，然后通过symbol字段映射
+            DataServiceResponse<List<Map<String, Object>>> body = webClient
+                .method(getHttpPost())
+                .uri(url)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(request)
+                .retrieve()
+                .bodyToMono(getListDataResponseType())
+                .block();
+
+            if (body == null || body.data() == null) {
+                return Collections.emptyMap();
+            }
+
+            return body.data().stream()
+                .map(AKShareDataMapperSupport::parseStockIndustryResponse)
+                .filter(Objects::nonNull)
+                .filter(dto -> dto.symbol() != null)
+                .collect(Collectors.toMap(
+                    StockIndustryDto::symbol,
+                    dto -> dto,
+                    (existing, replacement) -> replacement,
+                    java.util.LinkedHashMap::new
+                ));
+
+        }
+        catch (WebClientResponseException e) {
+            LOG.error("Failed to get batch industries: {}", e.getMessage());
+            return Collections.emptyMap();
+        }
+    }
+
+    @NonNull
+    private static HttpMethod getHttpGet() {
+        return Objects.requireNonNull(HttpMethod.GET, HTTP_GET_MESSAGE);
+    }
+
+    @NonNull
+    private static HttpMethod getHttpPost() {
+        return Objects.requireNonNull(HttpMethod.POST, HTTP_POST_MESSAGE);
+    }
+
+    @NonNull
+    private static ParameterizedTypeReference<DataServiceResponse<List<Map<String, Object>>>>
+        getListDataResponseType() {
+        return Objects.requireNonNull(LIST_DATA_RESPONSE_TYPE, RESPONSE_TYPE_MESSAGE);
+    }
+
+    @NonNull
+    private static ParameterizedTypeReference<DataServiceResponse<Map<String, Object>>>
+        getMapDataResponseType() {
+        return Objects.requireNonNull(MAP_DATA_RESPONSE_TYPE, RESPONSE_TYPE_MESSAGE);
+    }
+}

--- a/koduck-backend/koduck-market/koduck-market-impl/src/main/java/com/koduck/market/provider/AbstractDataServiceMarketProvider.java
+++ b/koduck-backend/koduck-market/koduck-market-impl/src/main/java/com/koduck/market/provider/AbstractDataServiceMarketProvider.java
@@ -1,0 +1,405 @@
+package com.koduck.market.provider;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.slf4j.Logger;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpMethod;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import com.koduck.infrastructure.config.properties.DataServiceProperties;
+import com.koduck.market.model.KlineData;
+import com.koduck.market.model.TickData;
+import com.koduck.market.provider.MarketDataProvider;
+import com.koduck.market.util.MarketFieldParser;
+
+/**
+ * Abstract base class for market providers backed by the python data-service.
+ * <p>
+ * This class implements common retrieval logic for kline, real-time tick, search
+ * and subscription operations. Subclasses provide provider-specific URL paths,
+ * symbol normalization and conversion from response payloads to domain models.
+ * </p>
+ *
+ * <p>
+ * It includes fallback behavior to generate mock data when the data service is
+ * unavailable or returns empty payloads.
+ * </p>
+ *
+ * @author GitHub Copilot
+ */
+public abstract class AbstractDataServiceMarketProvider implements MarketDataProvider {
+
+    /** Response type for list of maps. */
+    private static final ParameterizedTypeReference<List<Map<String, Object>>> LIST_MAP_RESPONSE_TYPE =
+        new ParameterizedTypeReference<List<Map<String, Object>>>() {
+        };
+
+    /** Response type for single map. */
+    private static final ParameterizedTypeReference<Map<String, Object>> MAP_RESPONSE_TYPE =
+        new ParameterizedTypeReference<Map<String, Object>>() {
+        };
+
+    /** Health score when enabled. */
+    private static final int HEALTH_SCORE_ENABLED = 100;
+
+    /** Health score when disabled. */
+    private static final int HEALTH_SCORE_DISABLED = 0;
+
+    /** Configuration properties. */
+    private final DataServiceProperties properties;
+
+    /** WebClient for HTTP calls. */
+    private final WebClient webClient;
+
+    /** Set of subscribed symbols. */
+    private final Set<String> subscribedSymbols = ConcurrentHashMap.newKeySet();
+
+    /**
+     * Constructs a new AbstractDataServiceMarketProvider.
+     *
+     * @param properties the data service properties
+     * @param dataServiceWebClient the WebClient
+     */
+    protected AbstractDataServiceMarketProvider(
+            DataServiceProperties properties,
+            WebClient dataServiceWebClient) {
+        this.properties = properties;
+        this.webClient = dataServiceWebClient;
+    }
+
+    /**
+     * Returns whether the market provider is enabled via configuration.
+     *
+     * @return true if provider is enabled, false otherwise
+     */
+    @Override
+    public boolean isAvailable() {
+        return properties.isEnabled();
+    }
+
+    /**
+     * Returns a provider health score for monitoring and priority decisions.
+     *
+     * @return 100 when enabled, 0 when disabled
+     */
+    @Override
+    public int getHealthScore() {
+        return properties.isEnabled() ? HEALTH_SCORE_ENABLED : HEALTH_SCORE_DISABLED;
+    }
+
+    /**
+     * Retrieves kline (candlestick) data for a symbol from the data service.
+     * <p>
+     * If the service is unavailable or the response is empty, fallback mock data
+     * is returned.
+     * </p>
+     *
+     * @param symbol stock symbol to query
+     * @param timeframe interval (e.g., 1m, 1d)
+     * @param limit maximum number of points
+     * @param startTime optional start timestamp for range filtering
+     * @param endTime optional end timestamp for range filtering
+     * @return list of KlineData objects
+     * @throws MarketDataException on invalid input or retrievable errors
+     */
+    @Override
+    public List<KlineData> getKlineData(String symbol, String timeframe, int limit,
+                                        Instant startTime, Instant endTime)
+            throws MarketDataException {
+        if (!isAvailable()) {
+            logger().debug("Data service not available, using mock data for {} kline",
+                getLogMarketName());
+            return generateMockKlineData(symbol, timeframe, limit, startTime, endTime);
+        }
+
+        String normalizedSymbol = normalizeSymbol(symbol);
+        try {
+            UriComponentsBuilder builder = UriComponentsBuilder
+                    .fromUriString(properties.getBaseUrl()
+                        + getDataServiceBasePath() + "/kline/{symbol}")
+                    .queryParam("timeframe", timeframe)
+                    .queryParam("limit", limit);
+
+            if (startTime != null) {
+                builder.queryParam("startTime", startTime.toEpochMilli());
+            }
+            if (endTime != null) {
+                builder.queryParam("endTime", endTime.toEpochMilli());
+            }
+
+            String url = builder.buildAndExpand(normalizedSymbol).toUriString();
+            logger().debug("Fetching {} kline from data service: symbol={}, timeframe={}",
+                    getLogMarketName(), normalizedSymbol, timeframe);
+
+            List<Map<String, Object>> data = webClient.method(Objects.requireNonNull(HttpMethod.GET))
+                    .uri(url)
+                    .retrieve()
+                    .bodyToMono(LIST_MAP_RESPONSE_TYPE)
+                    .block();
+
+            if (data == null || data.isEmpty()) {
+                return generateMockKlineData(symbol, timeframe, limit, startTime, endTime);
+            }
+
+            return convertToKlineData(data, normalizedSymbol, timeframe);
+        }
+        catch (WebClientResponseException exception) {
+            logger().error("Failed to fetch {} kline from data service: {}",
+                    getLogMarketName(), exception.getMessage());
+            return generateMockKlineData(symbol, timeframe, limit, startTime, endTime);
+        }
+    }
+
+    /**
+     * Retrieves real-time tick data for a symbol via data service.
+     *
+     * @param symbol stock symbol to query
+     * @return optional tick data (absent when no data is available or service error occurs)
+     * @throws MarketDataException on invalid input or retrievable errors
+     */
+    @Override
+    public Optional<TickData> getRealTimeTick(String symbol) throws MarketDataException {
+        if (!isAvailable()) {
+            logger().debug("Data service not available, using mock data for {} tick",
+                getLogMarketName());
+            return generateMockTickData(symbol);
+        }
+
+        String normalizedSymbol = normalizeSymbol(symbol);
+        try {
+            String url = UriComponentsBuilder
+                    .fromUriString(properties.getBaseUrl()
+                        + getDataServiceBasePath() + "/price/{symbol}")
+                    .buildAndExpand(normalizedSymbol)
+                    .toUriString();
+
+            logger().debug("Fetching {} price from data service: symbol={}",
+                getLogMarketName(), normalizedSymbol);
+
+            Map<String, Object> data = webClient.method(Objects.requireNonNull(HttpMethod.GET))
+                    .uri(url)
+                    .retrieve()
+                    .bodyToMono(MAP_RESPONSE_TYPE)
+                    .block();
+
+            if (data == null || data.isEmpty()) {
+                return generateMockTickData(symbol);
+            }
+
+            return Optional.of(convertToTickData(data, normalizedSymbol));
+        }
+        catch (WebClientResponseException exception) {
+            logger().error("Failed to fetch {} price from data service: {}",
+                    getLogMarketName(), exception.getMessage());
+            return generateMockTickData(symbol);
+        }
+    }
+
+    /**
+     * Subscribes to real-time data updates for the given symbols.
+     *
+     * @param symbols list of symbols to subscribe
+     * @param callback callback invoked for each tick update
+     * @throws MarketDataException when provider is unavailable
+     */
+    @Override
+    public void subscribeRealTime(List<String> symbols, RealTimeDataCallback callback)
+            throws MarketDataException {
+        if (!isAvailable()) {
+            throw new MarketDataException("Provider is not available");
+        }
+
+        if (symbols == null || symbols.isEmpty()) {
+            return;
+        }
+
+        symbols.forEach(symbol -> subscribedSymbols.add(normalizeSymbol(symbol)));
+        logger().info("Subscribed to {} {} for real-time data",
+            symbols.size(), getSubscriptionLabel());
+    }
+
+    /**
+     * Unsubscribes from real-time data updates for the given symbols.
+     *
+     * @param symbols list of symbols to unsubscribe
+     */
+    @Override
+    public void unsubscribeRealTime(List<String> symbols) {
+        if (symbols == null || symbols.isEmpty()) {
+            return;
+        }
+
+        symbols.forEach(symbol -> subscribedSymbols.remove(normalizeSymbol(symbol)));
+        logger().info("Unsubscribed from {} {}", symbols.size(), getSubscriptionLabel());
+    }
+
+    /**
+     * Searches symbols using the data service endpoint.
+     *
+     * @param keyword search keyword
+     * @param limit maximum number of results
+     * @return list of symbol insights
+     */
+    @Override
+    public List<SymbolInfo> searchSymbols(String keyword, int limit) {
+        if (!isAvailable()) {
+            return generateMockSearchResults(keyword, limit);
+        }
+
+        try {
+            String url = UriComponentsBuilder
+                    .fromUriString(properties.getBaseUrl()
+                        + getDataServiceBasePath() + "/search")
+                    .queryParam("keyword", keyword)
+                    .queryParam("limit", limit)
+                    .toUriString();
+
+            List<Map<String, Object>> data = webClient.method(Objects.requireNonNull(HttpMethod.GET))
+                    .uri(url)
+                    .retrieve()
+                    .bodyToMono(LIST_MAP_RESPONSE_TYPE)
+                    .block();
+
+            if (data == null || data.isEmpty()) {
+                return generateMockSearchResults(keyword, limit);
+            }
+
+            return data.stream()
+                    .map(this::convertToSymbolInfo)
+                    .limit(limit)
+                    .toList();
+        }
+        catch (WebClientResponseException exception) {
+            logger().error("Failed to search {} symbols: {}",
+                getLogMarketName(), exception.getMessage());
+            return generateMockSearchResults(keyword, limit);
+        }
+    }
+
+    /**
+     * Gets a string value from raw market response map safely.
+     *
+     * @param data raw response map
+     * @param key the key to read
+     * @return parsed string, or null when missing/unparseable
+     */
+    protected final String getString(Map<String, Object> data, String key) {
+        return MarketFieldParser.toStringValue(data, key);
+    }
+
+    /**
+     * Gets a long value from raw market response map safely.
+     *
+     * @param data raw response map
+     * @param key the key to read
+     * @return parsed long, or null when missing/unparseable
+     */
+    protected final Long getLong(Map<String, Object> data, String key) {
+        return MarketFieldParser.toLong(data, key);
+    }
+
+    /**
+     * Provides a typed logger for subclasses.
+     *
+     * @return logger instance
+     */
+    protected abstract Logger logger();
+
+    /**
+     * Gets data-service base path specific to the provider (e.g. /hk, /us).
+     *
+     * @return provider-specific data-service base path
+     */
+    protected abstract String getDataServiceBasePath();
+
+    /**
+     * Gets the provider friendly name for logs.
+     *
+     * @return provider log name
+     */
+    protected abstract String getLogMarketName();
+
+    /**
+     * Gets the subscription label used in log events.
+     *
+     * @return subscription label string
+     */
+    protected abstract String getSubscriptionLabel();
+
+    /**
+     * Normalizes a symbol into provider-specific format.
+     *
+     * @param symbol raw symbol input
+     * @return normalized symbol
+     */
+    protected abstract String normalizeSymbol(String symbol);
+
+    /**
+     * Generates mock kline data when the real data service is unavailable.
+     *
+     * @param symbol target symbol
+     * @param timeframe interval (e.g., 1m, 1d)
+     * @param limit number of points
+     * @param startTime optional start time
+     * @param endTime optional end time
+     * @return list of kline data points
+     */
+    protected abstract List<KlineData> generateMockKlineData(String symbol, String timeframe,
+                                                             int limit, Instant startTime,
+                                                             Instant endTime);
+
+    /**
+     * Generates mock tick data when the real data service is unavailable.
+     *
+     * @param symbol target symbol
+     * @return optional tick data
+     */
+    protected abstract Optional<TickData> generateMockTickData(String symbol);
+
+    /**
+     * Generates mock symbol search results when the data service is unavailable.
+     *
+     * @param keyword search keyword
+     * @param limit maximum number of results
+     * @return list of symbol info
+     */
+    protected abstract List<SymbolInfo> generateMockSearchResults(String keyword, int limit);
+
+    /**
+     * Converts a raw response payload to domain kline data.
+     *
+     * @param data raw response data list
+     * @param symbol normalized symbol
+     * @param timeframe interval
+     * @return list of KlineData
+     */
+    protected abstract List<KlineData> convertToKlineData(List<Map<String, Object>> data,
+                                                          String symbol,
+                                                          String timeframe);
+
+    /**
+     * Converts a raw response payload to domain tick data.
+     *
+     * @param data raw response map
+     * @param symbol normalized symbol
+     * @return TickData instance
+     */
+    protected abstract TickData convertToTickData(Map<String, Object> data, String symbol);
+
+    /**
+     * Converts a raw response payload to a symbol search info object.
+     *
+     * @param data raw response map
+     * @return SymbolInfo object
+     */
+    protected abstract SymbolInfo convertToSymbolInfo(Map<String, Object> data);
+}

--- a/koduck-backend/koduck-market/koduck-market-impl/src/main/java/com/koduck/market/provider/ForexProvider.java
+++ b/koduck-backend/koduck-market/koduck-market-impl/src/main/java/com/koduck/market/provider/ForexProvider.java
@@ -1,0 +1,483 @@
+package com.koduck.market.provider;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.DayOfWeek;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import com.koduck.infrastructure.config.properties.DataServiceProperties;
+import com.koduck.market.MarketType;
+import com.koduck.market.model.KlineData;
+import com.koduck.market.model.TickData;
+import com.koduck.market.util.DataConverter;
+import com.koduck.market.service.support.MarketDataMapReader;
+import com.koduck.market.service.support.MarketTimeframeParser;
+
+/**
+ * Forex market data provider.
+ *
+ * <p>Data-service based implementation with unified retrieval and error handling
+ * inherited from {@link AbstractDataServiceMarketProvider}.</p>
+ *
+ * @author Koduck Team
+ */
+@Component
+public class ForexProvider extends AbstractDataServiceMarketProvider {
+
+    /** Logger instance for this class. */
+    private static final Logger LOG = LoggerFactory.getLogger(ForexProvider.class);
+
+    /** New York timezone for market hours calculation. */
+    private static final ZoneId NEW_YORK_ZONE = ZoneId.of("America/New_York");
+
+    /** Base path for forex data service endpoints. */
+    private static final String FOREX_BASE_PATH = "/forex";
+
+    /** Provider name identifier. */
+    private static final String PROVIDER_NAME = "akshare-forex";
+
+    /** Forex market opening hour (Sunday 17:00 ET). */
+    private static final int FOREX_MARKET_OPEN_HOUR = 17;
+
+    /** Forex market closing hour (Friday 17:00 ET). */
+    private static final int FOREX_MARKET_CLOSE_HOUR = 17;
+
+    /** Standard number of decimal digits for pips (4 digits). */
+    private static final int PIP_DIGITS_STANDARD = 4;
+
+    /** Number of decimal digits for gold pips (2 digits). */
+    private static final int PIP_DIGITS_GOLD = 2;
+
+    /** Number of decimal digits for JPY and silver pips (3 digits). */
+    private static final int PIP_DIGITS_JPY_SILVER = 3;
+
+    /** Standard forex symbol length (6 characters). */
+    private static final int SYMBOL_LENGTH_STANDARD = 6;
+
+    /** Length of symbol prefix (3 characters). */
+    private static final int SYMBOL_PREFIX_LENGTH = 3;
+
+    /** Volatility for precious metals (0.8%). */
+    private static final double VOLATILITY_PRECIOUS_METALS = 0.008;
+
+    /** Volatility for forex pairs (0.15%). */
+    private static final double VOLATILITY_FOREX_PAIRS = 0.0015;
+
+    /** Volatility for tick data of precious metals (0.5%). */
+    private static final double VOLATILITY_TICK_PRECIOUS_METALS = 0.005;
+
+    /** Volatility for tick data of forex pairs (0.1%). */
+    private static final double VOLATILITY_TICK_FOREX = 0.001;
+
+    /** Multiplier for price change calculation (0.5 for centering random value). */
+    private static final double PRICE_CHANGE_MULTIPLIER = 0.5;
+
+    /** Multiplier for day high price calculation (101%). */
+    private static final double DAY_HIGH_MULTIPLIER = 1.01;
+
+    /** Multiplier for day low price calculation (99%). */
+    private static final double DAY_LOW_MULTIPLIER = 0.99;
+
+    /** Minimum volume for kline data generation. */
+    private static final long VOLUME_MIN = 10_000L;
+
+    /** Maximum exclusive volume for kline data generation. */
+    private static final long VOLUME_MAX_EXCLUSIVE = 1_000_000L;
+
+    /** Minimum volume for tick data generation. */
+    private static final long TICK_VOLUME_MIN = 100_000L;
+
+    /** Maximum exclusive volume for tick data generation. */
+    private static final long TICK_VOLUME_MAX_EXCLUSIVE = 5_000_000L;
+
+    /** Minimum volume for order book data generation. */
+    private static final long ORDER_BOOK_VOLUME_MIN = 100L;
+
+    /** Maximum exclusive volume for order book data generation. */
+    private static final long ORDER_BOOK_VOLUME_MAX_EXCLUSIVE = 10_000L;
+
+    /** Multiplier for bid/ask spread calculation. */
+    private static final int BID_ASK_SPREAD_MULTIPLIER = 2;
+
+    /** Decimal scale for division operations. */
+    private static final int DIVIDE_SCALE = 4;
+
+    /** Multiplier for percentage calculations (100%). */
+    private static final double PERCENT_MULTIPLIER = 100.0;
+
+    /** XAU (Gold) symbol prefix. */
+    private static final String XAU_PREFIX = "XAU";
+
+    /** XAG (Silver) symbol prefix. */
+    private static final String XAG_PREFIX = "XAG";
+
+    /** JPY (Japanese Yen) symbol suffix. */
+    private static final String JPY_SUFFIX = "JPY";
+
+    /** Symbol separator: forward slash (/). */
+    private static final String SYMBOL_SEPARATOR_SLASH = "/";
+
+    /** Symbol separator: dash (-). */
+    private static final String SYMBOL_SEPARATOR_DASH = "-";
+
+    /** Symbol separator: underscore (_). */
+    private static final String SYMBOL_SEPARATOR_UNDERSCORE = "_";
+
+    /** Exchange name for forex. */
+    private static final String EXCHANGE_FOREX = "FOREX";
+
+    /** Symbol type identifier for forex. */
+    private static final String SYMBOL_TYPE_FOREX = "forex";
+
+    /** Initial capacity for maps (14 forex pairs). */
+    private static final int INITIAL_CAPACITY = 14;
+
+    /** Base for pip size calculation (10). */
+    private static final int PIP_SIZE_BASE = 10;
+
+    /** Base rates for major forex pairs (fallback mock data). */
+    private final Map<String, BigDecimal> baseRates = new LinkedHashMap<>(INITIAL_CAPACITY);
+
+    /**
+     * Constructs a new ForexProvider.
+     *
+     * @param properties the data service properties
+     * @param webClient the WebClient for data service calls
+     */
+    public ForexProvider(DataServiceProperties properties,
+        @Qualifier("dataServiceWebClient") WebClient webClient) {
+        super(properties, webClient);
+        initBaseRates();
+    }
+
+    @Override
+    public String getProviderName() {
+        return PROVIDER_NAME;
+    }
+
+    @Override
+    public MarketType getMarketType() {
+        return MarketType.FOREX;
+    }
+
+    @Override
+    public MarketStatus getMarketStatus() {
+        ZonedDateTime now = ZonedDateTime.now(NEW_YORK_ZONE);
+        DayOfWeek dayOfWeek = now.getDayOfWeek();
+        LocalTime time = now.toLocalTime();
+
+        // Forex trades 24 hours from Sunday 17:00 ET to Friday 17:00 ET
+        boolean isWeekend = dayOfWeek == DayOfWeek.SATURDAY
+            || (dayOfWeek == DayOfWeek.SUNDAY
+            && time.isBefore(LocalTime.of(FOREX_MARKET_OPEN_HOUR, 0)))
+            || (dayOfWeek == DayOfWeek.FRIDAY
+            && time.isAfter(LocalTime.of(FOREX_MARKET_CLOSE_HOUR, 0)));
+
+        if (isWeekend) {
+            return MarketStatus.CLOSED;
+        }
+
+        return MarketStatus.OPEN;
+    }
+
+    @Override
+    protected Logger logger() {
+        return LOG;
+    }
+
+    @Override
+    protected String getDataServiceBasePath() {
+        return FOREX_BASE_PATH;
+    }
+
+    @Override
+    protected String getLogMarketName() {
+        return "forex";
+    }
+
+    @Override
+    protected String getSubscriptionLabel() {
+        return "forex pairs";
+    }
+
+    @Override
+    protected String normalizeSymbol(String symbol) {
+        if (symbol == null || symbol.trim().isEmpty()) {
+            return "";
+        }
+
+        String normalized = symbol.trim().toUpperCase(Locale.ROOT);
+
+        // Handle different formats: EURUSD, EUR-USD, EUR_USD -> EUR/USD
+        normalized = normalized.replace(SYMBOL_SEPARATOR_DASH, SYMBOL_SEPARATOR_SLASH)
+            .replace(SYMBOL_SEPARATOR_UNDERSCORE, SYMBOL_SEPARATOR_SLASH);
+
+        // If no separator and length is 6, insert / in the middle (e.g., EURUSD -> EUR/USD)
+        if (!normalized.contains(SYMBOL_SEPARATOR_SLASH)
+            && normalized.length() == SYMBOL_LENGTH_STANDARD
+            && normalized.matches("[A-Z]{6}")) {
+            normalized = normalized.substring(0, SYMBOL_PREFIX_LENGTH)
+                + SYMBOL_SEPARATOR_SLASH
+                + normalized.substring(SYMBOL_PREFIX_LENGTH);
+        }
+
+        // Handle XAUUSD/XAGUSD format
+        if (!normalized.contains(SYMBOL_SEPARATOR_SLASH)
+            && normalized.length() == SYMBOL_LENGTH_STANDARD
+            && (normalized.startsWith(XAU_PREFIX) || normalized.startsWith(XAG_PREFIX))) {
+            normalized = normalized.substring(0, SYMBOL_PREFIX_LENGTH)
+                + SYMBOL_SEPARATOR_SLASH
+                + normalized.substring(SYMBOL_PREFIX_LENGTH);
+        }
+
+        return normalized;
+    }
+
+    @Override
+    protected List<KlineData> generateMockKlineData(String symbol, String timeframe, int limit,
+        Instant startTime, Instant endTime) {
+        List<KlineData> klines = new ArrayList<>();
+        String normalizedSymbol = normalizeSymbol(symbol);
+        BigDecimal baseRate = baseRates.getOrDefault(normalizedSymbol, BigDecimal.ONE);
+
+        Instant currentTime = endTime != null ? endTime : Instant.now();
+        if (endTime == null && startTime != null) {
+            currentTime = startTime;
+        }
+        Duration interval = MarketTimeframeParser.parseWithFourHour(timeframe);
+
+        // Precious metals are more volatile than major forex pairs
+        double volatility = normalizedSymbol.startsWith(XAU_PREFIX)
+            || normalizedSymbol.startsWith(XAG_PREFIX)
+            ? VOLATILITY_PRECIOUS_METALS : VOLATILITY_FOREX_PAIRS;
+
+        BigDecimal currentRate = baseRate;
+        for (int i = 0; i < limit; i++) {
+            double changePercent = (ThreadLocalRandom.current().nextDouble() - PRICE_CHANGE_MULTIPLIER)
+                * volatility * 2;
+            BigDecimal change = currentRate.multiply(BigDecimal.valueOf(changePercent));
+            BigDecimal close = currentRate.add(change);
+
+            BigDecimal high = close.multiply(BigDecimal.valueOf(1
+                + ThreadLocalRandom.current().nextDouble() * volatility));
+            BigDecimal low = close.multiply(BigDecimal.valueOf(1
+                - ThreadLocalRandom.current().nextDouble() * volatility));
+            BigDecimal open = currentRate;
+
+            long volume = ThreadLocalRandom.current().nextLong(VOLUME_MIN, VOLUME_MAX_EXCLUSIVE);
+
+            klines.add(KlineData.builder()
+                .symbol(normalizedSymbol)
+                .market(MarketType.FOREX.getCode())
+                .timestamp(currentTime)
+                .open(open)
+                .high(high)
+                .low(low)
+                .close(close)
+                .volume(volume)
+                .amount(close.multiply(BigDecimal.valueOf(volume)))
+                .timeframe(timeframe)
+                .build());
+
+            currentRate = close;
+            currentTime = currentTime.minus(interval);
+        }
+
+        Collections.reverse(klines);
+        return klines;
+    }
+
+    @Override
+    protected Optional<TickData> generateMockTickData(String symbol) {
+        String normalizedSymbol = normalizeSymbol(symbol);
+        BigDecimal baseRate = baseRates.getOrDefault(normalizedSymbol, BigDecimal.ONE);
+
+        double volatility = normalizedSymbol.startsWith(XAU_PREFIX)
+            || normalizedSymbol.startsWith(XAG_PREFIX)
+            ? VOLATILITY_TICK_PRECIOUS_METALS : VOLATILITY_TICK_FOREX;
+
+        double changePercent = (ThreadLocalRandom.current().nextDouble() - PRICE_CHANGE_MULTIPLIER)
+            * volatility * 2;
+        BigDecimal price = baseRate.multiply(BigDecimal.valueOf(1 + changePercent));
+        BigDecimal change = price.subtract(baseRate);
+        BigDecimal changePercentValue = change.divide(baseRate, DIVIDE_SCALE, RoundingMode.HALF_UP)
+            .multiply(BigDecimal.valueOf(PERCENT_MULTIPLIER));
+
+        long volume = ThreadLocalRandom.current().nextLong(TICK_VOLUME_MIN,
+            TICK_VOLUME_MAX_EXCLUSIVE);
+
+        int pipDigits = PIP_DIGITS_STANDARD;
+        if (normalizedSymbol.startsWith(XAU_PREFIX)) {
+            pipDigits = PIP_DIGITS_GOLD;
+        }
+        else if (normalizedSymbol.contains(JPY_SUFFIX)
+            || normalizedSymbol.startsWith(XAG_PREFIX)) {
+            pipDigits = PIP_DIGITS_JPY_SILVER;
+        }
+        BigDecimal pipSize = BigDecimal.valueOf(Math.pow(PIP_SIZE_BASE, -pipDigits));
+
+        TickData tickData = TickData.builder()
+            .symbol(normalizedSymbol)
+            .market(MarketType.FOREX.getCode())
+            .timestamp(Instant.now())
+            .price(price)
+            .change(change)
+            .changePercent(changePercentValue)
+            .volume(volume)
+            .amount(price.multiply(BigDecimal.valueOf(volume)))
+            .bidPrice(price.subtract(pipSize.multiply(
+                BigDecimal.valueOf(BID_ASK_SPREAD_MULTIPLIER))))
+            .bidVolume(ThreadLocalRandom.current().nextLong(ORDER_BOOK_VOLUME_MIN,
+                ORDER_BOOK_VOLUME_MAX_EXCLUSIVE))
+            .askPrice(price.add(pipSize.multiply(
+                BigDecimal.valueOf(BID_ASK_SPREAD_MULTIPLIER))))
+            .askVolume(ThreadLocalRandom.current().nextLong(ORDER_BOOK_VOLUME_MIN,
+                ORDER_BOOK_VOLUME_MAX_EXCLUSIVE))
+            .dayHigh(price.multiply(BigDecimal.valueOf(DAY_HIGH_MULTIPLIER)))
+            .dayLow(price.multiply(BigDecimal.valueOf(DAY_LOW_MULTIPLIER)))
+            .open(baseRate)
+            .prevClose(baseRate)
+            .build();
+
+        return Optional.of(tickData);
+    }
+
+    @Override
+    protected List<SymbolInfo> generateMockSearchResults(String keyword, int limit) {
+        List<SymbolInfo> results = new ArrayList<>();
+        String upperKeyword = keyword.toUpperCase(Locale.ROOT);
+
+        Map<String, String> forexPairs = new LinkedHashMap<>(INITIAL_CAPACITY);
+        forexPairs.put("EUR/USD", "Euro / US Dollar");
+        forexPairs.put("USD/JPY", "US Dollar / Japanese Yen");
+        forexPairs.put("GBP/USD", "British Pound / US Dollar");
+        forexPairs.put("USD/CHF", "US Dollar / Swiss Franc");
+        forexPairs.put("AUD/USD", "Australian Dollar / US Dollar");
+        forexPairs.put("USD/CAD", "US Dollar / Canadian Dollar");
+        forexPairs.put("EUR/GBP", "Euro / British Pound");
+        forexPairs.put("EUR/JPY", "Euro / Japanese Yen");
+        forexPairs.put("GBP/JPY", "British Pound / Japanese Yen");
+        forexPairs.put("USD/CNH", "US Dollar / Chinese Yuan (Offshore)");
+        forexPairs.put("USD/SGD", "US Dollar / Singapore Dollar");
+        forexPairs.put("USD/HKD", "US Dollar / Hong Kong Dollar");
+        forexPairs.put("XAU/USD", "Gold / US Dollar");
+        forexPairs.put("XAG/USD", "Silver / US Dollar");
+
+        forexPairs.entrySet().stream()
+            .filter(e -> e.getKey().contains(upperKeyword)
+                || e.getValue().toUpperCase(Locale.ROOT).contains(upperKeyword))
+            .limit(limit)
+            .forEach(e -> results.add(new SymbolInfo(e.getKey(), e.getValue(),
+                MarketType.FOREX.getCode(), EXCHANGE_FOREX, SYMBOL_TYPE_FOREX)));
+
+        return results;
+    }
+
+    @Override
+    protected List<KlineData> convertToKlineData(List<Map<String, Object>> data, String symbol,
+        String timeframe) {
+        List<KlineData> klines = new ArrayList<>();
+
+        for (Map<String, Object> item : data) {
+            klines.add(KlineData.builder()
+                .symbol(symbol)
+                .market(MarketType.FOREX.getCode())
+                .timestamp(DataConverter.toInstantFromMillis(
+                    MarketDataMapReader.getLong(item, "timestamp")))
+                .open(DataConverter.toBigDecimal(
+                    MarketDataMapReader.getString(item, "open")))
+                .high(DataConverter.toBigDecimal(
+                    MarketDataMapReader.getString(item, "high")))
+                .low(DataConverter.toBigDecimal(
+                    MarketDataMapReader.getString(item, "low")))
+                .close(DataConverter.toBigDecimal(
+                    MarketDataMapReader.getString(item, "close")))
+                .volume(MarketDataMapReader.getLong(item, "volume"))
+                .amount(DataConverter.toBigDecimal(
+                    MarketDataMapReader.getString(item, "amount")))
+                .timeframe(timeframe)
+                .build());
+        }
+
+        return klines;
+    }
+
+    @Override
+    protected TickData convertToTickData(Map<String, Object> data, String symbol) {
+        return TickData.builder()
+            .symbol(symbol)
+            .market(MarketType.FOREX.getCode())
+            .timestamp(DataConverter.toInstantFromMillis(
+                MarketDataMapReader.getLong(data, "timestamp")))
+            .price(DataConverter.toBigDecimal(
+                MarketDataMapReader.getString(data, "price")))
+            .change(DataConverter.toBigDecimal(
+                MarketDataMapReader.getString(data, "change")))
+            .changePercent(DataConverter.toBigDecimal(
+                MarketDataMapReader.getString(data, "changePercent")))
+            .volume(MarketDataMapReader.getLong(data, "volume"))
+            .amount(DataConverter.toBigDecimal(
+                MarketDataMapReader.getString(data, "amount")))
+            .bidPrice(DataConverter.toBigDecimal(
+                MarketDataMapReader.getString(data, "bidPrice")))
+            .bidVolume(MarketDataMapReader.getLong(data, "bidVolume"))
+            .askPrice(DataConverter.toBigDecimal(
+                MarketDataMapReader.getString(data, "askPrice")))
+            .askVolume(MarketDataMapReader.getLong(data, "askVolume"))
+            .dayHigh(DataConverter.toBigDecimal(
+                MarketDataMapReader.getString(data, "high")))
+            .dayLow(DataConverter.toBigDecimal(
+                MarketDataMapReader.getString(data, "low")))
+            .open(DataConverter.toBigDecimal(
+                MarketDataMapReader.getString(data, "open")))
+            .prevClose(DataConverter.toBigDecimal(
+                MarketDataMapReader.getString(data, "prevClose")))
+            .build();
+    }
+
+    @Override
+    protected SymbolInfo convertToSymbolInfo(Map<String, Object> data) {
+        return new SymbolInfo(
+            MarketDataMapReader.getString(data, "symbol"),
+            MarketDataMapReader.getString(data, "name"),
+            MarketType.FOREX.getCode(),
+            EXCHANGE_FOREX,
+            SYMBOL_TYPE_FOREX
+        );
+    }
+
+    private void initBaseRates() {
+        baseRates.put("EUR/USD", new BigDecimal("1.0850"));
+        baseRates.put("USD/JPY", new BigDecimal("149.50"));
+        baseRates.put("GBP/USD", new BigDecimal("1.2650"));
+        baseRates.put("USD/CHF", new BigDecimal("0.8820"));
+        baseRates.put("AUD/USD", new BigDecimal("0.6550"));
+        baseRates.put("USD/CAD", new BigDecimal("1.3520"));
+        baseRates.put("EUR/GBP", new BigDecimal("0.8570"));
+        baseRates.put("EUR/JPY", new BigDecimal("162.20"));
+        baseRates.put("GBP/JPY", new BigDecimal("189.20"));
+        baseRates.put("USD/CNH", new BigDecimal("7.2150"));
+        baseRates.put("USD/SGD", new BigDecimal("1.3450"));
+        baseRates.put("USD/HKD", new BigDecimal("7.8230"));
+        baseRates.put("XAU/USD", new BigDecimal("2150.00"));
+        baseRates.put("XAG/USD", new BigDecimal("24.50"));
+    }
+}

--- a/koduck-backend/koduck-market/koduck-market-impl/src/main/java/com/koduck/market/provider/FuturesProvider.java
+++ b/koduck-backend/koduck-market/koduck-market-impl/src/main/java/com/koduck/market/provider/FuturesProvider.java
@@ -1,0 +1,222 @@
+package com.koduck.market.provider;
+
+import java.math.BigDecimal;
+import java.time.DayOfWeek;
+import java.time.Instant;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import com.koduck.common.constants.DateTimePatternConstants;
+import com.koduck.infrastructure.config.properties.DataServiceProperties;
+import com.koduck.market.MarketType;
+import com.koduck.market.model.KlineData;
+import com.koduck.market.model.TickData;
+import com.koduck.market.util.DataConverter;
+import com.koduck.market.service.support.FuturesMockDataSupport;
+import com.koduck.market.service.support.MarketDataMapReader;
+
+/**
+ * Futures market data provider.
+ *
+ * <p>Data-service based implementation with unified retrieval and error handling inherited from
+ * {@link AbstractDataServiceMarketProvider}.</p>
+ *
+ * @author GitHub Copilot
+ */
+@Component
+public class FuturesProvider extends AbstractDataServiceMarketProvider {
+
+    /**
+     * Logger for this provider.
+     */
+    private static final Logger LOG = LoggerFactory.getLogger(FuturesProvider.class);
+
+    /**
+     * Beijing timezone for market hours calculation.
+     */
+    private static final ZoneId BEIJING_ZONE = DateTimePatternConstants.MARKET_ZONE_ID;
+
+    /**
+     * Base path for futures data service endpoints.
+     */
+    private static final String FUTURES_BASE_PATH = "/futures";
+
+    /**
+     * Provider name identifier.
+     */
+    private static final String PROVIDER_NAME = "akshare-futures";
+
+    /**
+     * Base prices for popular futures (mock data fallback).
+     */
+    private final Map<String, BigDecimal> basePrices;
+
+    /**
+     * Constructs a new FuturesProvider.
+     *
+     * @param properties the data service properties
+     * @param webClient the WebClient for data service calls
+     */
+    public FuturesProvider(
+            DataServiceProperties properties,
+            @Qualifier("dataServiceWebClient") WebClient webClient) {
+        super(properties, webClient);
+        this.basePrices = FuturesMockDataSupport.defaultBasePrices();
+    }
+
+    @Override
+    public String getProviderName() {
+        return PROVIDER_NAME;
+    }
+
+    @Override
+    public MarketType getMarketType() {
+        return MarketType.FUTURES;
+    }
+
+    @Override
+    public MarketStatus getMarketStatus() {
+        ZonedDateTime now = ZonedDateTime.now(BEIJING_ZONE);
+        LocalTime time = now.toLocalTime();
+        DayOfWeek dayOfWeek = now.getDayOfWeek();
+
+        if (FuturesMockDataSupport.isWeekend(dayOfWeek)) {
+            return MarketStatus.CLOSED;
+        }
+
+        if (FuturesMockDataSupport.isDaySession(time)) {
+            return MarketStatus.OPEN;
+        }
+
+        if (FuturesMockDataSupport.isNightSession(time)) {
+            return MarketStatus.POST_MARKET;
+        }
+
+        if (FuturesMockDataSupport.isBreakSession(time)) {
+            return MarketStatus.BREAK;
+        }
+
+        return MarketStatus.CLOSED;
+    }
+
+    @Override
+    protected Logger logger() {
+        return LOG;
+    }
+
+    @Override
+    protected String getDataServiceBasePath() {
+        return FUTURES_BASE_PATH;
+    }
+
+    @Override
+    protected String getLogMarketName() {
+        return "futures";
+    }
+
+    @Override
+    protected String getSubscriptionLabel() {
+        return "futures contracts";
+    }
+
+    @Override
+    protected String normalizeSymbol(String symbol) {
+        if (symbol == null || symbol.trim().isEmpty()) {
+            return "";
+        }
+
+        String normalized = symbol.trim().toUpperCase(Locale.ROOT);
+
+        // Remove exchange suffix if present.
+        if (normalized.contains(".")) {
+            normalized = normalized.substring(0, normalized.indexOf('.'));
+        }
+
+        return normalized;
+    }
+
+    @Override
+    protected List<KlineData> generateMockKlineData(String symbol, String timeframe, int limit,
+                                                    Instant startTime, Instant endTime) {
+        return FuturesMockDataSupport.generateMockKlineData(
+                normalizeSymbol(symbol), timeframe, limit, endTime, basePrices);
+    }
+
+    @Override
+    protected Optional<TickData> generateMockTickData(String symbol) {
+        return Optional.of(FuturesMockDataSupport.generateMockTickData(normalizeSymbol(symbol), basePrices));
+    }
+
+    @Override
+    protected List<SymbolInfo> generateMockSearchResults(String keyword, int limit) {
+        return FuturesMockDataSupport.generateMockSearchResults(keyword, limit);
+    }
+
+    @Override
+    protected List<KlineData> convertToKlineData(List<Map<String, Object>> data, String symbol,
+                                                 String timeframe) {
+        List<KlineData> klines = new ArrayList<>();
+
+        for (Map<String, Object> item : data) {
+            klines.add(KlineData.builder()
+                    .symbol(symbol)
+                    .market(MarketType.FUTURES.getCode())
+                    .timestamp(DataConverter.toInstantFromMillis(MarketDataMapReader.getLong(item, "timestamp")))
+                    .open(DataConverter.toBigDecimal(MarketDataMapReader.getString(item, "open")))
+                    .high(DataConverter.toBigDecimal(MarketDataMapReader.getString(item, "high")))
+                    .low(DataConverter.toBigDecimal(MarketDataMapReader.getString(item, "low")))
+                    .close(DataConverter.toBigDecimal(MarketDataMapReader.getString(item, "close")))
+                    .volume(MarketDataMapReader.getLong(item, "volume"))
+                    .amount(DataConverter.toBigDecimal(MarketDataMapReader.getString(item, "amount")))
+                    .timeframe(timeframe)
+                    .build());
+        }
+
+        return klines;
+    }
+
+    @Override
+    protected TickData convertToTickData(Map<String, Object> data, String symbol) {
+        return TickData.builder()
+                .symbol(symbol)
+                .market(MarketType.FUTURES.getCode())
+                .timestamp(DataConverter.toInstantFromMillis(MarketDataMapReader.getLong(data, "timestamp")))
+                .price(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "price")))
+                .change(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "change")))
+                .changePercent(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "changePercent")))
+                .volume(MarketDataMapReader.getLong(data, "volume"))
+                .amount(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "amount")))
+                .bidPrice(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "bidPrice")))
+                .bidVolume(MarketDataMapReader.getLong(data, "bidVolume"))
+                .askPrice(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "askPrice")))
+                .askVolume(MarketDataMapReader.getLong(data, "askVolume"))
+                .dayHigh(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "high")))
+                .dayLow(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "low")))
+                .open(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "open")))
+                .prevClose(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "prevClose")))
+                .build();
+    }
+
+    @Override
+    protected SymbolInfo convertToSymbolInfo(Map<String, Object> data) {
+        return new SymbolInfo(
+                MarketDataMapReader.getString(data, "symbol"),
+                MarketDataMapReader.getString(data, "name"),
+                MarketType.FUTURES.getCode(),
+                FuturesMockDataSupport.resolveExchangeOrDefault(MarketDataMapReader.getString(data, "exchange")),
+                "futures"
+        );
+    }
+}

--- a/koduck-backend/koduck-market/koduck-market-impl/src/main/java/com/koduck/market/provider/HKStockProvider.java
+++ b/koduck-backend/koduck-market/koduck-market-impl/src/main/java/com/koduck/market/provider/HKStockProvider.java
@@ -1,0 +1,386 @@
+package com.koduck.market.provider;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.DayOfWeek;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import com.koduck.infrastructure.config.properties.DataServiceProperties;
+import com.koduck.market.MarketType;
+import com.koduck.market.model.KlineData;
+import com.koduck.market.model.TickData;
+import com.koduck.market.util.DataConverter;
+import com.koduck.market.service.support.HKStockMarketCalendar;
+import com.koduck.market.service.support.MarketDataMapReader;
+import com.koduck.market.service.support.MarketTimeframeParser;
+
+/**
+ * Hong Kong stock market data provider.
+ *
+ * <p>Data-service based implementation with unified retrieval and error handling inherited from
+ * {@link AbstractDataServiceMarketProvider}.</p>
+ *
+ * @author Koduck Team
+ */
+@Component
+public class HKStockProvider extends AbstractDataServiceMarketProvider {
+
+    /** Logger instance for this class. */
+    private static final Logger LOG = LoggerFactory.getLogger(HKStockProvider.class);
+
+    /** Hong Kong timezone for market hours calculation. */
+    private static final ZoneId HONG_KONG_ZONE = ZoneId.of("Asia/Hong_Kong");
+
+    /** Base path for HK stock data service endpoints. */
+    private static final String HK_STOCK_BASE_PATH = "/hk";
+
+    /** Provider name identifier. */
+    private static final String PROVIDER_NAME = "akshare-hk-stock";
+
+    /** Minimum volume for kline mock data generation. */
+    private static final long KLINE_VOLUME_MIN = 100_000L;
+
+    /** Maximum exclusive volume for kline mock data generation. */
+    private static final long KLINE_VOLUME_MAX_EXCLUSIVE = 10_000_000L;
+
+    /** Minimum volume for tick mock data generation. */
+    private static final long TICK_VOLUME_MIN = 1_000_000L;
+
+    /** Maximum exclusive volume for tick mock data generation. */
+    private static final long TICK_VOLUME_MAX_EXCLUSIVE = 50_000_000L;
+
+    /** Minimum volume for order book mock data generation. */
+    private static final long ORDER_BOOK_VOLUME_MIN = 100L;
+
+    /** Maximum exclusive volume for order book mock data generation. */
+    private static final long ORDER_BOOK_VOLUME_MAX_EXCLUSIVE = 10_000L;
+
+    /** Length of the ".HK" suffix in stock symbols. */
+    private static final int HK_SUFFIX_LENGTH = 3;
+
+    /** Random offset center for price change calculation. */
+    private static final double RANDOM_OFFSET_CENTER = 0.5;
+
+    /** Maximum kline price change percentage (4%). */
+    private static final double KLINE_MAX_CHANGE_PERCENT = 0.04;
+
+    /** Maximum high/low variation percentage (1%). */
+    private static final double HIGH_LOW_VARIATION_PERCENT = 0.01;
+
+    /** Maximum tick price change percentage (2%). */
+    private static final double TICK_MAX_CHANGE_PERCENT = 0.02;
+
+    /** Decimal places for percentage division calculation. */
+    private static final int PERCENTAGE_DECIMAL_PLACES = 4;
+
+    /** Percentage multiplier (100%). */
+    private static final double PERCENTAGE_MULTIPLIER = 100.0;
+
+    /** Bid price ratio (99.9% of current price). */
+    private static final double BID_PRICE_RATIO = 0.999;
+
+    /** Ask price ratio (100.1% of current price). */
+    private static final double ASK_PRICE_RATIO = 1.001;
+
+    /** Day high ratio (102% of current price). */
+    private static final double DAY_HIGH_RATIO = 1.02;
+
+    /** Day low ratio (98% of current price). */
+    private static final double DAY_LOW_RATIO = 0.98;
+
+    /** Mock data for fallback. */
+    private final Map<String, BigDecimal> basePrices = new LinkedHashMap<>();
+
+    /**
+     * Constructs a new HKStockProvider.
+     *
+     * @param properties the data service properties
+     * @param webClient the WebClient for data service calls
+     */
+    public HKStockProvider(
+            DataServiceProperties properties,
+            @Qualifier("dataServiceWebClient") WebClient webClient) {
+        super(properties, webClient);
+        initBasePrices();
+    }
+
+    @Override
+    public String getProviderName() {
+        return PROVIDER_NAME;
+    }
+
+    @Override
+    public MarketType getMarketType() {
+        return MarketType.HK_STOCK;
+    }
+
+    @Override
+    public MarketStatus getMarketStatus() {
+        ZonedDateTime now = ZonedDateTime.now(HONG_KONG_ZONE);
+        LocalTime time = now.toLocalTime();
+        DayOfWeek dayOfWeek = now.getDayOfWeek();
+
+        if (HKStockMarketCalendar.isWeekend(dayOfWeek)
+                || HKStockMarketCalendar.isPublicHoliday(now.toLocalDate())) {
+            return MarketStatus.CLOSED;
+        }
+
+        if (HKStockMarketCalendar.isPreMarket(time)) {
+            return MarketStatus.PRE_MARKET;
+        }
+
+        if (HKStockMarketCalendar.isMorningSession(time)
+                || HKStockMarketCalendar.isAfternoonSession(time)) {
+            return MarketStatus.OPEN;
+        }
+
+        if (HKStockMarketCalendar.isLunchBreak(time)) {
+            return MarketStatus.BREAK;
+        }
+
+        if (HKStockMarketCalendar.isClosingAuction(time)) {
+            return MarketStatus.POST_MARKET;
+        }
+
+        return MarketStatus.CLOSED;
+    }
+
+    @Override
+    protected Logger logger() {
+        return LOG;
+    }
+
+    @Override
+    protected String getDataServiceBasePath() {
+        return HK_STOCK_BASE_PATH;
+    }
+
+    @Override
+    protected String getLogMarketName() {
+        return "HK stock";
+    }
+
+    @Override
+    protected String getSubscriptionLabel() {
+        return "HK stocks";
+    }
+
+    @Override
+    protected String normalizeSymbol(String symbol) {
+        if (symbol == null || symbol.trim().isEmpty()) {
+            return "";
+        }
+
+        String normalized = symbol.trim().toUpperCase(Locale.ROOT);
+
+        // Remove .HK suffix if present.
+        if (normalized.endsWith(".HK")) {
+            normalized = normalized.substring(0, normalized.length() - HK_SUFFIX_LENGTH);
+        }
+
+        // Pad to 5 digits.
+        if (normalized.matches("\\d+")) {
+            normalized = String.format("%05d", Integer.parseInt(normalized));
+        }
+
+        return normalized;
+    }
+
+    @Override
+    protected List<KlineData> generateMockKlineData(String symbol, String timeframe, int limit,
+                                                    Instant startTime, Instant endTime) {
+        List<KlineData> klines = new ArrayList<>();
+        String normalizedSymbol = normalizeSymbol(symbol);
+        BigDecimal basePrice = basePrices.getOrDefault(normalizedSymbol, new BigDecimal("50.00"));
+
+        Instant currentTime = endTime != null ? endTime : Instant.now();
+        Duration interval = MarketTimeframeParser.parseStandard(timeframe);
+
+        BigDecimal currentPrice = basePrice;
+        for (int i = 0; i < limit; i++) {
+            double changePercent = (Math.random() - RANDOM_OFFSET_CENTER) * KLINE_MAX_CHANGE_PERCENT;
+            BigDecimal change = currentPrice.multiply(BigDecimal.valueOf(changePercent));
+            BigDecimal close = currentPrice.add(change);
+
+            BigDecimal high = close.multiply(BigDecimal.valueOf(1 + Math.random() * HIGH_LOW_VARIATION_PERCENT));
+            BigDecimal low = close.multiply(BigDecimal.valueOf(1 - Math.random() * HIGH_LOW_VARIATION_PERCENT));
+            BigDecimal open = currentPrice;
+
+            long volume = ThreadLocalRandom.current().nextLong(KLINE_VOLUME_MIN, KLINE_VOLUME_MAX_EXCLUSIVE);
+
+            klines.add(KlineData.builder()
+                    .symbol(normalizedSymbol)
+                    .market(MarketType.HK_STOCK.getCode())
+                    .timestamp(currentTime)
+                    .open(open)
+                    .high(high)
+                    .low(low)
+                    .close(close)
+                    .volume(volume)
+                    .amount(close.multiply(BigDecimal.valueOf(volume)))
+                    .timeframe(timeframe)
+                    .build());
+
+            currentPrice = close;
+            currentTime = currentTime.minus(interval);
+        }
+
+        Collections.reverse(klines);
+        return klines;
+    }
+
+    @Override
+    protected Optional<TickData> generateMockTickData(String symbol) {
+        String normalizedSymbol = normalizeSymbol(symbol);
+        BigDecimal basePrice = basePrices.getOrDefault(normalizedSymbol, new BigDecimal("50.00"));
+
+        double changePercent = (Math.random() - RANDOM_OFFSET_CENTER) * TICK_MAX_CHANGE_PERCENT;
+        BigDecimal price = basePrice.multiply(BigDecimal.valueOf(1 + changePercent));
+        BigDecimal change = price.subtract(basePrice);
+        BigDecimal changePercentValue = change.divide(basePrice, PERCENTAGE_DECIMAL_PLACES, RoundingMode.HALF_UP)
+                .multiply(BigDecimal.valueOf(PERCENTAGE_MULTIPLIER));
+
+        long volume = ThreadLocalRandom.current().nextLong(TICK_VOLUME_MIN, TICK_VOLUME_MAX_EXCLUSIVE);
+
+        TickData tickData = TickData.builder()
+                .symbol(normalizedSymbol)
+                .market(MarketType.HK_STOCK.getCode())
+                .timestamp(Instant.now())
+                .price(price)
+                .change(change)
+                .changePercent(changePercentValue)
+                .volume(volume)
+                .amount(price.multiply(BigDecimal.valueOf(volume)))
+                .bidPrice(price.multiply(BigDecimal.valueOf(BID_PRICE_RATIO)))
+                .bidVolume(ThreadLocalRandom.current().nextLong(ORDER_BOOK_VOLUME_MIN, ORDER_BOOK_VOLUME_MAX_EXCLUSIVE))
+                .askPrice(price.multiply(BigDecimal.valueOf(ASK_PRICE_RATIO)))
+                .askVolume(ThreadLocalRandom.current().nextLong(ORDER_BOOK_VOLUME_MIN, ORDER_BOOK_VOLUME_MAX_EXCLUSIVE))
+                .dayHigh(price.multiply(BigDecimal.valueOf(DAY_HIGH_RATIO)))
+                .dayLow(price.multiply(BigDecimal.valueOf(DAY_LOW_RATIO)))
+                .open(basePrice)
+                .prevClose(basePrice)
+                .build();
+
+        return Optional.of(tickData);
+    }
+
+    @Override
+    protected List<SymbolInfo> generateMockSearchResults(String keyword, int limit) {
+        List<SymbolInfo> results = new ArrayList<>();
+        String upperKeyword = keyword.toUpperCase(Locale.ROOT);
+
+        Map<String, String> hkStocks = new LinkedHashMap<>();
+        hkStocks.put("00700", "Tencent Holdings Ltd.");
+        hkStocks.put("09988", "Alibaba Health Information Technology");
+        hkStocks.put("01898", "Meituan");
+        hkStocks.put("09618", "JD.com Inc.");
+        hkStocks.put("01211", "BYD Company Limited");
+        hkStocks.put("09888", "Baidu Inc.");
+        hkStocks.put("01024", "Kuaishou Technology");
+        hkStocks.put("02015", "Li Auto Inc.");
+        hkStocks.put("09868", "XPeng Inc.");
+        hkStocks.put("06690", "Haier Smart Home Co.");
+
+        hkStocks.entrySet().stream()
+                .filter(e -> e.getKey().contains(upperKeyword)
+                        || e.getValue().toUpperCase(Locale.ROOT).contains(upperKeyword))
+                .limit(limit)
+                .forEach(e -> results.add(new SymbolInfo(
+                        e.getKey(),
+                        e.getValue(),
+                        MarketType.HK_STOCK.getCode(),
+                        "HKEX",
+                        "stock"
+                )));
+
+        return results;
+    }
+
+    @Override
+    protected List<KlineData> convertToKlineData(List<Map<String, Object>> data, String symbol,
+                                                 String timeframe) {
+        List<KlineData> klines = new ArrayList<>();
+
+        for (Map<String, Object> item : data) {
+            klines.add(KlineData.builder()
+                    .symbol(symbol)
+                    .market(MarketType.HK_STOCK.getCode())
+                    .timestamp(DataConverter.toInstantFromMillis(MarketDataMapReader.getLong(item, "timestamp")))
+                    .open(DataConverter.toBigDecimal(MarketDataMapReader.getString(item, "open")))
+                    .high(DataConverter.toBigDecimal(MarketDataMapReader.getString(item, "high")))
+                    .low(DataConverter.toBigDecimal(MarketDataMapReader.getString(item, "low")))
+                    .close(DataConverter.toBigDecimal(MarketDataMapReader.getString(item, "close")))
+                    .volume(MarketDataMapReader.getLong(item, "volume"))
+                    .amount(DataConverter.toBigDecimal(MarketDataMapReader.getString(item, "amount")))
+                    .timeframe(timeframe)
+                    .build());
+        }
+
+        return klines;
+    }
+
+    @Override
+    protected TickData convertToTickData(Map<String, Object> data, String symbol) {
+        return TickData.builder()
+                .symbol(symbol)
+                .market(MarketType.HK_STOCK.getCode())
+                .timestamp(DataConverter.toInstantFromMillis(MarketDataMapReader.getLong(data, "timestamp")))
+                .price(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "price")))
+                .change(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "change")))
+                .changePercent(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "changePercent")))
+                .volume(MarketDataMapReader.getLong(data, "volume"))
+                .amount(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "amount")))
+                .bidPrice(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "bidPrice")))
+                .bidVolume(MarketDataMapReader.getLong(data, "bidVolume"))
+                .askPrice(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "askPrice")))
+                .askVolume(MarketDataMapReader.getLong(data, "askVolume"))
+                .dayHigh(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "high")))
+                .dayLow(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "low")))
+                .open(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "open")))
+                .prevClose(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "prevClose")))
+                .build();
+    }
+
+    @Override
+    protected SymbolInfo convertToSymbolInfo(Map<String, Object> data) {
+        String exchange = MarketDataMapReader.getString(data, "exchange");
+        return new SymbolInfo(
+                MarketDataMapReader.getString(data, "symbol"),
+                MarketDataMapReader.getString(data, "name"),
+                MarketType.HK_STOCK.getCode(),
+                exchange != null ? exchange : "HKEX",
+                "stock"
+        );
+    }
+
+    private void initBasePrices() {
+        basePrices.put("00700", new BigDecimal("380.00"));
+        basePrices.put("09988", new BigDecimal("75.00"));
+        basePrices.put("01898", new BigDecimal("120.00"));
+        basePrices.put("09618", new BigDecimal("95.00"));
+        basePrices.put("01211", new BigDecimal("150.00"));
+        basePrices.put("09888", new BigDecimal("85.00"));
+        basePrices.put("01024", new BigDecimal("45.00"));
+        basePrices.put("02015", new BigDecimal("55.00"));
+        basePrices.put("09868", new BigDecimal("40.00"));
+        basePrices.put("06690", new BigDecimal("25.00"));
+    }
+}

--- a/koduck-backend/koduck-market/koduck-market-impl/src/main/java/com/koduck/market/provider/MarketDataProvider.java
+++ b/koduck-backend/koduck-market/koduck-market-impl/src/main/java/com/koduck/market/provider/MarketDataProvider.java
@@ -1,0 +1,194 @@
+package com.koduck.market.provider;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import com.koduck.market.MarketType;
+import com.koduck.market.model.KlineData;
+import com.koduck.market.model.TickData;
+
+/**
+ * Interface for market data providers.
+ * All market data sources must implement this interface.
+ *
+ * @author Koduck Team
+ */
+public interface MarketDataProvider {
+
+    /** Maximum health score value (100%). */
+    int MAX_HEALTH_SCORE = 100;
+
+    /** Minimum health score value (0%). */
+    int MIN_HEALTH_SCORE = 0;
+
+    /**
+     * Get the provider name.
+     *
+     * @return provider identifier name
+     */
+    String getProviderName();
+
+    /**
+     * Get the supported market type.
+     *
+     * @return MarketType this provider supports
+     */
+    MarketType getMarketType();
+
+    /**
+     * Check if the provider is available.
+     *
+     * @return true if provider is healthy and available
+     */
+    boolean isAvailable();
+
+    /**
+     * Get k-line data.
+     *
+     * @param symbol    the stock symbol
+     * @param timeframe the timeframe (e.g., "1m", "5m", "1h", "1d")
+     * @param limit     maximum number of records to return
+     * @param startTime optional start time filter
+     * @param endTime   optional end time filter
+     * @return list of k-line data
+     * @throws MarketDataException if data fetch fails
+     */
+    List<KlineData> getKlineData(String symbol, String timeframe, int limit,
+                                  Instant startTime, Instant endTime)
+            throws MarketDataException;
+
+    /**
+     * Get real-time tick data.
+     *
+     * @param symbol the stock symbol
+     * @return optional tick data
+     * @throws MarketDataException if data fetch fails
+     */
+    Optional<TickData> getRealTimeTick(String symbol) throws MarketDataException;
+
+    /**
+     * Subscribe to real-time data for symbols.
+     *
+     * @param symbols  list of symbols to subscribe
+     * @param callback callback for data updates
+     * @throws MarketDataException if subscription fails
+     */
+    void subscribeRealTime(List<String> symbols, RealTimeDataCallback callback)
+            throws MarketDataException;
+
+    /**
+     * Unsubscribe from real-time data.
+     *
+     * @param symbols list of symbols to unsubscribe
+     */
+    void unsubscribeRealTime(List<String> symbols);
+
+    /**
+     * Get current market status.
+     *
+     * @return MarketStatus indicating if market is open, closed, etc.
+     */
+    MarketStatus getMarketStatus();
+
+    /**
+     * Search for symbols.
+     *
+     * @param keyword search keyword
+     * @param limit   maximum results
+     * @return list of matching symbols
+     */
+    List<SymbolInfo> searchSymbols(String keyword, int limit);
+
+    /**
+     * Get provider health score (0-100).
+     *
+     * @return health score
+     */
+    default int getHealthScore() {
+        return isAvailable() ? MAX_HEALTH_SCORE : MIN_HEALTH_SCORE;
+    }
+
+    /**
+     * Callback interface for real-time data.
+     */
+    @FunctionalInterface
+    interface RealTimeDataCallback {
+        void onDataUpdate(TickData tickData);
+
+        default void onError(Throwable error) {
+            // Default no-op error handler
+        }
+    }
+
+    /**
+     * Market status enum.
+     */
+    enum MarketStatus {
+        /** Market is open for trading. */
+        OPEN,
+        /** Market is closed. */
+        CLOSED,
+        /** Pre-market trading session. */
+        PRE_MARKET,
+        /** Post-market trading session. */
+        POST_MARKET,
+        /** Market is on break. */
+        BREAK,
+        /** Market status is unknown. */
+        UNKNOWN
+    }
+
+    /**
+     * Symbol information record.
+     *
+     * @param symbol   the stock symbol
+     * @param name     the stock name
+     * @param market   the market type
+     * @param exchange the exchange code
+     * @param type     the security type
+     */
+    record SymbolInfo(
+            String symbol,
+            String name,
+            String market,
+            String exchange,
+            String type
+    ) {
+    }
+
+    /**
+     * Exception for market data errors.
+     */
+    class MarketDataException extends Exception {
+        private static final long serialVersionUID = 1L;
+
+        /**
+         * Constructs a new MarketDataException with the specified message.
+         *
+         * @param message the error message
+         */
+        public MarketDataException(String message) {
+            super(message);
+        }
+
+        /**
+         * Constructs a new MarketDataException with the specified message and cause.
+         *
+         * @param message the error message
+         * @param cause   the underlying cause
+         */
+        public MarketDataException(String message, Throwable cause) {
+            super(message, cause);
+        }
+
+        /**
+         * Constructs a new MarketDataException with the specified cause.
+         *
+         * @param cause the underlying cause
+         */
+        public MarketDataException(Throwable cause) {
+            super(cause);
+        }
+    }
+}

--- a/koduck-backend/koduck-market/koduck-market-impl/src/main/java/com/koduck/market/provider/ProviderFactory.java
+++ b/koduck-backend/koduck-market/koduck-market-impl/src/main/java/com/koduck/market/provider/ProviderFactory.java
@@ -1,0 +1,361 @@
+package com.koduck.market.provider;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import org.springframework.stereotype.Component;
+
+import com.koduck.market.MarketType;
+
+/**
+ * Factory for managing and retrieving market data providers.
+ * Implements a fallback strategy when primary provider fails.
+ *
+ * @author Koduck Team
+ */
+@Component
+public class ProviderFactory {
+
+    /** Providers grouped by market type. */
+    private final Map<MarketType, List<MarketDataProvider>> providersByMarket =
+            new ConcurrentHashMap<>();
+
+    /** Providers indexed by name. */
+    private final Map<String, MarketDataProvider> providersByName =
+            new ConcurrentHashMap<>();
+
+    /** Primary provider for each market type. */
+    private final Map<MarketType, MarketDataProvider> primaryProviders =
+            new ConcurrentHashMap<>();
+
+    /** Read-write lock to ensure atomicity across multiple maps. */
+    private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+
+    /**
+     * Register a provider.
+     *
+     * @param provider the provider to register
+     */
+    public void registerProvider(MarketDataProvider provider) {
+        lock.writeLock().lock();
+        try {
+            MarketType marketType = provider.getMarketType();
+            String providerName = provider.getProviderName();
+
+            // Add to name map
+            providersByName.put(providerName, provider);
+
+            // Add to market map
+            providersByMarket.computeIfAbsent(marketType, k -> new CopyOnWriteArrayList<>())
+                            .add(provider);
+
+            // Set as primary if no primary exists for this market
+            primaryProviders.putIfAbsent(marketType, provider);
+        }
+        finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    /**
+     * Unregister a provider.
+     *
+     * @param providerName the name of provider to unregister
+     */
+    public void unregisterProvider(String providerName) {
+        lock.writeLock().lock();
+        try {
+            MarketDataProvider provider = providersByName.remove(providerName);
+            if (provider != null) {
+                MarketType marketType = provider.getMarketType();
+                List<MarketDataProvider> providers = providersByMarket.get(marketType);
+                if (providers != null) {
+                    providers.remove(provider);
+                    if (providers.isEmpty()) {
+                        providersByMarket.remove(marketType);
+                    }
+                }
+
+                // Update primary if needed
+                if (primaryProviders.get(marketType) == provider) {
+                    List<MarketDataProvider> remaining = providersByMarket.get(marketType);
+                    if (remaining != null && !remaining.isEmpty()) {
+                        primaryProviders.put(marketType, remaining.get(0));
+                    }
+                    else {
+                        primaryProviders.remove(marketType);
+                    }
+                }
+            }
+        }
+        finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    /**
+     * Get provider by name.
+     *
+     * @param providerName the provider name
+     * @return Optional of provider
+     */
+    public Optional<MarketDataProvider> getProvider(String providerName) {
+        lock.readLock().lock();
+        try {
+            return Optional.ofNullable(providersByName.get(providerName));
+        }
+        finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    /**
+     * Get primary provider for a market type.
+     *
+     * @param marketType the market type
+     * @return Optional of primary provider
+     */
+    public Optional<MarketDataProvider> getPrimaryProvider(MarketType marketType) {
+        lock.readLock().lock();
+        try {
+            return Optional.ofNullable(primaryProviders.get(marketType));
+        }
+        finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    /**
+     * Get all providers for a market type.
+     *
+     * @param marketType the market type
+     * @return list of providers
+     */
+    public List<MarketDataProvider> getProviders(MarketType marketType) {
+        lock.readLock().lock();
+        try {
+            return providersByMarket.getOrDefault(marketType, Collections.emptyList());
+        }
+        finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    /**
+     * Set primary provider for a market type.
+     *
+     * @param marketType   the market type
+     * @param providerName the provider name
+     * @throws IllegalArgumentException if provider not found or wrong market type
+     */
+    public void setPrimaryProvider(MarketType marketType, String providerName) {
+        lock.writeLock().lock();
+        try {
+            MarketDataProvider provider = providersByName.get(providerName);
+            if (provider == null) {
+                throw new IllegalArgumentException("Provider not found: " + providerName);
+            }
+            if (provider.getMarketType() != marketType) {
+                throw new IllegalArgumentException(
+                    "Provider " + providerName + " is not for market type " + marketType);
+            }
+            primaryProviders.put(marketType, provider);
+        }
+        finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    /**
+     * Get all registered market types.
+     *
+     * @return list of market types
+     */
+    public List<MarketType> getRegisteredMarketTypes() {
+        lock.readLock().lock();
+        try {
+            return new ArrayList<>(providersByMarket.keySet());
+        }
+        finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    /**
+     * Get provider health information.
+     *
+     * @param marketType the market type
+     * @return list of provider health info
+     */
+    public List<ProviderHealthInfo> getProviderHealthInfo(MarketType marketType) {
+        lock.readLock().lock();
+        try {
+            List<MarketDataProvider> providers = providersByMarket.get(marketType);
+            if (providers == null) {
+                return Collections.emptyList();
+            }
+
+            MarketDataProvider primary = primaryProviders.get(marketType);
+            List<ProviderHealthInfo> healthInfo = new ArrayList<>();
+
+            for (MarketDataProvider provider : providers) {
+                healthInfo.add(new ProviderHealthInfo(
+                    provider.getProviderName(),
+                    marketType,
+                    provider.isAvailable(),
+                    provider.getHealthScore(),
+                    provider == primary
+                ));
+            }
+
+            return healthInfo;
+        }
+        finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    /**
+     * Get available provider for a market type.
+     *
+     * @param marketType the market type
+     * @return optional of available provider
+     */
+    public Optional<MarketDataProvider> getAvailableProvider(MarketType marketType) {
+        lock.readLock().lock();
+        try {
+            List<MarketDataProvider> providers = providersByMarket.get(marketType);
+            if (providers == null || providers.isEmpty()) {
+                return Optional.empty();
+            }
+
+            // Return first available provider
+            return providers.stream()
+                           .filter(MarketDataProvider::isAvailable)
+                           .findFirst();
+        }
+        finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    /**
+     * Check if a market type is supported.
+     *
+     * @param marketType the market type
+     * @return true if supported
+     */
+    public boolean isMarketSupported(MarketType marketType) {
+        lock.readLock().lock();
+        try {
+            return providersByMarket.containsKey(marketType);
+        }
+        finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    /**
+     * Get all supported market types.
+     *
+     * @return set of market types
+     */
+    public Set<MarketType> getSupportedMarkets() {
+        lock.readLock().lock();
+        try {
+            return new HashSet<>(providersByMarket.keySet());
+        }
+        finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    /**
+     * Get provider health summary for all providers.
+     *
+     * @return map of provider name to health info
+     */
+    public Map<String, ProviderHealthInfo> getProviderHealthSummary() {
+        lock.readLock().lock();
+        try {
+            Map<String, ProviderHealthInfo> healthMap = new HashMap<>();
+
+            for (Map.Entry<String, MarketDataProvider> entry : providersByName.entrySet()) {
+                String providerName = entry.getKey();
+                MarketDataProvider provider = entry.getValue();
+                MarketType marketType = provider.getMarketType();
+                MarketDataProvider primary = primaryProviders.get(marketType);
+
+                healthMap.put(providerName, new ProviderHealthInfo(
+                    providerName,
+                    marketType,
+                    provider.isAvailable(),
+                    provider.getHealthScore(),
+                    provider == primary
+                ));
+            }
+
+            return healthMap;
+        }
+        finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    /**
+     * Get all provider names.
+     *
+     * @return set of provider names
+     */
+    public Set<String> getProviderNames() {
+        lock.readLock().lock();
+        try {
+            return new HashSet<>(providersByName.keySet());
+        }
+        finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    /**
+     * Clear all registrations.
+     */
+    public void clear() {
+        lock.writeLock().lock();
+        try {
+            providersByName.clear();
+            providersByMarket.clear();
+            primaryProviders.clear();
+        }
+        finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    /**
+     * Provider health information.
+     *
+     * @param providerName the provider name
+     * @param marketType   the market type
+     * @param available    whether the provider is available
+     * @param healthScore  the health score
+     * @param isPrimary    whether this is the primary provider
+     */
+    public record ProviderHealthInfo(
+        String providerName,
+        MarketType marketType,
+        boolean available,
+        int healthScore,
+        boolean isPrimary
+    ) {
+    }
+}

--- a/koduck-backend/koduck-market/koduck-market-impl/src/main/java/com/koduck/market/provider/USStockProvider.java
+++ b/koduck-backend/koduck-market/koduck-market-impl/src/main/java/com/koduck/market/provider/USStockProvider.java
@@ -1,0 +1,556 @@
+package com.koduck.market.provider;
+
+import java.math.BigDecimal;
+import java.time.DayOfWeek;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import com.koduck.infrastructure.config.properties.FinnhubProperties;
+import com.koduck.market.MarketType;
+import com.koduck.market.model.KlineData;
+import com.koduck.market.model.TickData;
+import com.koduck.market.provider.MarketDataProvider;
+import com.koduck.market.service.support.USStockMockDataProvider;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * 使用 Finnhub API 的美股数据提供者。
+ * 支持盘前和盘后交易。
+ *
+ * <p>免费版限制：60 次/分钟</p>
+ *
+ * <p>交易时间（东部时间）：
+ * - 盘前：04:00 - 09:30
+ * - 常规：09:30 - 16:00
+ * - 盘后：16:00 - 20:00</p>
+ *
+ * @see <a href="https://finnhub.io/docs/api">Finnhub API Docs</a>
+ * @author Koduck Team
+ */
+@Component
+public class USStockProvider implements MarketDataProvider {
+
+    /** Logger. */
+    private static final Logger LOG = LoggerFactory.getLogger(USStockProvider.class);
+    /** US Eastern time zone. */
+    private static final ZoneId US_EASTERN = ZoneId.of("America/New_York");
+    /** Provider name. */
+    private static final String PROVIDER_NAME = "finnhub-us-stock";
+    /** Query param: token. */
+    private static final String QUERY_PARAM_TOKEN = "token";
+    /** Thirty days in seconds. */
+    private static final long THIRTY_DAYS_SECONDS = 86_400L * 30L;
+    /** Health score: full. */
+    private static final int HEALTH_SCORE_FULL = 100;
+    /** Health score: half. */
+    private static final int HEALTH_SCORE_HALF = 50;
+    /** Pre-market start hour. */
+    private static final int PRE_MARKET_START_HOUR = 4;
+    /** Pre-market end hour. */
+    private static final int PRE_MARKET_END_HOUR = 9;
+    /** Pre-market end minute. */
+    private static final int PRE_MARKET_END_MINUTE = 30;
+    /** Regular start hour. */
+    private static final int REGULAR_START_HOUR = 9;
+    /** Regular start minute. */
+    private static final int REGULAR_START_MINUTE = 30;
+    /** Regular end hour. */
+    private static final int REGULAR_END_HOUR = 16;
+    /** Post-market end hour. */
+    private static final int POST_MARKET_END_HOUR = 20;
+    /** January. */
+    private static final int JANUARY = 1;
+    /** July. */
+    private static final int JULY = 7;
+    /** December. */
+    private static final int DECEMBER = 12;
+    /** New Year's Day. */
+    private static final int NEW_YEAR_DAY = 1;
+    /** Alternative New Year's Day. */
+    private static final int NEW_YEAR_DAY_ALT = 2;
+    /** Independence Day. */
+    private static final int INDEPENDENCE_DAY = 4;
+    /** Independence Day Eve. */
+    private static final int INDEPENDENCE_DAY_EVE = 3;
+    /** Day after Independence Day. */
+    private static final int INDEPENDENCE_DAY_AFTER = 5;
+    /** Christmas Day. */
+    private static final int CHRISTMAS_DAY = 25;
+    /** Christmas Eve. */
+    private static final int CHRISTMAS_EVE = 24;
+    /** Day after Christmas. */
+    private static final int CHRISTMAS_AFTER = 26;
+    /** Timeframe: 1 minute. */
+    private static final String TIMEFRAME_1M = "1m";
+    /** Timeframe: 5 minutes. */
+    private static final String TIMEFRAME_5M = "5m";
+    /** Timeframe: 15 minutes. */
+    private static final String TIMEFRAME_15M = "15m";
+    /** Timeframe: 30 minutes. */
+    private static final String TIMEFRAME_30M = "30m";
+    /** Timeframe: 1 hour. */
+    private static final String TIMEFRAME_1H = "1h";
+    /** Timeframe: 60 minutes. */
+    private static final String TIMEFRAME_60M = "60m";
+    /** Timeframe: 1 day. */
+    private static final String TIMEFRAME_1D = "1d";
+    /** Timeframe: daily. */
+    private static final String TIMEFRAME_DAILY = "daily";
+    /** Timeframe: 1 week. */
+    private static final String TIMEFRAME_1W = "1w";
+    /** Timeframe: weekly. */
+    private static final String TIMEFRAME_WEEKLY = "weekly";
+    /** Timeframe: 1 month. */
+    private static final String TIMEFRAME_1MTH = "1mth";
+    /** Timeframe: monthly. */
+    private static final String TIMEFRAME_MONTHLY = "monthly";
+    /** Resolution: 1. */
+    private static final String RESOLUTION_1 = "1";
+    /** Resolution: 5. */
+    private static final String RESOLUTION_5 = "5";
+    /** Resolution: 15. */
+    private static final String RESOLUTION_15 = "15";
+    /** Resolution: 30. */
+    private static final String RESOLUTION_30 = "30";
+    /** Resolution: 60. */
+    private static final String RESOLUTION_60 = "60";
+    /** Resolution: D. */
+    private static final String RESOLUTION_D = "D";
+    /** Resolution: W. */
+    private static final String RESOLUTION_W = "W";
+    /** Resolution: M. */
+    private static final String RESOLUTION_M = "M";
+    /** Response status: ok. */
+    private static final String RESPONSE_STATUS_OK = "ok";
+    /** Stock type: Common Stock. */
+    private static final String STOCK_TYPE_COMMON = "Common Stock";
+    /** Default exchange. */
+    private static final String DEFAULT_EXCHANGE = "NASDAQ";
+    /** Symbol type: stock. */
+    private static final String SYMBOL_TYPE_STOCK = "stock";
+
+    /** Finnhub properties. */
+    private final FinnhubProperties properties;
+    /** WebClient. */
+    private final WebClient webClient;
+    /** Subscribed symbols. */
+    private final Set<String> subscribedSymbols = ConcurrentHashMap.newKeySet();
+
+    // 当 API 不可用时回退到模拟数据
+    /** Mock data provider. */
+    private final USStockMockDataProvider mockProvider = new USStockMockDataProvider();
+
+    /**
+     * 构造函数。
+     *
+     * @param properties 配置属性
+     * @param webClient WebClient
+     */
+    public USStockProvider(FinnhubProperties properties,
+        @Qualifier("finnhubWebClient") WebClient webClient) {
+        this.properties = Objects.requireNonNull(properties, "properties must not be null");
+        this.webClient = Objects.requireNonNull(webClient,
+            "webClient must not be null");
+    }
+
+    @Override
+    public String getProviderName() {
+        return PROVIDER_NAME;
+    }
+
+    @Override
+    public MarketType getMarketType() {
+        return MarketType.US_STOCK;
+    }
+
+    @Override
+    public boolean isAvailable() {
+        return properties.isReady() || mockProvider.isAvailable();
+    }
+
+    @Override
+    public int getHealthScore() {
+        if (properties.isReady()) {
+            return HEALTH_SCORE_FULL;
+        }
+        else if (properties.isEnabled()) {
+            return HEALTH_SCORE_HALF;
+        }
+        else {
+            return mockProvider.getHealthScore();
+        }
+    }
+
+    @Override
+    public List<KlineData> getKlineData(String symbol, String timeframe, int limit,
+        Instant startTime, Instant endTime) throws MarketDataException {
+
+        if (!properties.isReady()) {
+            LOG.debug("Finnhub not configured, using mock data for kline");
+            return mockProvider.getKlineData(symbol, timeframe, limit, startTime, endTime);
+        }
+
+        try {
+            String resolution = mapTimeframe(timeframe);
+
+            long from = startTime != null ? startTime.getEpochSecond()
+                : Instant.now().minusSeconds(THIRTY_DAYS_SECONDS).getEpochSecond();
+            long to = endTime != null ? endTime.getEpochSecond() : Instant.now().getEpochSecond();
+
+            String url = UriComponentsBuilder
+                .fromUriString(properties.getBaseUrl() + "/stock/candle")
+                .queryParam("symbol", symbol.toUpperCase(Locale.ROOT))
+                .queryParam("resolution", resolution)
+                .queryParam("from", from)
+                .queryParam("to", to)
+                .queryParam(QUERY_PARAM_TOKEN, properties.getApiKey())
+                .toUriString();
+
+            LOG.debug("Fetching kline from Finnhub: symbol={}, resolution={}",
+                symbol, resolution);
+
+            CandleResponse body = webClient
+                .method(Objects.requireNonNull(HttpMethod.GET))
+                .uri(url)
+                .retrieve()
+                .bodyToMono(CandleResponse.class)
+                .block();
+
+            if (body == null || body.getS() == null
+                || !body.getS().equals(RESPONSE_STATUS_OK)) {
+                throw new MarketDataException("Invalid response from Finnhub: "
+                    + (body != null ? body.getS() : "null"));
+            }
+
+            return convertToKlineData(body, symbol.toUpperCase(Locale.ROOT), timeframe, limit);
+
+        }
+        catch (WebClientResponseException e) {
+            LOG.error("Failed to fetch kline from Finnhub: {}", e.getMessage());
+            // 回退到模拟数据
+            return mockProvider.getKlineData(symbol, timeframe, limit, startTime, endTime);
+        }
+    }
+
+    @Override
+    public Optional<TickData> getRealTimeTick(String symbol) throws MarketDataException {
+        if (!properties.isReady()) {
+            LOG.debug("Finnhub not configured, using mock data for tick");
+            return mockProvider.getRealTimeTick(symbol);
+        }
+
+        try {
+            String url = UriComponentsBuilder
+                .fromUriString(properties.getBaseUrl() + "/quote")
+                .queryParam("symbol", symbol.toUpperCase(Locale.ROOT))
+                .queryParam(QUERY_PARAM_TOKEN, properties.getApiKey())
+                .toUriString();
+
+            LOG.debug("Fetching quote from Finnhub: symbol={}", symbol);
+
+            QuoteResponse quote = webClient
+                .method(Objects.requireNonNull(HttpMethod.GET))
+                .uri(url)
+                .retrieve()
+                .bodyToMono(QuoteResponse.class)
+                .block();
+
+            if (quote == null) {
+                return Optional.empty();
+            }
+
+            TickData tickData = TickData.builder()
+                .symbol(symbol.toUpperCase(Locale.ROOT))
+                .market(MarketType.US_STOCK.getCode())
+                .timestamp(Instant.ofEpochSecond(quote.getT()))
+                .price(BigDecimal.valueOf(quote.getC()))
+                .change(BigDecimal.valueOf(quote.getD()))
+                .changePercent(BigDecimal.valueOf(quote.getDp()))
+                .open(BigDecimal.valueOf(quote.getO()))
+                .dayHigh(BigDecimal.valueOf(quote.getH()))
+                .dayLow(BigDecimal.valueOf(quote.getL()))
+                .prevClose(BigDecimal.valueOf(quote.getPc()))
+                .volume(null)
+                .build();
+
+            return Optional.of(tickData);
+
+        }
+        catch (WebClientResponseException e) {
+            LOG.error("Failed to fetch quote from Finnhub: {}", e.getMessage());
+            // 回退到模拟数据
+            return mockProvider.getRealTimeTick(symbol);
+        }
+    }
+
+    @Override
+    public void subscribeRealTime(List<String> symbols, RealTimeDataCallback callback)
+        throws MarketDataException {
+
+        symbols.forEach(sym -> subscribedSymbols.add(sym.toUpperCase(Locale.ROOT)));
+        LOG.info("Subscribed to {} US stocks for real-time data", symbols.size());
+
+        // Finnhub WebSocket 需要单独连接
+        // 目前仅跟踪订阅
+        // 生产环境中应实现 WebSocket 连接到 wss://ws.finnhub.io
+    }
+
+    @Override
+    public void unsubscribeRealTime(List<String> symbols) {
+        symbols.forEach(sym -> subscribedSymbols.remove(sym.toUpperCase(Locale.ROOT)));
+        LOG.info("Unsubscribed from {} US stocks", symbols.size());
+    }
+
+    @Override
+    public MarketStatus getMarketStatus() {
+        ZonedDateTime now = ZonedDateTime.now(US_EASTERN);
+        LocalTime time = now.toLocalTime();
+        DayOfWeek dayOfWeek = now.getDayOfWeek();
+
+        // 周末检查
+        if (dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY) {
+            return MarketStatus.CLOSED;
+        }
+
+        // 市场假日（简化）
+        if (isMarketHoliday(now.toLocalDate())) {
+            return MarketStatus.CLOSED;
+        }
+
+        // 交易时间（东部时间）
+        LocalTime preMarketStart = LocalTime.of(PRE_MARKET_START_HOUR, 0);
+        LocalTime preMarketEnd = LocalTime.of(PRE_MARKET_END_HOUR, PRE_MARKET_END_MINUTE);
+        LocalTime regularStart = LocalTime.of(REGULAR_START_HOUR, REGULAR_START_MINUTE);
+        LocalTime regularEnd = LocalTime.of(REGULAR_END_HOUR, 0);
+        LocalTime postMarketEnd = LocalTime.of(POST_MARKET_END_HOUR, 0);
+
+        if (time.isAfter(preMarketStart) && time.isBefore(preMarketEnd)) {
+            return MarketStatus.PRE_MARKET;
+        }
+        else if ((time.equals(regularStart) || time.isAfter(regularStart))
+            && time.isBefore(regularEnd)) {
+            return MarketStatus.OPEN;
+        }
+        else if ((time.equals(regularEnd) || time.isAfter(regularEnd))
+            && time.isBefore(postMarketEnd)) {
+            return MarketStatus.POST_MARKET;
+        }
+        else {
+            return MarketStatus.CLOSED;
+        }
+    }
+
+    @Override
+    public List<SymbolInfo> searchSymbols(String keyword, int limit) {
+        if (!properties.isReady()) {
+            return mockProvider.searchSymbols(keyword, limit);
+        }
+
+        try {
+            String url = UriComponentsBuilder
+                .fromUriString(properties.getBaseUrl() + "/search")
+                .queryParam("q", keyword)
+                .queryParam(QUERY_PARAM_TOKEN, properties.getApiKey())
+                .toUriString();
+
+            SearchResponse body = webClient
+                .method(Objects.requireNonNull(HttpMethod.GET))
+                .uri(url)
+                .retrieve()
+                .bodyToMono(SearchResponse.class)
+                .block();
+
+            if (body == null || body.result() == null) {
+                return Collections.emptyList();
+            }
+
+            return body.result().stream()
+                .filter(r -> r.type() != null && r.type().equals(STOCK_TYPE_COMMON))
+                .limit(limit)
+                .map(r -> new SymbolInfo(r.symbol(), r.description(),
+                    MarketType.US_STOCK.getCode(),
+                    r.exchange() != null ? r.exchange() : DEFAULT_EXCHANGE, SYMBOL_TYPE_STOCK))
+                .toList();
+
+        }
+        catch (WebClientResponseException e) {
+            LOG.error("Failed to search symbols from Finnhub: {}", e.getMessage());
+            return mockProvider.searchSymbols(keyword, limit);
+        }
+    }
+
+    // Helper methods
+
+    private String mapTimeframe(String timeframe) {
+        return switch (timeframe.toLowerCase(Locale.ROOT)) {
+            case TIMEFRAME_1M -> RESOLUTION_1;
+            case TIMEFRAME_5M -> RESOLUTION_5;
+            case TIMEFRAME_15M -> RESOLUTION_15;
+            case TIMEFRAME_30M -> RESOLUTION_30;
+            case TIMEFRAME_1H, TIMEFRAME_60M -> RESOLUTION_60;
+            case TIMEFRAME_1D, TIMEFRAME_DAILY -> RESOLUTION_D;
+            case TIMEFRAME_1W, TIMEFRAME_WEEKLY -> RESOLUTION_W;
+            case TIMEFRAME_1MTH, TIMEFRAME_MONTHLY -> RESOLUTION_M;
+            default -> RESOLUTION_D;
+        };
+    }
+
+    private List<KlineData> convertToKlineData(CandleResponse response, String symbol,
+        String timeframe, int limit) {
+        List<KlineData> klines = new ArrayList<>();
+
+        if (response.getT() == null || response.getT().isEmpty()) {
+            return klines;
+        }
+
+        int count = Math.min(response.getT().size(), limit);
+        for (int i = 0; i < count; i++) {
+            klines.add(KlineData.builder()
+                .symbol(symbol)
+                .market(MarketType.US_STOCK.getCode())
+                .timestamp(Instant.ofEpochSecond(response.getT().get(i)))
+                .open(BigDecimal.valueOf(response.getO().get(i)))
+                .high(BigDecimal.valueOf(response.getH().get(i)))
+                .low(BigDecimal.valueOf(response.getL().get(i)))
+                .close(BigDecimal.valueOf(response.getC().get(i)))
+                .volume(response.getV().get(i))
+                .amount(BigDecimal.valueOf(response.getC().get(i) * response.getV().get(i)))
+                .timeframe(timeframe)
+                .build());
+        }
+
+        return klines;
+    }
+
+    private boolean isMarketHoliday(LocalDate date) {
+        int month = date.getMonthValue();
+        int day = date.getDayOfMonth();
+        DayOfWeek dow = date.getDayOfWeek();
+
+        return isNewYearHoliday(month, day, dow)
+            || isIndependenceDayHoliday(month, day, dow)
+            || isChristmasHoliday(month, day, dow);
+    }
+
+    private boolean isNewYearHoliday(int month, int day, DayOfWeek dow) {
+        return month == JANUARY
+            && (day == NEW_YEAR_DAY
+            || (day == NEW_YEAR_DAY_ALT && dow == DayOfWeek.MONDAY));
+    }
+
+    private boolean isIndependenceDayHoliday(int month, int day, DayOfWeek dow) {
+        return month == JULY
+            && (day == INDEPENDENCE_DAY
+            || (day == INDEPENDENCE_DAY_EVE && dow == DayOfWeek.FRIDAY)
+            || (day == INDEPENDENCE_DAY_AFTER && dow == DayOfWeek.MONDAY));
+    }
+
+    private boolean isChristmasHoliday(int month, int day, DayOfWeek dow) {
+        return month == DECEMBER
+            && (day == CHRISTMAS_DAY
+            || (day == CHRISTMAS_EVE && dow == DayOfWeek.FRIDAY)
+            || (day == CHRISTMAS_AFTER && dow == DayOfWeek.MONDAY));
+    }
+
+    /**
+     * 获取已订阅的股票代码。
+     *
+     * @return 订阅的股票代码集合
+     */
+    public Set<String> getSubscribedSymbols() {
+        return new java.util.HashSet<>(subscribedSymbols);
+    }
+
+    // Finnhub API 响应类
+
+    /**
+     * K线数据响应。
+     */
+    @Getter
+    @Setter
+    static class CandleResponse {
+        /** Status. */
+        private String s;
+        /** Timestamps. */
+        private List<Long> t;
+        /** Open prices. */
+        private List<Double> o;
+        /** High prices. */
+        private List<Double> h;
+        /** Low prices. */
+        private List<Double> l;
+        /** Close prices. */
+        private List<Double> c;
+        /** Volumes. */
+        private List<Long> v;
+    }
+
+    /**
+     * 报价响应。
+     */
+    @Getter
+    @Setter
+    static class QuoteResponse {
+        /** Current price. */
+        private double c;
+        /** Change. */
+        private double d;
+        /** Change percent. */
+        private double dp;
+        /** High price. */
+        private double h;
+        /** Low price. */
+        private double l;
+        /** Open price. */
+        private double o;
+        /** Previous close. */
+        private double pc;
+        /** Timestamp. */
+        private long t;
+    }
+
+    /**
+     * 搜索响应。
+     *
+     * @param count 结果数量
+     * @param result 结果列表
+     */
+    record SearchResponse(int count, List<SearchResult> result) {
+    }
+
+    /**
+     * 搜索结果。
+     *
+     * @param description 描述
+     * @param displaySymbol 显示代码
+     * @param symbol 代码
+     * @param type 类型
+     * @param exchange 交易所
+     */
+    record SearchResult(String description, String displaySymbol, String symbol,
+        String type, String exchange) {
+    }
+
+}

--- a/koduck-backend/koduck-market/koduck-market-impl/src/main/java/com/koduck/market/service/KlineService.java
+++ b/koduck-backend/koduck-market/koduck-market-impl/src/main/java/com/koduck/market/service/KlineService.java
@@ -1,0 +1,84 @@
+package com.koduck.market.service;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+import com.koduck.market.dto.KlineDataDto;
+import com.koduck.market.entity.KlineData;
+
+/**
+ * K线数据操作服务接口。
+ *
+ * @author Koduck Team
+ */
+public interface KlineService {
+
+    /**
+     * 获取指定股票的K线数据。
+     * 缓存1分钟。
+     *
+     * @param market     市场代码
+     * @param symbol     股票代码
+     * @param timeframe  时间周期（例如 "1d", "1h"）
+     * @param limit      最大记录数
+     * @param beforeTime 查询该时间戳之前的数据
+     * @return K线数据DTO列表
+     */
+    List<KlineDataDto> getKlineData(String market, String symbol, String timeframe,
+                                    Integer limit, Long beforeTime);
+
+    /**
+     * 获取指定股票的最新价格。
+     * 缓存30秒。
+     *
+     * @param market    市场代码
+     * @param symbol    股票代码
+     * @param timeframe 时间周期
+     * @return 包含最新价格的Optional
+     */
+    Optional<BigDecimal> getLatestPrice(String market, String symbol, String timeframe);
+
+    /**
+     * 获取指定股票的前收盘价（昨日收盘价）。
+     * 用于计算涨跌幅。
+     * 缓存1分钟。
+     *
+     * @param market    市场代码
+     * @param symbol    股票代码
+     * @param timeframe 时间周期
+     * @return 包含前收盘价的Optional
+     */
+    Optional<BigDecimal> getPreviousClosePrice(String market, String symbol, String timeframe);
+
+    /**
+     * 获取指定股票的最新K线数据记录。
+     *
+     * @param market    市场代码
+     * @param symbol    股票代码
+     * @param timeframe 时间周期
+     * @return 包含最新K线数据的Optional
+     */
+    Optional<KlineData> getLatestKline(String market, String symbol, String timeframe);
+
+    /**
+     * 保存K线数据。
+     * 保存后清除该股票的缓存。
+     *
+     * @param dtos      K线数据DTO列表
+     * @param market    市场代码
+     * @param symbol    股票代码
+     * @param timeframe 时间周期
+     */
+    void saveKlineData(List<KlineDataDto> dtos, String market, String symbol, String timeframe);
+
+    /**
+     * 从周期别名或显式时间周期中规范化时间周期。
+     * <p>支持传统的周期别名（daily/weekly/monthly）和显式的时间周期值。</p>
+     *
+     * @param period    周期别名（daily/weekly/monthly），可能为null
+     * @param timeframe 显式时间周期（1D/1W/1M），可能为null
+     * @return 规范化后的时间周期
+     */
+    String normalizeTimeframe(String period, String timeframe);
+}

--- a/koduck-backend/koduck-market/koduck-market-impl/src/main/java/com/koduck/market/service/KlineSyncService.java
+++ b/koduck-backend/koduck-market/koduck-market-impl/src/main/java/com/koduck/market/service/KlineSyncService.java
@@ -1,0 +1,55 @@
+package com.koduck.market.service;
+
+import java.util.List;
+
+/**
+ * 从Python数据服务同步K线数据的服务。
+ *
+ * @author GitHub Copilot
+ */
+public interface KlineSyncService {
+
+    /**
+     * 同步热门股票的日K线数据。
+     * 在工作日收盘后（15:05）运行。
+     */
+    void syncDailyKlineData();
+
+    /**
+     * 同步指定股票的K线数据。
+     *
+     * @param market    市场标识
+     * @param symbol    股票代码
+     * @param timeframe K线时间周期
+     */
+    void syncSymbolKline(String market, String symbol, String timeframe);
+
+    /**
+     * 异步批量同步股票数据，使用固定间隔以避免上游限流。
+     *
+     * @param market    市场标识
+     * @param symbols   要同步的股票代码列表
+     * @param timeframe K线时间周期
+     */
+    void syncBatchSymbols(String market, List<String> symbols, String timeframe);
+
+    /**
+     * 请求异步K线同步，带飞行中去重。
+     *
+     * @param market    市场标识
+     * @param symbol    股票代码
+     * @param timeframe K线时间周期
+     * @return 如果启动新同步任务则返回true；如果跳过或已在运行则返回false
+     */
+    boolean requestSyncSymbolKline(String market, String symbol, String timeframe);
+
+    /**
+     * 回填新股票的历史数据。
+     *
+     * @param market    市场标识
+     * @param symbol    股票代码
+     * @param timeframe K线时间周期
+     * @param days      要回填的天数
+     */
+    void backfillHistoricalData(String market, String symbol, String timeframe, int days);
+}

--- a/koduck-backend/koduck-market/koduck-market-impl/src/main/java/com/koduck/market/service/StockCacheService.java
+++ b/koduck-backend/koduck-market/koduck-market-impl/src/main/java/com/koduck/market/service/StockCacheService.java
@@ -1,0 +1,77 @@
+package com.koduck.market.service;
+
+import java.util.List;
+
+import com.koduck.market.dto.PriceQuoteDto;
+
+/**
+ * 股票数据缓存服务接口。
+ * 提供基于Redis的股票实时数据和K线数据缓存。
+ *
+ * @author GitHub Copilot
+ */
+public interface StockCacheService {
+
+    // ==================== 股票追踪 ====================
+
+    /**
+     * 缓存股票实时行情数据。
+     * 键：stock:track:{symbol}，TTL：10秒
+     *
+     * @param symbol 股票代码
+     * @param quote  行情报价数据
+     */
+    void cacheStockTrack(String symbol, PriceQuoteDto quote);
+
+    /**
+     * 获取缓存的股票实时行情。
+     *
+     * @param symbol 股票代码
+     * @return 缓存的行情报价，如未找到则返回null
+     */
+    PriceQuoteDto getCachedStockTrack(String symbol);
+
+    /**
+     * 获取多只股票缓存的行情。
+     *
+     * @param symbols 股票代码列表
+     * @return 行情报价列表
+     */
+    List<PriceQuoteDto> getCachedStockTracks(List<String> symbols);
+
+    // ==================== 热门股票 ====================
+
+    /**
+     * 缓存热门股票列表。
+     * 键：hot:stocks:{type}，TTL：60秒
+     *
+     * @param type    热门股票类型（volume, gain, loss）
+     * @param symbols 股票代码列表
+     */
+    void cacheHotStocks(String type, List<String> symbols);
+
+    /**
+     * 获取缓存的热门股票列表。
+     *
+     * @param type 热门股票类型（volume, gain, loss）
+     * @return 股票代码列表，如未找到则返回null
+     */
+    List<String> getCachedHotStocks(String type);
+
+    // ==================== 批量操作 ====================
+
+    /**
+     * 批量缓存股票行情。
+     *
+     * @param quotes 行情报价列表
+     */
+    void cacheBatchStockTracks(List<PriceQuoteDto> quotes);
+
+    /**
+     * 检查股票数据是否已缓存。
+     *
+     * @param symbol 股票代码
+     * @return 如果已缓存则返回true
+     */
+    boolean isStockTrackCached(String symbol);
+}

--- a/koduck-backend/koduck-market/koduck-market-impl/src/main/java/com/koduck/market/service/StockSubscriptionService.java
+++ b/koduck-backend/koduck-market/koduck-market-impl/src/main/java/com/koduck/market/service/StockSubscriptionService.java
@@ -1,0 +1,222 @@
+package com.koduck.market.service;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import com.koduck.market.dto.PriceUpdateDto;
+
+/**
+ * 用户股票订阅管理服务接口。
+ * 提供订阅/取消订阅股票价格更新的功能。
+ *
+ * <p>使用线程安全的集合（ConcurrentHashMap）管理双向映射：</p>
+ * <ul>
+ *   <li>用户订阅（userId -> Set&lt;symbol&gt;）</li>
+ *   <li>股票订阅者（symbol -> Set&lt;userId&gt;）</li>
+ *   <li>实时价格分发</li>
+ * </ul>
+ *
+ * @author Koduck Team
+ */
+public interface StockSubscriptionService {
+
+    /**
+     * 订阅用户到股票代码。
+     *
+     * @param userId  用户ID
+     * @param symbols 要订阅的股票代码列表
+     * @return 订阅结果，包含成功和失败的股票代码
+     */
+    SubscribeResult subscribe(Long userId, List<String> symbols);
+
+    /**
+     * 取消订阅用户从股票代码。
+     *
+     * @param userId  用户ID
+     * @param symbols 要取消订阅的股票代码列表
+     * @return 订阅结果，包含成功和失败的股票代码
+     */
+    SubscribeResult unsubscribe(Long userId, List<String> symbols);
+
+    /**
+     * 获取某只股票的所有订阅者。
+     *
+     * @param symbol 股票代码
+     * @return 订阅者用户ID集合
+     */
+    Set<Long> getSubscribers(String symbol);
+
+    /**
+     * 获取用户的所有订阅。
+     *
+     * @param userId 用户ID
+     * @return 已订阅的股票代码集合
+     */
+    Set<String> getUserSubscriptions(Long userId);
+
+    /**
+     * 获取所有用户订阅的股票代码。
+     *
+     * @return 所有已订阅的股票代码集合
+     */
+    Set<String> getAllSubscribedSymbols();
+
+    /**
+     * 处理价格更新事件。
+     *
+     * @param priceUpdate 价格更新数据
+     */
+    void onPriceUpdate(PriceUpdateDto priceUpdate);
+
+    /**
+     * 处理用户断开连接事件。
+     *
+     * @param userId 用户ID
+     */
+    void onUserDisconnect(Long userId);
+
+    /**
+     * 订阅/取消订阅操作的结果。
+     */
+    class SubscribeResult {
+        /** 成功处理的股票代码列表。 */
+        private final List<String> success;
+
+        /** 失败的股票代码到错误原因的映射。 */
+        private final Map<String, String> failed;
+
+        /**
+         * 构造SubscribeResult。
+         *
+         * @param success 成功的股票代码列表
+         * @param failed  失败的股票代码到原因的映射
+         */
+        public SubscribeResult(List<String> success, Map<String, String> failed) {
+            this.success = success == null ? List.of() : List.copyOf(success);
+            this.failed = failed == null ? Map.of() : Map.copyOf(new HashMap<>(failed));
+        }
+
+        /**
+         * 获取成功的股票代码列表。
+         *
+         * @return 成功的股票代码列表
+         */
+        public List<String> getSuccess() {
+            return List.copyOf(success);
+        }
+
+        /**
+         * 获取失败的股票代码映射。
+         *
+         * @return 失败的股票代码到原因的映射
+         */
+        public Map<String, String> getFailed() {
+            return Map.copyOf(failed);
+        }
+
+        /**
+         * 为给定的股票代码创建失败结果。
+         *
+         * @param symbols 失败的股票代码
+         * @param reason  失败原因
+         * @return 所有股票代码都标记为失败的SubscribeResult
+         */
+        public static SubscribeResult failure(List<String> symbols, String reason) {
+            Map<String, String> failed = new HashMap<>();
+            if (symbols != null) {
+                symbols.forEach(s -> failed.put(s, reason));
+            }
+            return new SubscribeResult(Collections.emptyList(), failed);
+        }
+
+        /**
+         * 检查是否有失败。
+         *
+         * @return 如果有失败的股票代码则返回true
+         */
+        public boolean hasFailures() {
+            return !failed.isEmpty();
+        }
+    }
+
+    /**
+     * 包含用于WebSocket传输的价格更新数据的消息。
+     */
+    class PriceUpdateMessage {
+        /** 消息类型。 */
+        private String type;
+
+        /** 消息时间戳。 */
+        private String timestamp;
+
+        /** 价格数据。 */
+        private PriceUpdateDto data;
+
+        /**
+         * 获取消息类型。
+         *
+         * @return 类型
+         */
+        public String getType() {
+            return type;
+        }
+
+        /**
+         * 设置消息类型。
+         *
+         * @param type 类型
+         */
+        public void setType(String type) {
+            this.type = type;
+        }
+
+        /**
+         * 获取时间戳。
+         *
+         * @return 时间戳
+         */
+        public String getTimestamp() {
+            return timestamp;
+        }
+
+        /**
+         * 设置时间戳。
+         *
+         * @param timestamp 时间戳
+         */
+        public void setTimestamp(String timestamp) {
+            this.timestamp = timestamp;
+        }
+
+        /**
+         * 获取价格数据。
+         *
+         * @return 价格数据（防御性拷贝）
+         */
+        public PriceUpdateDto getData() {
+            if (data == null) {
+                return null;
+            }
+            return PriceUpdateDto.builder()
+                    .symbol(data.symbol())
+                    .name(data.name())
+                    .price(data.price())
+                    .change(data.change())
+                    .changePercent(data.changePercent())
+                    .volume(data.volume())
+                    .build();
+        }
+
+        /**
+         * 设置价格数据。
+         *
+         * @param data 价格数据
+         */
+        public void setData(PriceUpdateDto data) {
+            this.data = data;
+        }
+    }
+}

--- a/koduck-backend/koduck-market/koduck-market-impl/src/main/java/com/koduck/market/service/SyntheticTickService.java
+++ b/koduck-backend/koduck-market/koduck-market-impl/src/main/java/com/koduck/market/service/SyntheticTickService.java
@@ -1,0 +1,47 @@
+package com.koduck.market.service;
+
+import java.util.List;
+import java.util.Set;
+
+import com.koduck.market.dto.TickDto;
+import com.koduck.market.entity.StockRealtime;
+
+/**
+ * 合成Tick服务接口。
+ * 提供股票实时数据追踪和合成Tick生成功能。
+ *
+ * @author GitHub Copilot
+ */
+public interface SyntheticTickService {
+
+    /**
+     * 追踪指定股票代码。
+     *
+     * @param symbol 股票代码
+     */
+    void trackSymbol(String symbol);
+
+    /**
+     * 获取当前追踪的股票代码快照。
+     *
+     * @return 追踪的股票代码集合
+     */
+    Set<String> snapshotTrackedSymbols();
+
+    /**
+     * 从实时数据追加合成Tick。
+     *
+     * @param realtime 实时股票数据
+     * @return Tick数据传输对象
+     */
+    TickDto appendSyntheticTickFromRealtime(StockRealtime realtime);
+
+    /**
+     * 获取指定股票的最新Tick数据。
+     *
+     * @param symbol 股票代码
+     * @param limit  返回记录数限制
+     * @return Tick数据传输对象列表
+     */
+    List<TickDto> getLatestTicks(String symbol, int limit);
+}

--- a/koduck-backend/koduck-market/koduck-market-impl/src/main/java/com/koduck/market/service/TechnicalIndicatorService.java
+++ b/koduck-backend/koduck-market/koduck-market-impl/src/main/java/com/koduck/market/service/TechnicalIndicatorService.java
@@ -1,0 +1,31 @@
+package com.koduck.market.service;
+
+import com.koduck.market.dto.indicator.IndicatorListResponse;
+import com.koduck.market.dto.indicator.IndicatorResponse;
+
+/**
+ * 技术指标计算服务接口。
+ *
+ * @author koduck
+ */
+public interface TechnicalIndicatorService {
+
+    /**
+     * 获取可用指标。
+     *
+     * @return 可用技术指标列表
+     */
+    IndicatorListResponse getAvailableIndicators();
+
+    /**
+     * 计算指定股票的技术指标。
+     *
+     * @param market    市场标识
+     * @param symbol    股票代码
+     * @param indicator 指标名称
+     * @param period    计算周期
+     * @return 计算后的指标响应
+     */
+    IndicatorResponse calculateIndicator(
+            String market, String symbol, String indicator, Integer period);
+}

--- a/koduck-backend/koduck-market/koduck-market-impl/src/main/java/com/koduck/market/service/TickStreamService.java
+++ b/koduck-backend/koduck-market/koduck-market-impl/src/main/java/com/koduck/market/service/TickStreamService.java
@@ -1,0 +1,12 @@
+package com.koduck.market.service;
+
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import com.koduck.market.dto.TickDto;
+
+public interface TickStreamService {
+
+    SseEmitter subscribe(String symbol);
+
+    void publishTick(String symbol, TickDto tick);
+}

--- a/koduck-backend/koduck-market/koduck-market-impl/src/main/java/com/koduck/market/service/support/AKShareDataMapperSupport.java
+++ b/koduck-backend/koduck-market/koduck-market-impl/src/main/java/com/koduck/market/service/support/AKShareDataMapperSupport.java
@@ -1,0 +1,201 @@
+package com.koduck.market.service.support;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import com.koduck.common.constants.MapKeyConstants;
+import com.koduck.common.constants.MarketConstants;
+import com.koduck.market.dto.PriceQuoteDto;
+import com.koduck.market.dto.StockIndustryDto;
+import com.koduck.market.dto.StockValuationDto;
+import com.koduck.market.dto.SymbolInfoDto;
+import com.koduck.market.MarketType;
+import com.koduck.market.model.KlineData;
+import com.koduck.market.provider.MarketDataProvider;
+import com.koduck.market.util.DataConverter;
+
+/**
+ * Mapping helpers for AKShare payload conversion.
+ *
+ * @author Koduck Team
+ */
+public final class AKShareDataMapperSupport {
+
+    /** The key for symbol field. */
+    private static final String KEY_SYMBOL = MapKeyConstants.KEY_SYMBOL;
+
+    /** The key for name field. */
+    private static final String KEY_NAME = MapKeyConstants.KEY_NAME;
+
+    /** The key for volume field. */
+    private static final String KEY_VOLUME = "volume";
+
+    /** The key for amount field. */
+    private static final String KEY_AMOUNT = "amount";
+
+    private AKShareDataMapperSupport() {
+    }
+
+    public static List<KlineData> parseKlineResponse(List<Map<String, Object>> responseData) {
+        if (responseData == null) {
+            return Collections.emptyList();
+        }
+        return responseData.stream().map(AKShareDataMapperSupport::mapToKlineData).toList();
+    }
+
+    public static List<MarketDataProvider.SymbolInfo> parseSymbolInfoResponse(List<Map<String, Object>> responseData) {
+        if (responseData == null) {
+            return Collections.emptyList();
+        }
+        return responseData.stream().map(AKShareDataMapperSupport::mapToSymbolInfo).toList();
+    }
+
+    public static List<SymbolInfoDto> parseSymbolListResponse(List<Map<String, Object>> responseData) {
+        if (responseData == null) {
+            return Collections.emptyList();
+        }
+        return responseData.stream().map(AKShareDataMapperSupport::mapToSymbolInfoDto).toList();
+    }
+
+    public static PriceQuoteDto parsePriceQuoteResponse(Map<String, Object> responseData) {
+        if (responseData == null) {
+            return null;
+        }
+        return mapToPriceQuoteDto(responseData);
+    }
+
+    public static StockValuationDto parseStockValuationResponse(Map<String, Object> responseData) {
+        if (responseData == null) {
+            return null;
+        }
+        return mapToStockValuationDto(responseData);
+    }
+
+    public static StockIndustryDto parseStockIndustryResponse(Map<String, Object> responseData) {
+        if (responseData == null) {
+            return null;
+        }
+        return mapToStockIndustryDto(responseData);
+    }
+
+    public static PriceQuoteDto mapToPriceQuoteDto(Map<String, Object> data) {
+        return PriceQuoteDto.builder()
+            .symbol(MarketDataMapReader.getString(data, KEY_SYMBOL))
+            .name(MarketDataMapReader.getString(data, KEY_NAME))
+            .type(Optional.ofNullable(MarketDataMapReader.getString(data, "type"))
+                .orElse(MarketConstants.STOCK_TYPE))
+            .price(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "price")))
+            .open(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "open")))
+            .high(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "high")))
+            .low(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "low")))
+            .prevClose(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "prev_close")))
+            .volume(MarketDataMapReader.getLong(data, KEY_VOLUME))
+            .amount(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, KEY_AMOUNT)))
+            .change(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "change")))
+            .changePercent(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "change_percent")))
+            .bidPrice(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "bid_price")))
+            .bidVolume(MarketDataMapReader.getLong(data, "bid_volume"))
+            .askPrice(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "ask_price")))
+            .askVolume(MarketDataMapReader.getLong(data, "ask_volume"))
+            .timestamp(getInstant(data, "timestamp"))
+            .build();
+    }
+
+    private static KlineData mapToKlineData(Map<String, Object> data) {
+        return KlineData.builder()
+            .symbol(MarketDataMapReader.getString(data, KEY_SYMBOL))
+            .market(MarketType.A_SHARE.getCode())
+            .timestamp(DataConverter.toInstantFromMillis(MarketDataMapReader.getLong(data, "timestamp")))
+            .open(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "open")))
+            .high(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "high")))
+            .low(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "low")))
+            .close(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "close")))
+            .volume(MarketDataMapReader.getLong(data, KEY_VOLUME))
+            .amount(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, KEY_AMOUNT)))
+            .timeframe(MarketDataMapReader.getString(data, "timeframe"))
+            .build();
+    }
+
+    private static MarketDataProvider.SymbolInfo mapToSymbolInfo(Map<String, Object> data) {
+        String normalizedSymbol = DataConverter.normalizeSymbol(
+            MarketDataMapReader.getString(data, KEY_SYMBOL),
+            MarketType.A_SHARE.getCode());
+        return new MarketDataProvider.SymbolInfo(
+            normalizedSymbol,
+            MarketDataMapReader.getString(data, KEY_NAME),
+            MarketType.A_SHARE.getCode(),
+            resolveExchange(normalizedSymbol),
+            "stock"
+        );
+    }
+
+    private static SymbolInfoDto mapToSymbolInfoDto(Map<String, Object> data) {
+        return SymbolInfoDto.builder()
+            .symbol(MarketDataMapReader.getString(data, KEY_SYMBOL))
+            .name(MarketDataMapReader.getString(data, KEY_NAME))
+            .type(Optional.ofNullable(MarketDataMapReader.getString(data, "type"))
+                .orElse(MarketConstants.STOCK_TYPE))
+            .market(MarketDataMapReader.getString(data, "market"))
+            .price(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "price")))
+            .changePercent(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "change_percent")))
+            .volume(MarketDataMapReader.getLong(data, KEY_VOLUME))
+            .amount(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, KEY_AMOUNT)))
+            .build();
+    }
+
+    private static StockValuationDto mapToStockValuationDto(Map<String, Object> data) {
+        return StockValuationDto.builder()
+            .symbol(MarketDataMapReader.getString(data, KEY_SYMBOL))
+            .name(MarketDataMapReader.getString(data, KEY_NAME))
+            .peTtm(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "pe_ttm")))
+            .pb(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "pb")))
+            .psTtm(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "ps_ttm")))
+            .marketCap(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "market_cap")))
+            .floatMarketCap(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "float_market_cap")))
+            .totalShares(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "total_shares")))
+            .floatShares(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "float_shares")))
+            .floatRatio(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "float_ratio")))
+            .turnoverRate(DataConverter.toBigDecimal(MarketDataMapReader.getString(data, "turnover_rate")))
+            .build();
+    }
+
+    private static StockIndustryDto mapToStockIndustryDto(Map<String, Object> data) {
+        return StockIndustryDto.builder()
+            .symbol(MarketDataMapReader.getString(data, KEY_SYMBOL))
+            .name(MarketDataMapReader.getString(data, KEY_NAME))
+            .industry(MarketDataMapReader.getString(data, "industry"))
+            .sector(MarketDataMapReader.getString(data, "sector"))
+            .subIndustry(MarketDataMapReader.getString(data, "sub_industry"))
+            .board(MarketDataMapReader.getString(data, "board"))
+            .build();
+    }
+
+    private static Instant getInstant(Map<String, Object> data, String key) {
+        Object value = data.get(key);
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof String timestamp) {
+            try {
+                return Instant.parse(timestamp);
+            }
+            catch (Exception _) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    private static String resolveExchange(String normalizedSymbol) {
+        if (normalizedSymbol.contains(".SH")) {
+            return "SH";
+        }
+        if (normalizedSymbol.contains(".SZ")) {
+            return "SZ";
+        }
+        return "CN";
+    }
+}

--- a/koduck-backend/koduck-market/koduck-market-impl/src/main/java/com/koduck/market/service/support/FuturesMockDataSupport.java
+++ b/koduck-backend/koduck-market/koduck-market-impl/src/main/java/com/koduck/market/service/support/FuturesMockDataSupport.java
@@ -1,0 +1,405 @@
+package com.koduck.market.service.support;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.DayOfWeek;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+
+import com.koduck.market.MarketType;
+import com.koduck.market.model.KlineData;
+import com.koduck.market.model.TickData;
+import com.koduck.market.provider.MarketDataProvider;
+
+/**
+ * Mock data helper class for futures provider fallback and local search.
+ *
+ * @author Koduck Team
+ */
+public final class FuturesMockDataSupport {
+
+    /** Default exchange code. */
+    private static final String DEFAULT_EXCHANGE = "SHFE";
+    /** Dalian Commodity Exchange code. */
+    private static final String EXCHANGE_DCE = "DCE";
+    /** China Financial Futures Exchange code. */
+    private static final String EXCHANGE_CFFEX = "CFFEX";
+    /** Minimum volume for kline data. */
+    private static final long KLINE_VOLUME_MIN = 1_000L;
+    /** Maximum exclusive volume for kline data. */
+    private static final long KLINE_VOLUME_MAX_EXCLUSIVE = 100_000L;
+    /** Minimum volume for tick data. */
+    private static final long TICK_VOLUME_MIN = 10_000L;
+    /** Maximum exclusive volume for tick data. */
+    private static final long TICK_VOLUME_MAX_EXCLUSIVE = 500_000L;
+    /** Minimum volume for order book. */
+    private static final long ORDER_BOOK_VOLUME_MIN = 10L;
+    /** Maximum exclusive volume for order book. */
+    private static final long ORDER_BOOK_VOLUME_MAX_EXCLUSIVE = 1_000L;
+    /** Volatility for gold futures. */
+    private static final double VOLATILITY_GOLD = 0.008;
+    /** Default volatility for futures. */
+    private static final double VOLATILITY_DEFAULT = 0.015;
+    /** Price change multiplier for random generation. */
+    private static final double PRICE_CHANGE_MULTIPLIER = 0.5;
+    /** Change percent range for tick data. */
+    private static final double CHANGE_PERCENT_RANGE = 0.02;
+    /** High/low price range multiplier. */
+    private static final double HIGH_LOW_RANGE = 0.02;
+    /** Decimal scale for division operations. */
+    private static final int DIVIDE_SCALE = 4;
+    /** Multiplier to convert to percentage. */
+    private static final double PERCENT_MULTIPLIER = 100.0;
+    /** Gold futures symbol prefix. */
+    private static final String PREFIX_AU = "AU";
+    /** Gold commodity symbol. */
+    private static final String SYMBOL_GC = "GC";
+    /** Tick size for gold futures. */
+    private static final BigDecimal TICK_SIZE_GOLD = new BigDecimal("0.02");
+    /** Default tick size. */
+    private static final BigDecimal TICK_SIZE_DEFAULT = BigDecimal.ONE;
+    /** First session start hour. */
+    private static final int SESSION_START_HOUR_1 = 9;
+    /** First session start minute. */
+    private static final int SESSION_START_MINUTE_1 = 0;
+    /** First session end hour. */
+    private static final int SESSION_END_HOUR_1 = 10;
+    /** First session end minute. */
+    private static final int SESSION_END_MINUTE_1 = 15;
+    /** Second session start hour. */
+    private static final int SESSION_START_HOUR_2 = 10;
+    /** Second session start minute. */
+    private static final int SESSION_START_MINUTE_2 = 30;
+    /** Second session end hour. */
+    private static final int SESSION_END_HOUR_2 = 11;
+    /** Second session end minute. */
+    private static final int SESSION_END_MINUTE_2 = 30;
+    /** Third session start hour. */
+    private static final int SESSION_START_HOUR_3 = 13;
+    /** Third session start minute. */
+    private static final int SESSION_START_MINUTE_3 = 30;
+    /** Third session end hour. */
+    private static final int SESSION_END_HOUR_3 = 15;
+    /** Third session end minute. */
+    private static final int SESSION_END_MINUTE_3 = 0;
+    /** Night session start hour. */
+    private static final int NIGHT_SESSION_START_HOUR = 21;
+    /** Night session end hour. */
+    private static final int NIGHT_SESSION_END_HOUR = 2;
+    /** Night session end minute. */
+    private static final int NIGHT_SESSION_END_MINUTE = 30;
+    /** First break start hour. */
+    private static final int BREAK_START_HOUR_1 = 10;
+    /** First break start minute. */
+    private static final int BREAK_START_MINUTE_1 = 15;
+    /** First break end hour. */
+    private static final int BREAK_END_HOUR_1 = 10;
+    /** First break end minute. */
+    private static final int BREAK_END_MINUTE_1 = 30;
+    /** Second break start hour. */
+    private static final int BREAK_START_HOUR_2 = 11;
+    /** Second break start minute. */
+    private static final int BREAK_START_MINUTE_2 = 30;
+    /** Second break end hour. */
+    private static final int BREAK_END_HOUR_2 = 13;
+    /** Second break end minute. */
+    private static final int BREAK_END_MINUTE_2 = 30;
+    /** Third break start hour. */
+    private static final int BREAK_START_HOUR_3 = 15;
+    /** Third break start minute. */
+    private static final int BREAK_START_MINUTE_3 = 0;
+    /** Third break end hour. */
+    private static final int BREAK_END_HOUR_3 = 21;
+    /** Third break end minute. */
+    private static final int BREAK_END_MINUTE_3 = 0;
+    /** Initial capacity for price maps. */
+    private static final int INITIAL_CAPACITY = 25;
+
+    private FuturesMockDataSupport() {
+    }
+
+    /**
+     * Gets default base prices.
+     *
+     * @return mapping from symbol to price
+     */
+    public static Map<String, BigDecimal> defaultBasePrices() {
+        Map<String, BigDecimal> basePrices = new LinkedHashMap<>(INITIAL_CAPACITY);
+        basePrices.put("AU2412", new BigDecimal("480.00"));
+        basePrices.put("AG2412", new BigDecimal("5800.00"));
+        basePrices.put("CU2412", new BigDecimal("68000.00"));
+        basePrices.put("AL2412", new BigDecimal("19200.00"));
+        basePrices.put("ZN2412", new BigDecimal("23500.00"));
+        basePrices.put("NI2412", new BigDecimal("128000.00"));
+        basePrices.put("RB2412", new BigDecimal("3500.00"));
+        basePrices.put("HC2412", new BigDecimal("3650.00"));
+        basePrices.put("I2501", new BigDecimal("780.00"));
+        basePrices.put("A2501", new BigDecimal("4200.00"));
+        basePrices.put("M2501", new BigDecimal("3200.00"));
+        basePrices.put("Y2501", new BigDecimal("7500.00"));
+        basePrices.put("P2501", new BigDecimal("7200.00"));
+        basePrices.put("IF2412", new BigDecimal("3800.00"));
+        basePrices.put("IH2412", new BigDecimal("2550.00"));
+        basePrices.put("IC2412", new BigDecimal("5600.00"));
+        basePrices.put("IM2412", new BigDecimal("6200.00"));
+        basePrices.put("T2412", new BigDecimal("104.50"));
+        basePrices.put("TF2412", new BigDecimal("103.20"));
+        basePrices.put("GC", new BigDecimal("2150.00"));
+        basePrices.put("SI", new BigDecimal("24.50"));
+        basePrices.put("CL", new BigDecimal("78.50"));
+        basePrices.put("ES", new BigDecimal("5800.00"));
+        basePrices.put("NQ", new BigDecimal("20500.00"));
+        return basePrices;
+    }
+
+    /**
+     * Generates mock K-line data.
+     *
+     * @param normalizedSymbol normalized symbol
+     * @param timeframe time period
+     * @param limit count limit
+     * @param endTime end time
+     * @param basePrices base prices
+     * @return K-line data list
+     */
+    public static List<KlineData> generateMockKlineData(String normalizedSymbol,
+        String timeframe, int limit, Instant endTime,
+        Map<String, BigDecimal> basePrices) {
+        List<KlineData> klines = new ArrayList<>();
+        BigDecimal basePrice = basePrices.getOrDefault(normalizedSymbol,
+            new BigDecimal("5000.00"));
+
+        Instant currentTime = endTime != null ? endTime : Instant.now();
+        Duration interval = MarketTimeframeParser.parseWithTwoAndFourHour(timeframe);
+
+        double volatility = normalizedSymbol.startsWith(PREFIX_AU)
+            || normalizedSymbol.equals(SYMBOL_GC)
+            ? VOLATILITY_GOLD : VOLATILITY_DEFAULT;
+
+        BigDecimal currentPrice = basePrice;
+        for (int i = 0; i < limit; i++) {
+            double changePercent = (Math.random() - PRICE_CHANGE_MULTIPLIER) * volatility * 2;
+            BigDecimal change = currentPrice.multiply(BigDecimal.valueOf(changePercent));
+            BigDecimal close = currentPrice.add(change);
+
+            BigDecimal high = close.multiply(BigDecimal.valueOf(1 + Math.random() * volatility));
+            BigDecimal low = close.multiply(BigDecimal.valueOf(1 - Math.random() * volatility));
+
+            long volume = ThreadLocalRandom.current().nextLong(KLINE_VOLUME_MIN,
+                KLINE_VOLUME_MAX_EXCLUSIVE);
+
+            klines.add(KlineData.builder()
+                .symbol(normalizedSymbol)
+                .market(MarketType.FUTURES.getCode())
+                .timestamp(currentTime)
+                .open(currentPrice)
+                .high(high)
+                .low(low)
+                .close(close)
+                .volume(volume)
+                .amount(close.multiply(BigDecimal.valueOf(volume)))
+                .timeframe(timeframe)
+                .build());
+
+            currentPrice = close;
+            currentTime = currentTime.minus(interval);
+        }
+
+        Collections.reverse(klines);
+        return klines;
+    }
+
+    /**
+     * Generates mock Tick data.
+     *
+     * @param normalizedSymbol normalized symbol
+     * @param basePrices base prices
+     * @return Tick data
+     */
+    public static TickData generateMockTickData(String normalizedSymbol,
+        Map<String, BigDecimal> basePrices) {
+        BigDecimal basePrice = basePrices.getOrDefault(normalizedSymbol,
+            new BigDecimal("5000.00"));
+
+        double changePercent = (Math.random() - PRICE_CHANGE_MULTIPLIER) * CHANGE_PERCENT_RANGE;
+        BigDecimal price = basePrice.multiply(BigDecimal.valueOf(1 + changePercent));
+        BigDecimal change = price.subtract(basePrice);
+        BigDecimal changePercentValue = change.divide(basePrice, DIVIDE_SCALE, RoundingMode.HALF_UP)
+            .multiply(BigDecimal.valueOf(PERCENT_MULTIPLIER));
+
+        long volume = ThreadLocalRandom.current().nextLong(TICK_VOLUME_MIN,
+            TICK_VOLUME_MAX_EXCLUSIVE);
+        BigDecimal tickSize = normalizedSymbol.startsWith(PREFIX_AU)
+            || normalizedSymbol.equals(SYMBOL_GC)
+            ? TICK_SIZE_GOLD : TICK_SIZE_DEFAULT;
+
+        return TickData.builder()
+            .symbol(normalizedSymbol)
+            .market(MarketType.FUTURES.getCode())
+            .timestamp(Instant.now())
+            .price(price)
+            .change(change)
+            .changePercent(changePercentValue)
+            .volume(volume)
+            .amount(price.multiply(BigDecimal.valueOf(volume)))
+            .bidPrice(price.subtract(tickSize))
+            .bidVolume(ThreadLocalRandom.current().nextLong(ORDER_BOOK_VOLUME_MIN,
+                ORDER_BOOK_VOLUME_MAX_EXCLUSIVE))
+            .askPrice(price.add(tickSize))
+            .askVolume(ThreadLocalRandom.current().nextLong(ORDER_BOOK_VOLUME_MIN,
+                ORDER_BOOK_VOLUME_MAX_EXCLUSIVE))
+            .dayHigh(price.multiply(BigDecimal.valueOf(1 + HIGH_LOW_RANGE)))
+            .dayLow(price.multiply(BigDecimal.valueOf(1 - HIGH_LOW_RANGE)))
+            .open(basePrice)
+            .prevClose(basePrice)
+            .build();
+    }
+
+    /**
+     * Generates mock search results.
+     *
+     * @param keyword keyword
+     * @param limit limit count
+     * @return search results list
+     */
+    public static List<MarketDataProvider.SymbolInfo> generateMockSearchResults(
+        String keyword, int limit) {
+        List<MarketDataProvider.SymbolInfo> results = new ArrayList<>();
+        String upperKeyword = keyword.toUpperCase(Locale.ROOT);
+
+        Map<String, String> shfeFutures = new LinkedHashMap<>();
+        shfeFutures.put("AU2412", "上海黄金期货 (Gold)");
+        shfeFutures.put("AG2412", "上海白银期货 (Silver)");
+        shfeFutures.put("CU2412", "上海铜期货 (Copper)");
+        shfeFutures.put("AL2412", "上海铝期货 (Aluminum)");
+        shfeFutures.put("ZN2412", "上海锌期货 (Zinc)");
+        shfeFutures.put("NI2412", "上海镍期货 (Nickel)");
+        shfeFutures.put("RB2412", "螺纹钢期货 (Rebar)");
+        shfeFutures.put("HC2412", "热轧卷板期货 (HRC)");
+
+        Map<String, String> dceFutures = new LinkedHashMap<>();
+        dceFutures.put("I2501", "铁矿石期货 (Iron Ore)");
+        dceFutures.put("A2501", "豆一期货 (Soybean No.1)");
+        dceFutures.put("M2501", "豆粕期货 (Soybean Meal)");
+        dceFutures.put("Y2501", "豆油期货 (Soybean Oil)");
+        dceFutures.put("P2501", "棕榈油期货 (Palm Oil)");
+
+        Map<String, String> cffexFutures = new LinkedHashMap<>();
+        cffexFutures.put("IF2412", "沪深300指数期货 (CSI300)");
+        cffexFutures.put("IH2412", "上证50指数期货 (SSE50)");
+        cffexFutures.put("IC2412", "中证500指数期货 (CSI500)");
+        cffexFutures.put("IM2412", "中证1000指数期货 (CSI1000)");
+        cffexFutures.put("T2412", "10年期国债期货 (10Y Treasury)");
+        cffexFutures.put("TF2412", "5年期国债期货 (5Y Treasury)");
+
+        Map<String, String> allFutures = new LinkedHashMap<>();
+        allFutures.putAll(shfeFutures);
+        allFutures.putAll(dceFutures);
+        allFutures.putAll(cffexFutures);
+
+        allFutures.entrySet().stream()
+            .filter(entry -> entry.getKey().contains(upperKeyword)
+                || entry.getValue().toUpperCase(Locale.ROOT).contains(upperKeyword))
+            .limit(limit)
+            .forEach(entry -> results.add(new MarketDataProvider.SymbolInfo(
+                entry.getKey(), entry.getValue(), MarketType.FUTURES.getCode(),
+                resolveExchange(entry.getKey(), shfeFutures, dceFutures), "futures")));
+
+        return results;
+    }
+
+    /**
+     * Resolves exchange or returns default.
+     *
+     * @param exchange exchange
+     * @return resolved exchange
+     */
+    public static String resolveExchangeOrDefault(String exchange) {
+        if (exchange == null || exchange.isBlank()) {
+            return DEFAULT_EXCHANGE;
+        }
+        return exchange;
+    }
+
+    /**
+     * Checks if weekend.
+     *
+     * @param dayOfWeek day of week
+     * @return true if weekend
+     */
+    public static boolean isWeekend(DayOfWeek dayOfWeek) {
+        return dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY;
+    }
+
+    /**
+     * Checks if day session time.
+     *
+     * @param time time
+     * @return true if day session
+     */
+    public static boolean isDaySession(LocalTime time) {
+        LocalTime session1Start = LocalTime.of(SESSION_START_HOUR_1, SESSION_START_MINUTE_1);
+        LocalTime session1End = LocalTime.of(SESSION_END_HOUR_1, SESSION_END_MINUTE_1);
+        LocalTime session2Start = LocalTime.of(SESSION_START_HOUR_2, SESSION_START_MINUTE_2);
+        LocalTime session2End = LocalTime.of(SESSION_END_HOUR_2, SESSION_END_MINUTE_2);
+        LocalTime session3Start = LocalTime.of(SESSION_START_HOUR_3, SESSION_START_MINUTE_3);
+        LocalTime session3End = LocalTime.of(SESSION_END_HOUR_3, SESSION_END_MINUTE_3);
+
+        return (time.isAfter(session1Start) && time.isBefore(session1End))
+            || (time.isAfter(session2Start) && time.isBefore(session2End))
+            || (time.isAfter(session3Start) && time.isBefore(session3End));
+    }
+
+    /**
+     * Checks if night session time.
+     *
+     * @param time time
+     * @return true if night session
+     */
+    public static boolean isNightSession(LocalTime time) {
+        LocalTime nightStart = LocalTime.of(NIGHT_SESSION_START_HOUR, 0);
+        LocalTime nightEnd = LocalTime.of(NIGHT_SESSION_END_HOUR, NIGHT_SESSION_END_MINUTE);
+        return time.isAfter(nightStart) || time.isBefore(nightEnd);
+    }
+
+    /**
+     * Checks if break session time.
+     *
+     * @param time time
+     * @return true if break session
+     */
+    public static boolean isBreakSession(LocalTime time) {
+        LocalTime break1Start = LocalTime.of(BREAK_START_HOUR_1, BREAK_START_MINUTE_1);
+        LocalTime break1End = LocalTime.of(BREAK_END_HOUR_1, BREAK_END_MINUTE_1);
+        LocalTime break2Start = LocalTime.of(BREAK_START_HOUR_2, BREAK_START_MINUTE_2);
+        LocalTime break2End = LocalTime.of(BREAK_END_HOUR_2, BREAK_END_MINUTE_2);
+        LocalTime break3Start = LocalTime.of(BREAK_START_HOUR_3, BREAK_START_MINUTE_3);
+        LocalTime break3End = LocalTime.of(BREAK_END_HOUR_3, BREAK_END_MINUTE_3);
+
+        return (time.equals(break1Start)
+            || (time.isAfter(break1Start) && time.isBefore(break1End)))
+            || (time.equals(break2Start)
+            || (time.isAfter(break2Start) && time.isBefore(break2End)))
+            || (time.equals(break3Start)
+            || (time.isAfter(break3Start) && time.isBefore(break3End)));
+    }
+
+    private static String resolveExchange(String symbol, Map<String, String> shfeFutures,
+        Map<String, String> dceFutures) {
+        if (shfeFutures.containsKey(symbol)) {
+            return DEFAULT_EXCHANGE;
+        }
+        if (dceFutures.containsKey(symbol)) {
+            return EXCHANGE_DCE;
+        }
+        return EXCHANGE_CFFEX;
+    }
+}

--- a/koduck-backend/koduck-market/koduck-market-impl/src/main/java/com/koduck/market/service/support/HKStockMarketCalendar.java
+++ b/koduck-backend/koduck-market/koduck-market-impl/src/main/java/com/koduck/market/service/support/HKStockMarketCalendar.java
@@ -1,0 +1,196 @@
+package com.koduck.market.service.support;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+/**
+ * Trading-session and holiday checks for Hong Kong stock market.
+ *
+ * @author GitHub Copilot
+ */
+public final class HKStockMarketCalendar {
+
+    /** Pre-market session start hour. */
+    private static final int PRE_MARKET_START_HOUR = 9;
+    /** Pre-market session start minute. */
+    private static final int PRE_MARKET_START_MINUTE = 0;
+    /** Pre-market session end hour. */
+    private static final int PRE_MARKET_END_HOUR = 9;
+    /** Pre-market session end minute. */
+    private static final int PRE_MARKET_END_MINUTE = 30;
+
+    /** Morning session start hour. */
+    private static final int MORNING_SESSION_START_HOUR = 9;
+    /** Morning session start minute. */
+    private static final int MORNING_SESSION_START_MINUTE = 30;
+    /** Morning session end hour. */
+    private static final int MORNING_SESSION_END_HOUR = 12;
+    /** Morning session end minute. */
+    private static final int MORNING_SESSION_END_MINUTE = 0;
+
+    /** Lunch break start hour. */
+    private static final int LUNCH_BREAK_START_HOUR = 12;
+    /** Lunch break start minute. */
+    private static final int LUNCH_BREAK_START_MINUTE = 0;
+    /** Lunch break end hour. */
+    private static final int LUNCH_BREAK_END_HOUR = 13;
+    /** Lunch break end minute. */
+    private static final int LUNCH_BREAK_END_MINUTE = 0;
+
+    /** Afternoon session start hour. */
+    private static final int AFTERNOON_SESSION_START_HOUR = 13;
+    /** Afternoon session start minute. */
+    private static final int AFTERNOON_SESSION_START_MINUTE = 0;
+    /** Afternoon session end hour. */
+    private static final int AFTERNOON_SESSION_END_HOUR = 16;
+    /** Afternoon session end minute. */
+    private static final int AFTERNOON_SESSION_END_MINUTE = 0;
+
+    /** Closing auction start hour. */
+    private static final int CLOSING_AUCTION_START_HOUR = 16;
+    /** Closing auction start minute. */
+    private static final int CLOSING_AUCTION_START_MINUTE = 0;
+    /** Closing auction end hour. */
+    private static final int CLOSING_AUCTION_END_HOUR = 16;
+    /** Closing auction end minute. */
+    private static final int CLOSING_AUCTION_END_MINUTE = 10;
+
+    /** February month number. */
+    private static final int FEBRUARY = 2;
+    /** April month number. */
+    private static final int APRIL = 4;
+    /** May month number. */
+    private static final int MAY = 5;
+    /** September month number. */
+    private static final int SEPTEMBER = 9;
+    /** October month number. */
+    private static final int OCTOBER = 10;
+    /** December month number. */
+    private static final int DECEMBER = 12;
+
+    /** Chinese New Year start day (approximate). */
+    private static final int CHINESE_NEW_YEAR_START_DAY = 10;
+    /** Chinese New Year end day (approximate). */
+    private static final int CHINESE_NEW_YEAR_END_DAY = 13;
+    /** Ching Ming Festival day. */
+    private static final int CHING_MING_DAY = 4;
+    /** Labour Day. */
+    private static final int LABOUR_DAY = 1;
+    /** Mid-Autumn Festival start day (approximate). */
+    private static final int MID_AUTUMN_START_DAY = 17;
+    /** Mid-Autumn Festival end day (approximate). */
+    private static final int MID_AUTUMN_END_DAY = 18;
+    /** National Day. */
+    private static final int NATIONAL_DAY = 1;
+    /** Christmas Day. */
+    private static final int CHRISTMAS_DAY = 25;
+    /** Boxing Day. */
+    private static final int BOXING_DAY = 26;
+
+    private HKStockMarketCalendar() {
+    }
+
+    /**
+     * Checks if the given day of week is a weekend.
+     *
+     * @param dayOfWeek the day of week to check
+     * @return true if Saturday or Sunday, false otherwise
+     */
+    public static boolean isWeekend(DayOfWeek dayOfWeek) {
+        return dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY;
+    }
+
+    /**
+     * Checks if the given time is during the pre-market session.
+     *
+     * @param time the time to check
+     * @return true if during pre-market hours (9:00-9:30), false otherwise
+     */
+    public static boolean isPreMarket(LocalTime time) {
+        return time.isAfter(LocalTime.of(PRE_MARKET_START_HOUR, PRE_MARKET_START_MINUTE))
+                && time.isBefore(LocalTime.of(PRE_MARKET_END_HOUR, PRE_MARKET_END_MINUTE));
+    }
+
+    /**
+     * Checks if the given time is during the morning session.
+     *
+     * @param time the time to check
+     * @return true if during morning session hours (9:30-12:00), false otherwise
+     */
+    public static boolean isMorningSession(LocalTime time) {
+        return isAtOrAfter(time, LocalTime.of(MORNING_SESSION_START_HOUR, MORNING_SESSION_START_MINUTE))
+                && time.isBefore(LocalTime.of(MORNING_SESSION_END_HOUR, MORNING_SESSION_END_MINUTE));
+    }
+
+    /**
+     * Checks if the given time is during the lunch break.
+     *
+     * @param time the time to check
+     * @return true if during lunch break hours (12:00-13:00), false otherwise
+     */
+    public static boolean isLunchBreak(LocalTime time) {
+        return isAtOrAfter(time, LocalTime.of(LUNCH_BREAK_START_HOUR, LUNCH_BREAK_START_MINUTE))
+                && time.isBefore(LocalTime.of(LUNCH_BREAK_END_HOUR, LUNCH_BREAK_END_MINUTE));
+    }
+
+    /**
+     * Checks if the given time is during the afternoon session.
+     *
+     * @param time the time to check
+     * @return true if during afternoon session hours (13:00-16:00), false otherwise
+     */
+    public static boolean isAfternoonSession(LocalTime time) {
+        return isAtOrAfter(time, LocalTime.of(AFTERNOON_SESSION_START_HOUR, AFTERNOON_SESSION_START_MINUTE))
+                && time.isBefore(LocalTime.of(AFTERNOON_SESSION_END_HOUR, AFTERNOON_SESSION_END_MINUTE));
+    }
+
+    /**
+     * Checks if the given time is during the closing auction session.
+     *
+     * @param time the time to check
+     * @return true if during closing auction hours (16:00-16:10), false otherwise
+     */
+    public static boolean isClosingAuction(LocalTime time) {
+        return isAtOrAfter(time, LocalTime.of(CLOSING_AUCTION_START_HOUR, CLOSING_AUCTION_START_MINUTE))
+                && time.isBefore(LocalTime.of(CLOSING_AUCTION_END_HOUR, CLOSING_AUCTION_END_MINUTE));
+    }
+
+    /**
+     * Checks if the given date is a public holiday in Hong Kong.
+     *
+     * @param date the date to check
+     * @return true if the date is a public holiday, false otherwise
+     */
+    public static boolean isPublicHoliday(LocalDate date) {
+        int month = date.getMonthValue();
+        int day = date.getDayOfMonth();
+        if (month == FEBRUARY && day >= CHINESE_NEW_YEAR_START_DAY && day <= CHINESE_NEW_YEAR_END_DAY) {
+            return true;
+        }
+        if (month == APRIL && day == CHING_MING_DAY) {
+            return true;
+        }
+        if (month == MAY && day == LABOUR_DAY) {
+            return true;
+        }
+        if (month == SEPTEMBER && day >= MID_AUTUMN_START_DAY && day <= MID_AUTUMN_END_DAY) {
+            return true;
+        }
+        if (month == OCTOBER && day == NATIONAL_DAY) {
+            return true;
+        }
+        return month == DECEMBER && (day == CHRISTMAS_DAY || day == BOXING_DAY);
+    }
+
+    /**
+     * Checks if the given time is at or after the threshold time.
+     *
+     * @param time the time to check
+     * @param threshold the threshold time
+     * @return true if time equals or is after threshold, false otherwise
+     */
+    private static boolean isAtOrAfter(LocalTime time, LocalTime threshold) {
+        return time.equals(threshold) || time.isAfter(threshold);
+    }
+}

--- a/koduck-backend/koduck-market/koduck-market-impl/src/main/java/com/koduck/market/service/support/MarketDataMapReader.java
+++ b/koduck-backend/koduck-market/koduck-market-impl/src/main/java/com/koduck/market/service/support/MarketDataMapReader.java
@@ -1,0 +1,36 @@
+package com.koduck.market.service.support;
+
+import java.util.Map;
+
+/**
+ * Utility methods for reading loosely-typed map payloads from market data-service responses.
+ *
+ * @author GitHub Copilot
+ */
+public final class MarketDataMapReader {
+
+    private MarketDataMapReader() {
+        // Prevent instantiation
+    }
+
+    public static String getString(Map<String, Object> data, String key) {
+        Object value = data.get(key);
+        return value != null ? value.toString() : null;
+    }
+
+    public static Long getLong(Map<String, Object> data, String key) {
+        Object value = data.get(key);
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof Number number) {
+            return number.longValue();
+        }
+        try {
+            return Long.parseLong(value.toString());
+        }
+        catch (NumberFormatException e) {
+            return null;
+        }
+    }
+}

--- a/koduck-backend/koduck-market/koduck-market-impl/src/main/java/com/koduck/market/service/support/MarketTimeframeParser.java
+++ b/koduck-backend/koduck-market/koduck-market-impl/src/main/java/com/koduck/market/service/support/MarketTimeframeParser.java
@@ -1,0 +1,62 @@
+package com.koduck.market.service.support;
+
+import java.time.Duration;
+import java.util.Locale;
+
+/**
+ * Shared timeframe parsing helpers used by market providers.
+ *
+ * @author Koduck Team
+ */
+public final class MarketTimeframeParser {
+
+    /** Number of minutes in a 5-minute interval. */
+    private static final int MINUTES_IN_5M = 5;
+
+    /** Number of minutes in a 15-minute interval. */
+    private static final int MINUTES_IN_15M = 15;
+
+    /** Number of minutes in a 30-minute interval. */
+    private static final int MINUTES_IN_30M = 30;
+
+    /** Number of days in a week. */
+    private static final int DAYS_IN_WEEK = 7;
+
+    /** Number of days in a month (approximate). */
+    private static final int DAYS_IN_MONTH = 30;
+
+    /** Number of hours in a 4-hour interval. */
+    private static final int HOURS_IN_4H = 4;
+
+    private MarketTimeframeParser() {
+    }
+
+    public static Duration parseStandard(String timeframe) {
+        return switch (timeframe.toLowerCase(Locale.ROOT)) {
+            case "1m" -> Duration.ofMinutes(1);
+            case "5m" -> Duration.ofMinutes(MINUTES_IN_5M);
+            case "15m" -> Duration.ofMinutes(MINUTES_IN_15M);
+            case "30m" -> Duration.ofMinutes(MINUTES_IN_30M);
+            case "1h", "60m" -> Duration.ofHours(1);
+            case "1d", "daily" -> Duration.ofDays(1);
+            case "1w", "weekly" -> Duration.ofDays(DAYS_IN_WEEK);
+            case "1mth", "monthly" -> Duration.ofDays(DAYS_IN_MONTH);
+            default -> Duration.ofDays(1);
+        };
+    }
+
+    public static Duration parseWithFourHour(String timeframe) {
+        return switch (timeframe.toLowerCase(Locale.ROOT)) {
+            case "4h" -> Duration.ofHours(HOURS_IN_4H);
+            default -> parseStandard(timeframe);
+        };
+    }
+
+    public static Duration parseWithTwoAndFourHour(String timeframe) {
+        return switch (timeframe.toLowerCase(Locale.ROOT)) {
+            case "2h" -> Duration.ofHours(2);
+            case "4h" -> Duration.ofHours(HOURS_IN_4H);
+            default -> parseStandard(timeframe);
+        };
+    }
+}

--- a/koduck-backend/koduck-market/koduck-market-impl/src/main/java/com/koduck/market/service/support/USStockMockDataProvider.java
+++ b/koduck-backend/koduck-market/koduck-market-impl/src/main/java/com/koduck/market/service/support/USStockMockDataProvider.java
@@ -1,0 +1,256 @@
+package com.koduck.market.service.support;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ThreadLocalRandom;
+
+import com.koduck.market.MarketType;
+import com.koduck.market.model.KlineData;
+import com.koduck.market.model.TickData;
+import com.koduck.market.provider.MarketDataProvider;
+
+/**
+ * Mock fallback provider for US stock data when upstream API is not available.
+ *
+ * @author GitHub Copilot
+ */
+public class USStockMockDataProvider {
+
+    /** Default health score for the provider. */
+    private static final int DEFAULT_HEALTH_SCORE = 50;
+
+    /** Random offset center for price change calculation. */
+    private static final double RANDOM_OFFSET_CENTER = 0.5;
+
+    /** Maximum kline price change percentage (4%). */
+    private static final double KLINE_MAX_CHANGE_PERCENT = 0.04;
+
+    /** Maximum high/low variation percentage (1%). */
+    private static final double HIGH_LOW_VARIATION_PERCENT = 0.01;
+
+    /** Minimum kline volume. */
+    private static final long KLINE_VOLUME_MIN = 100_000L;
+
+    /** Maximum exclusive kline volume. */
+    private static final long KLINE_VOLUME_MAX_EXCLUSIVE = 10_000_000L;
+
+    /** Maximum tick price change percentage (2%). */
+    private static final double TICK_MAX_CHANGE_PERCENT = 0.02;
+
+    /** Decimal places for percentage division calculation. */
+    private static final int PERCENTAGE_DECIMAL_PLACES = 4;
+
+    /** Percentage multiplier (100%). */
+    private static final double PERCENTAGE_MULTIPLIER = 100.0;
+
+    /** Minimum tick volume. */
+    private static final long TICK_VOLUME_MIN = 1_000_000L;
+
+    /** Maximum exclusive tick volume. */
+    private static final long TICK_VOLUME_MAX_EXCLUSIVE = 50_000_000L;
+
+    /** Bid price ratio (99.9% of current price). */
+    private static final double BID_PRICE_RATIO = 0.999;
+
+    /** Minimum order book volume. */
+    private static final long ORDER_BOOK_VOLUME_MIN = 100L;
+
+    /** Maximum exclusive order book volume. */
+    private static final long ORDER_BOOK_VOLUME_MAX_EXCLUSIVE = 10_000L;
+
+    /** Ask price ratio (100.1% of current price). */
+    private static final double ASK_PRICE_RATIO = 1.001;
+
+    /** Day high ratio (102% of current price). */
+    private static final double DAY_HIGH_RATIO = 1.02;
+
+    /** Day low ratio (98% of current price). */
+    private static final double DAY_LOW_RATIO = 0.98;
+
+    /** Base prices for US stocks. */
+    private final Map<String, BigDecimal> basePrices = new HashMap<>();
+
+    /**
+     * Constructs a new USStockMockDataProvider with default base prices.
+     */
+    public USStockMockDataProvider() {
+        basePrices.put("AAPL", new BigDecimal("175.50"));
+        basePrices.put("MSFT", new BigDecimal("420.00"));
+        basePrices.put("GOOGL", new BigDecimal("165.00"));
+        basePrices.put("AMZN", new BigDecimal("180.00"));
+        basePrices.put("TSLA", new BigDecimal("240.00"));
+        basePrices.put("META", new BigDecimal("500.00"));
+        basePrices.put("NVDA", new BigDecimal("880.00"));
+        basePrices.put("AMD", new BigDecimal("180.00"));
+        basePrices.put("INTC", new BigDecimal("45.00"));
+        basePrices.put("NFLX", new BigDecimal("600.00"));
+    }
+
+    /**
+     * Checks if the provider is available.
+     *
+     * @return true if available
+     */
+    public boolean isAvailable() {
+        return true;
+    }
+
+    /**
+     * Gets the health score of the provider.
+     *
+     * @return the health score
+     */
+    public int getHealthScore() {
+        return DEFAULT_HEALTH_SCORE;
+    }
+
+    /**
+     * Gets kline (candlestick) data for the specified symbol.
+     *
+     * @param symbol the stock symbol
+     * @param timeframe the timeframe
+     * @param limit the number of data points
+     * @param startTime the start time
+     * @param endTime the end time
+     * @return a list of kline data
+     */
+    public List<KlineData> getKlineData(
+            String symbol,
+            String timeframe,
+            int limit,
+            Instant startTime,
+            Instant endTime) {
+        List<KlineData> klines = new ArrayList<>();
+        BigDecimal basePrice = basePrices.getOrDefault(
+                symbol.toUpperCase(Locale.ROOT), new BigDecimal("100.00"));
+
+        Instant currentTime = endTime != null ? endTime : Instant.now();
+        if (endTime == null && startTime != null) {
+            currentTime = startTime;
+        }
+        Duration interval = MarketTimeframeParser.parseStandard(timeframe);
+
+        BigDecimal currentPrice = basePrice;
+        for (int i = 0; i < limit; i++) {
+            double changePercent = (ThreadLocalRandom.current().nextDouble()
+                    - RANDOM_OFFSET_CENTER) * KLINE_MAX_CHANGE_PERCENT;
+            BigDecimal change = currentPrice.multiply(BigDecimal.valueOf(changePercent));
+            BigDecimal close = currentPrice.add(change);
+
+            BigDecimal high = close.multiply(BigDecimal.valueOf(1
+                    + ThreadLocalRandom.current().nextDouble() * HIGH_LOW_VARIATION_PERCENT));
+            BigDecimal low = close.multiply(BigDecimal.valueOf(1
+                    - ThreadLocalRandom.current().nextDouble() * HIGH_LOW_VARIATION_PERCENT));
+
+            long volume = ThreadLocalRandom.current().nextLong(KLINE_VOLUME_MIN, KLINE_VOLUME_MAX_EXCLUSIVE);
+
+            klines.add(KlineData.builder()
+                .symbol(symbol.toUpperCase(Locale.ROOT))
+                .market(MarketType.US_STOCK.getCode())
+                .timestamp(currentTime)
+                .open(currentPrice)
+                .high(high)
+                .low(low)
+                .close(close)
+                .volume(volume)
+                .amount(close.multiply(BigDecimal.valueOf(volume)))
+                .timeframe(timeframe)
+                .build());
+
+            currentPrice = close;
+            currentTime = currentTime.minus(interval);
+        }
+
+        Collections.reverse(klines);
+        return klines;
+    }
+
+    /**
+     * Gets real-time tick data for the specified symbol.
+     *
+     * @param symbol the stock symbol
+     * @return an optional containing tick data
+     */
+    public Optional<TickData> getRealTimeTick(String symbol) {
+        BigDecimal basePrice = basePrices.getOrDefault(
+                symbol.toUpperCase(Locale.ROOT), new BigDecimal("100.00"));
+
+        double changePercent = (ThreadLocalRandom.current().nextDouble()
+                - RANDOM_OFFSET_CENTER) * TICK_MAX_CHANGE_PERCENT;
+        BigDecimal price = basePrice.multiply(BigDecimal.valueOf(1 + changePercent));
+        BigDecimal change = price.subtract(basePrice);
+        BigDecimal changePercentValue = change.divide(basePrice, PERCENTAGE_DECIMAL_PLACES, RoundingMode.HALF_UP)
+            .multiply(BigDecimal.valueOf(PERCENTAGE_MULTIPLIER));
+
+        long volume = ThreadLocalRandom.current().nextLong(TICK_VOLUME_MIN, TICK_VOLUME_MAX_EXCLUSIVE);
+
+        TickData tickData = TickData.builder()
+            .symbol(symbol.toUpperCase(Locale.ROOT))
+            .market(MarketType.US_STOCK.getCode())
+            .timestamp(Instant.now())
+            .price(price)
+            .change(change)
+            .changePercent(changePercentValue)
+            .volume(volume)
+            .amount(price.multiply(BigDecimal.valueOf(volume)))
+            .bidPrice(price.multiply(BigDecimal.valueOf(BID_PRICE_RATIO)))
+            .bidVolume(ThreadLocalRandom.current().nextLong(ORDER_BOOK_VOLUME_MIN, ORDER_BOOK_VOLUME_MAX_EXCLUSIVE))
+            .askPrice(price.multiply(BigDecimal.valueOf(ASK_PRICE_RATIO)))
+            .askVolume(ThreadLocalRandom.current().nextLong(ORDER_BOOK_VOLUME_MIN, ORDER_BOOK_VOLUME_MAX_EXCLUSIVE))
+            .dayHigh(price.multiply(BigDecimal.valueOf(DAY_HIGH_RATIO)))
+            .dayLow(price.multiply(BigDecimal.valueOf(DAY_LOW_RATIO)))
+            .open(basePrice)
+            .prevClose(basePrice)
+            .build();
+
+        return Optional.of(tickData);
+    }
+
+    /**
+     * Searches for symbols matching the given keyword.
+     *
+     * @param keyword the search keyword
+     * @param limit the maximum number of results
+     * @return a list of symbol information
+     */
+    public List<MarketDataProvider.SymbolInfo> searchSymbols(String keyword, int limit) {
+        List<MarketDataProvider.SymbolInfo> results = new ArrayList<>();
+        String upperKeyword = keyword.toUpperCase(Locale.ROOT);
+
+        Map<String, String> usStocks = Map.of(
+            "AAPL", "Apple Inc.",
+            "MSFT", "Microsoft Corporation",
+            "GOOGL", "Alphabet Inc.",
+            "AMZN", "Amazon.com Inc.",
+            "TSLA", "Tesla Inc.",
+            "META", "Meta Platforms Inc.",
+            "NVDA", "NVIDIA Corporation",
+            "AMD", "Advanced Micro Devices",
+            "INTC", "Intel Corporation",
+            "NFLX", "Netflix Inc."
+        );
+
+        usStocks.entrySet().stream()
+            .filter(entry -> entry.getKey().contains(upperKeyword)
+                || entry.getValue().toUpperCase(Locale.ROOT).contains(upperKeyword))
+            .limit(limit)
+            .forEach(entry -> results.add(new MarketDataProvider.SymbolInfo(
+                entry.getKey(),
+                entry.getValue(),
+                MarketType.US_STOCK.getCode(),
+                "NASDAQ",
+                "stock"
+            )));
+
+        return results;
+    }
+}

--- a/koduck-backend/koduck-market/koduck-market-impl/src/main/java/com/koduck/market/util/DataConverter.java
+++ b/koduck-backend/koduck-market/koduck-market-impl/src/main/java/com/koduck/market/util/DataConverter.java
@@ -1,0 +1,248 @@
+package com.koduck.market.util;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Locale;
+
+import com.koduck.common.constants.DateTimePatternConstants;
+import com.koduck.market.model.KlineData;
+import com.koduck.market.model.TickData;
+
+/**
+ * Utility class for converting data between different formats.
+ * Provides standardized conversion methods for market data.
+ *
+ * @author GitHub Copilot
+ */
+public final class DataConverter {
+
+    /**
+     * Formatter for standard date time pattern.
+     */
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern(
+            DateTimePatternConstants.STANDARD_DATE_TIME_PATTERN);
+
+    /**
+     * Typical price divisor for VWAP calculation.
+     */
+    private static final int TYPICAL_PRICE_DIVISOR = 3;
+
+    /**
+     * Scale for typical price calculation.
+     */
+    private static final int TYPICAL_PRICE_SCALE = 8;
+
+    /**
+     * Scale for VWAP result.
+     */
+    private static final int VWAP_SCALE = 4;
+
+    /**
+     * Length of A-share symbol code.
+     */
+    private static final int A_SHARE_SYMBOL_LENGTH = 6;
+
+    private DataConverter() {
+        // Utility class, prevent instantiation
+    }
+
+    /**
+     * Convert string price to BigDecimal
+     *
+     * @param priceStr price string
+     * @return BigDecimal or ZERO if invalid
+     */
+    public static BigDecimal toBigDecimal(String priceStr) {
+        if (priceStr == null || priceStr.trim().isEmpty()) {
+            return BigDecimal.ZERO;
+        }
+        try {
+            return new BigDecimal(priceStr.trim());
+        }
+        catch (NumberFormatException _) {
+            return BigDecimal.ZERO;
+        }
+    }
+
+    /**
+     * Convert string volume to Long
+     *
+     * @param volumeStr volume string
+     * @return Long or 0 if invalid
+     */
+    public static Long toLong(String volumeStr) {
+        if (volumeStr == null || volumeStr.trim().isEmpty()) {
+            return 0L;
+        }
+        try {
+            return Long.parseLong(volumeStr.trim());
+        }
+        catch (NumberFormatException _) {
+            return 0L;
+        }
+    }
+
+    /**
+     * Convert timestamp string to Instant
+     *
+     * @param timestamp timestamp string (supports various formats)
+     * @return Instant or null if invalid
+     */
+    public static Instant toInstant(String timestamp) {
+        if (timestamp == null || timestamp.trim().isEmpty()) {
+            return null;
+        }
+
+        // Try epoch milliseconds
+        try {
+            long epochMillis = Long.parseLong(timestamp.trim());
+            return Instant.ofEpochMilli(epochMillis);
+        }
+        catch (NumberFormatException _) {
+            // Ignore and continue with the next timestamp format.
+        }
+
+        // Try ISO format
+        try {
+            return Instant.parse(timestamp.trim());
+        }
+        catch (Exception _) {
+            // Ignore and continue with the next timestamp format.
+        }
+
+        // Try custom format
+        try {
+            LocalDateTime dateTime = LocalDateTime.parse(timestamp.trim(), DATE_FORMATTER);
+            return dateTime.atZone(ZoneId.systemDefault()).toInstant();
+        }
+        catch (Exception _) {
+            // Ignore and return null when all known formats fail.
+        }
+    
+        return null;
+    }
+
+    /**
+     * Convert seconds timestamp to Instant
+     *
+     * @param seconds seconds since epoch
+     * @return Instant
+     */
+    public static Instant toInstant(long seconds) {
+        return Instant.ofEpochSecond(seconds);
+    }
+
+    /**
+     * Convert milliseconds timestamp to Instant
+     *
+     * @param millis milliseconds since epoch
+     * @return Instant
+     */
+    public static Instant toInstantFromMillis(long millis) {
+        return Instant.ofEpochMilli(millis);
+    }
+
+    /**
+     * Format Instant to string
+     *
+     * @param instant the instant
+     * @return formatted string
+     */
+    public static String formatInstant(Instant instant) {
+        if (instant == null) {
+            return "";
+        }
+        return LocalDateTime.ofInstant(instant, ZoneId.systemDefault()).format(DATE_FORMATTER);
+    }
+
+    /**
+     * Normalize symbol code
+     *
+     * @param symbol raw symbol
+     * @param market market type
+     * @return normalized symbol
+     */
+    public static String normalizeSymbol(String symbol, String market) {
+        if (symbol == null || symbol.trim().isEmpty()) {
+            return "";
+        }
+
+        String normalized = symbol.trim().toUpperCase(Locale.ROOT);
+
+        // Add market suffix if not present
+        if ("a_share".equals(market) && !normalized.contains(".")
+                && normalized.length() == A_SHARE_SYMBOL_LENGTH) {
+            // A-Share: add exchange suffix based on first digit
+            char firstDigit = normalized.charAt(0);
+            if (firstDigit == '6') {
+                normalized += ".SH";
+            }
+            else {
+                normalized += ".SZ";
+            }
+        }
+
+        return normalized;
+    }
+
+    /**
+     * Convert k-line data to tick data (using close price)
+     *
+     * @param kline the k-line data
+     * @return tick data
+     */
+    public static TickData klineToTick(KlineData kline) {
+        if (kline == null) {
+            return null;
+        }
+
+        return TickData.builder()
+                .symbol(kline.symbol())
+                .market(kline.market())
+                .timestamp(kline.timestamp())
+                .price(kline.close())
+                .open(kline.open())
+                .dayHigh(kline.high())
+                .dayLow(kline.low())
+                .volume(kline.volume())
+                .amount(kline.amount())
+                .change(kline.getPriceChange())
+                .changePercent(kline.getPriceChangePercent())
+                .build();
+    }
+
+    /**
+     * Calculate VWAP (Volume Weighted Average Price)
+     *
+     * @param klines list of k-line data
+     * @return VWAP or ZERO if no data
+     */
+    public static BigDecimal calculateVWAP(List<KlineData> klines) {
+        if (klines == null || klines.isEmpty()) {
+            return BigDecimal.ZERO;
+        }
+
+        BigDecimal totalTPV = BigDecimal.ZERO; // Typical Price * Volume
+        long totalVolume = 0;
+
+        for (KlineData kline : klines) {
+            // Typical Price = (High + Low + Close) / 3
+            BigDecimal typicalPrice = kline.high().add(kline.low()).add(kline.close())
+                    .divide(BigDecimal.valueOf(TYPICAL_PRICE_DIVISOR), TYPICAL_PRICE_SCALE, RoundingMode.HALF_UP);
+
+            totalTPV = totalTPV.add(typicalPrice.multiply(BigDecimal.valueOf(kline.volume())));
+            totalVolume += kline.volume();
+        }
+
+        if (totalVolume == 0) {
+            return BigDecimal.ZERO;
+        }
+
+        return totalTPV.divide(BigDecimal.valueOf(totalVolume), VWAP_SCALE, RoundingMode.HALF_UP);
+    }
+}

--- a/koduck-backend/koduck-market/koduck-market-impl/src/main/java/com/koduck/market/util/MarketFieldParser.java
+++ b/koduck-backend/koduck-market/koduck-market-impl/src/main/java/com/koduck/market/util/MarketFieldParser.java
@@ -1,0 +1,74 @@
+package com.koduck.market.util;
+
+import java.math.BigDecimal;
+import java.util.Map;
+
+/**
+ * Helper methods for parsing typed values from map-based payloads.
+ *
+ * @author Koduck Team
+ */
+public final class MarketFieldParser {
+
+    private MarketFieldParser() {
+        // Utility class.
+    }
+
+    /**
+     * Reads a string value from map payload.
+     *
+     * @param data source map
+     * @param key key name
+     * @return string representation or null
+     */
+    public static String toStringValue(Map<String, Object> data, String key) {
+        Object value = data.get(key);
+        return value != null ? value.toString() : null;
+    }
+
+    /**
+     * Reads a long value from map payload.
+     *
+     * @param data source map
+     * @param key key name
+     * @return parsed long or null when absent/invalid
+     */
+    public static Long toLong(Map<String, Object> data, String key) {
+        Object value = data.get(key);
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof Number number) {
+            return number.longValue();
+        }
+        try {
+            return Long.parseLong(value.toString());
+        }
+        catch (NumberFormatException _) {
+            return null;
+        }
+    }
+
+    /**
+     * Reads a decimal value from map payload.
+     *
+     * @param data source map
+     * @param key key name
+     * @return parsed decimal or null when absent/invalid
+     */
+    public static BigDecimal toBigDecimal(Map<String, Object> data, String key) {
+        Object value = data.get(key);
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof Number number) {
+            return BigDecimal.valueOf(number.doubleValue());
+        }
+        try {
+            return new BigDecimal(value.toString());
+        }
+        catch (NumberFormatException _) {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
## 任务描述

迁移 koduck-core 中的 Market Service、Provider 和 Util 到 koduck-market-impl 模块。

## 变更内容

### 1. 迁移 Provider (8 个)
- AKShareDataProvider, USStockProvider, ForexProvider
- FuturesProvider, HKStockProvider, MarketDataProvider
- AbstractDataServiceMarketProvider, ProviderFactory

### 2. 迁移 Model (2 个)
- KlineData, TickData

### 3. 迁移 Util (2 个)
- DataConverter, MarketFieldParser

### 4. 迁移 Service (7 个)
- KlineService, KlineSyncService, StockCacheService
- StockSubscriptionService, SyntheticTickService
- TechnicalIndicatorService, TickStreamService

### 5. 迁移 Service Support (6 个)
- AKShareDataMapperSupport, FuturesMockDataSupport
- HKStockMarketCalendar, MarketDataMapReader
- MarketTimeframeParser, USStockMockDataProvider

### 6. 迁移 DTO 到 koduck-market-api
- MarketType
- IndicatorListResponse, IndicatorResponse

### 7. 包名更新
- com.koduck.service.market.* -> com.koduck.market.provider/service/util

## 验收标准

- [x] 所有 Market Provider/Service/Util 迁移到 koduck-market-impl
- [x] mvn clean compile 通过
- [x] mvn checkstyle:check 无异常

## 关联 Issue

Closes #585