### PR TITLE
test(archunit): add comprehensive architecture guard tests

### DIFF
--- a/koduck-backend/docs/ADR-0137-archunit-architecture-guard.md
+++ b/koduck-backend/docs/ADR-0137-archunit-architecture-guard.md
@@ -1,0 +1,133 @@
+# ADR-0137: ArchUnit 架构守护
+
+## 状态
+
+- **状态**: 草案
+- **日期**: 2026-04-06
+- **作者**: Koduck Team
+
+## 背景
+
+Phase 1.3 已经引入了 ArchUnit 基础架构测试，但随着 Phase 2 和 Phase 3 的模块拆分完成，需要更全面的架构规则来守护改进后的架构，防止架构退化。
+
+## 目标
+
+1. 建立全面的 ArchUnit 架构守护测试
+2. 确保模块依赖方向正确
+3. 防止循环依赖
+4. 统一命名规范
+5. 在 CI 中阻断违规构建
+
+## 架构规则
+
+### 1. 分层架构规则
+
+```
+bootstrap
+    ↑
+controller (optional)
+    ↑
+domain modules (api/impl)
+    ↑
+infrastructure
+    ↑
+common
+```
+
+**规则:**
+- Common 模块不应依赖任何其他模块
+- API 模块不应依赖 Infrastructure 模块
+- API 模块不应依赖 Impl 模块
+
+### 2. 模块依赖规则
+
+**允许的方向:**
+- `*-impl` → `*-api` (实现依赖接口)
+- `*-impl` → `common` (实现依赖公共工具)
+- `*-impl` → `infrastructure` (实现依赖基础设施)
+- `bootstrap` → `*-impl` (启动模块依赖实现)
+- `bootstrap` → `*-api` (启动模块依赖接口)
+
+**禁止的方向:**
+- `*-api` → `*-impl` (接口不应依赖实现)
+- `*-api` → `infrastructure` (接口不应依赖基础设施)
+- `common` → 任何其他模块 (公共模块不应依赖其他模块)
+
+### 3. 循环依赖规则
+
+- 模块间不应有循环依赖
+- 包间不应有循环依赖
+
+### 4. 命名规范规则
+
+**接口命名:**
+- API 接口应以 `Service` 结尾
+- Repository 接口应以 `Repository` 结尾
+
+**类命名:**
+- 实现类应以 `Impl` 结尾
+- Controller 类应以 `Controller` 结尾
+- DTO 类应以 `Dto` 结尾
+- Entity 类无特殊后缀要求
+
+## 实现策略
+
+### 测试类结构
+
+```
+koduck-bootstrap/src/test/java/com/koduck/architecture/
+├── ArchitectureConstants.java    # 常量定义
+├── LayeredArchitectureTest.java  # 分层架构规则
+├── PackageDependencyRulesTest.java   # 包依赖规则
+├── CircularDependencyRulesTest.java  # 循环依赖规则
+└── NamingConventionRulesTest.java    # 命名规范规则
+```
+
+### CI 集成
+
+ArchUnit 测试应在 CI 中运行，测试失败会阻断构建：
+
+```yaml
+- name: Run ArchUnit Tests
+  run: mvn test -pl koduck-bootstrap -Dtest="*ArchitectureTest,*RulesTest"
+```
+
+## 权衡
+
+### 优点
+
+1. **防止架构退化**: 自动化测试确保架构规则不被破坏
+2. **快速反馈**: 开发阶段就能发现架构违规
+3. **文档化**: 测试代码本身就是架构规则的文档
+4. **可维护性**: 新开发者可以通过测试了解架构约束
+
+### 缺点
+
+1. **学习成本**: 需要学习 ArchUnit 的 API
+2. **维护成本**: 架构变更时需要更新测试
+3. **假阳性**: 某些特殊情况可能需要例外处理
+
+## 兼容性影响
+
+### 对现有代码的影响
+
+- 现有代码需要通过所有 ArchUnit 测试
+- 如果现有代码违反规则，需要修复或添加例外
+
+### 迁移步骤
+
+1. 编写 ArchUnit 测试
+2. 运行测试，识别违规代码
+3. 修复违规代码或添加例外
+4. 在 CI 中启用 ArchUnit 测试
+
+## 相关文档
+
+- [ADR-0120-introduce-archunit-testing.md](./ADR-0120-introduce-archunit-testing.md)
+- Issue #598
+
+## 决策记录
+
+| 日期 | 决策 | 说明 |
+|------|------|------|
+| 2026-04-06 | 创建 ADR | 初始版本 |

--- a/koduck-backend/koduck-bootstrap/src/test/java/com/koduck/architecture/CircularDependencyRulesTest.java
+++ b/koduck-backend/koduck-bootstrap/src/test/java/com/koduck/architecture/CircularDependencyRulesTest.java
@@ -1,0 +1,68 @@
+package com.koduck.architecture;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.library.dependencies.SlicesRuleDefinition;
+
+/**
+ * 循环依赖规则测试。
+ *
+ * <p>验证模块间和包间不存在循环依赖：</p>
+ * <ul>
+ *   <li>模块间不应有循环依赖</li>
+ *   <li>包间不应有循环依赖</li>
+ * </ul>
+ *
+ * @author Koduck Team
+ */
+class CircularDependencyRulesTest {
+
+    /** 导入的类集合。 */
+    private static JavaClasses importedClasses;
+
+    @BeforeAll
+    static void setUp() {
+        importedClasses = new ClassFileImporter()
+                .importPackages(ArchitectureConstants.BASE_PACKAGE);
+    }
+
+    @Test
+    @DisplayName("模块间不应有循环依赖")
+    void modulesShouldBeFreeOfCycles() {
+        ArchRule rule = SlicesRuleDefinition.slices()
+                .matching(ArchitectureConstants.MODULE_SLICE_PATTERN)
+                .should().beFreeOfCycles()
+                .because("模块间的循环依赖会导致构建困难、测试复杂和代码耦合度高，"
+                        + "应通过依赖注入和接口解耦")
+                .allowEmptyShould(true);
+
+        rule.check(importedClasses);
+    }
+
+    @Test
+    @DisplayName("Domain 模块间不应有循环依赖")
+    void domainModulesShouldBeFreeOfCycles() {
+        String[] domainPackages = {
+                "com.koduck.market",
+                "com.koduck.portfolio",
+                "com.koduck.strategy",
+                "com.koduck.community",
+                "com.koduck.ai"
+        };
+
+        for (String packageName : domainPackages) {
+            ArchRule rule = SlicesRuleDefinition.slices()
+                    .matching(packageName + ".(*)..")
+                    .should().beFreeOfCycles()
+                    .because("Domain 模块内部的包不应有循环依赖")
+                    .allowEmptyShould(true);
+
+            rule.check(importedClasses);
+        }
+    }
+}

--- a/koduck-backend/koduck-bootstrap/src/test/java/com/koduck/architecture/NamingConventionRulesTest.java
+++ b/koduck-backend/koduck-bootstrap/src/test/java/com/koduck/architecture/NamingConventionRulesTest.java
@@ -1,0 +1,133 @@
+package com.koduck.architecture;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
+
+/**
+ * 命名规范规则测试。
+ *
+ * <p>验证代码命名符合规范：</p>
+ * <ul>
+ *   <li>API 接口应以 Service 结尾</li>
+ *   <li>Impl 类应以 Impl 结尾</li>
+ *   <li>Repository 接口应以 Repository 结尾</li>
+ *   <li>Controller 类应以 Controller 结尾</li>
+ *   <li>DTO 类应以 Dto 结尾</li>
+ * </ul>
+ *
+ * @author Koduck Team
+ */
+class NamingConventionRulesTest {
+
+    /** 导入的类集合。 */
+    private static JavaClasses importedClasses;
+
+    @BeforeAll
+    static void setUp() {
+        importedClasses = new ClassFileImporter()
+                .importPackages(ArchitectureConstants.BASE_PACKAGE);
+    }
+
+    @Test
+    @DisplayName("API 接口应以 Service 结尾")
+    void apiInterfacesShouldEndWithService() {
+        ArchRule rule = ArchRuleDefinition.classes()
+                .that()
+                .resideInAPackage(ArchitectureConstants.API_PACKAGE)
+                .and()
+                .areInterfaces()
+                .should()
+                .haveSimpleNameEndingWith("Service")
+                .because("API 模块的服务接口应以 Service 结尾，"
+                        + "以明确其作为服务契约的角色")
+                .allowEmptyShould(true);
+
+        rule.check(importedClasses);
+    }
+
+    @Test
+    @DisplayName("Impl 类应以 Impl 结尾")
+    void implClassesShouldEndWithImpl() {
+        ArchRule rule = ArchRuleDefinition.classes()
+                .that()
+                .resideInAPackage(ArchitectureConstants.IMPL_PACKAGE)
+                .and()
+                .areNotInterfaces()
+                .and()
+                .haveSimpleNameNotContaining("Test")
+                .should()
+                .haveSimpleNameEndingWith("Impl")
+                .orShould()
+                .haveSimpleNameEndingWith("Configuration")
+                .orShould()
+                .haveSimpleNameEndingWith("Properties")
+                .because("实现类应以 Impl 结尾，配置类应以 Configuration 或 Properties 结尾，"
+                        + "以明确其角色")
+                .allowEmptyShould(true);
+
+        rule.check(importedClasses);
+    }
+
+    @Test
+    @DisplayName("Repository 接口应以 Repository 结尾")
+    void repositoryInterfacesShouldEndWithRepository() {
+        ArchRule rule = ArchRuleDefinition.classes()
+                .that()
+                .resideInAPackage("..repository..")
+                .and()
+                .areInterfaces()
+                .should()
+                .haveSimpleNameEndingWith("Repository")
+                .because("Repository 接口应以 Repository 结尾，"
+                        + "以符合 Spring Data JPA 的命名约定")
+                .allowEmptyShould(true);
+
+        rule.check(importedClasses);
+    }
+
+    @Test
+    @DisplayName("Controller 类应以 Controller 结尾")
+    void controllerClassesShouldEndWithController() {
+        ArchRule rule = ArchRuleDefinition.classes()
+                .that()
+                .resideInAPackage("..controller..")
+                .and()
+                .areNotInterfaces()
+                .should()
+                .haveSimpleNameEndingWith("Controller")
+                .because("Controller 类应以 Controller 结尾，"
+                        + "以明确其作为 REST API 控制器的角色")
+                .allowEmptyShould(true);
+
+        rule.check(importedClasses);
+    }
+
+    @Test
+    @DisplayName("DTO 类应以 Dto 结尾")
+    void dtoClassesShouldEndWithDto() {
+        ArchRule rule = ArchRuleDefinition.classes()
+                .that()
+                .resideInAPackage("..dto..")
+                .and()
+                .areNotInterfaces()
+                .and()
+                .haveSimpleNameNotContaining("Test")
+                .should()
+                .haveSimpleNameEndingWith("Dto")
+                .orShould()
+                .haveSimpleNameEndingWith("Request")
+                .orShould()
+                .haveSimpleNameEndingWith("Response")
+                .because("DTO 类应以 Dto、Request 或 Response 结尾，"
+                        + "以明确其作为数据传输对象的角色")
+                .allowEmptyShould(true);
+
+        rule.check(importedClasses);
+    }
+}

--- a/koduck-backend/koduck-bootstrap/src/test/java/com/koduck/architecture/PackageDependencyRulesTest.java
+++ b/koduck-backend/koduck-bootstrap/src/test/java/com/koduck/architecture/PackageDependencyRulesTest.java
@@ -1,0 +1,99 @@
+package com.koduck.architecture;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
+
+/**
+ * 包依赖规则测试。
+ *
+ * <p>验证模块间的依赖方向是否正确：</p>
+ * <ul>
+ *   <li>API 模块不应依赖 Impl 模块</li>
+ *   <li>Impl 模块可以依赖 API 模块</li>
+ *   <li>Domain 模块间不应循环依赖</li>
+ * </ul>
+ *
+ * @author Koduck Team
+ */
+class PackageDependencyRulesTest {
+
+    /** 导入的类集合。 */
+    private static JavaClasses importedClasses;
+
+    @BeforeAll
+    static void setUp() {
+        importedClasses = new ClassFileImporter()
+                .importPackages(ArchitectureConstants.BASE_PACKAGE);
+    }
+
+    @Test
+    @DisplayName("API 模块不应依赖 Impl 模块")
+    void apiModulesShouldNotDependOnImplModules() {
+        ArchRule rule = ArchRuleDefinition.noClasses()
+                .that()
+                .resideInAPackage(ArchitectureConstants.API_PACKAGE)
+                .should()
+                .dependOnClassesThat()
+                .resideInAPackage(ArchitectureConstants.IMPL_PACKAGE)
+                .because("API 模块作为领域契约层，不应依赖实现模块，"
+                        + "以保持接口与实现的分离")
+                .allowEmptyShould(true);
+
+        rule.check(importedClasses);
+    }
+
+    @Test
+    @DisplayName("API 模块不应依赖 Core 模块")
+    void apiModulesShouldNotDependOnCoreModule() {
+        ArchRule rule = ArchRuleDefinition.noClasses()
+                .that()
+                .resideInAPackage(ArchitectureConstants.API_PACKAGE)
+                .should()
+                .dependOnClassesThat()
+                .resideInAPackage(ArchitectureConstants.CORE_PACKAGE)
+                .because("API 模块作为领域契约层，不应依赖 Core 模块，"
+                        + "以避免循环依赖和保持模块独立性")
+                .allowEmptyShould(true);
+
+        rule.check(importedClasses);
+    }
+
+    @Test
+    @DisplayName("Domain 模块不应直接依赖其他 Domain 模块的 Impl")
+    void domainModulesShouldNotDependOnOtherDomainImpl() {
+        String[] domainPackages = {
+                ArchitectureConstants.MARKET_PACKAGE,
+                ArchitectureConstants.PORTFOLIO_PACKAGE,
+                ArchitectureConstants.STRATEGY_PACKAGE,
+                ArchitectureConstants.COMMUNITY_PACKAGE,
+                ArchitectureConstants.AI_PACKAGE
+        };
+
+        for (String domainPackage : domainPackages) {
+            ArchRule rule = ArchRuleDefinition.noClasses()
+                    .that()
+                    .resideInAPackage(domainPackage)
+                    .and()
+                    .resideInAPackage(ArchitectureConstants.API_PACKAGE)
+                    .should()
+                    .dependOnClassesThat()
+                    .resideInAnyPackage(
+                            ArchitectureConstants.PORTFOLIO_PACKAGE.replace("..", ".impl.."),
+                            ArchitectureConstants.STRATEGY_PACKAGE.replace("..", ".impl.."),
+                            ArchitectureConstants.COMMUNITY_PACKAGE.replace("..", ".impl.."),
+                            ArchitectureConstants.AI_PACKAGE.replace("..", ".impl..")
+                    )
+                    .because("Domain 模块的 API 不应依赖其他 Domain 模块的实现，"
+                            + "模块间通信应通过 API 接口")
+                    .allowEmptyShould(true);
+
+            rule.check(importedClasses);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

完善 ArchUnit 架构守护测试，防止架构退化，确保依赖方向正确。

## Changes

### Added Tests

**PackageDependencyRulesTest** (3 rules):
- API 模块不应依赖 Impl 模块
- API 模块不应依赖 Core 模块
- Domain 模块不应依赖其他 Domain 模块的 Impl

**CircularDependencyRulesTest** (2 rules):
- 模块间不应有循环依赖
- Domain 模块间不应有循环依赖

**NamingConventionRulesTest** (5 rules):
- API 接口应以 Service 结尾
- Impl 类应以 Impl/Configuration/Properties 结尾
- Repository 接口应以 Repository 结尾
- Controller 类应以 Controller 结尾
- DTO 类应以 Dto/Request/Response 结尾

### Added Documentation

-  - ArchUnit 架构守护策略文档

## Architecture Rules

### 分层架构规则


### 允许的依赖方向
-  → 
-  → 
-  → 
-  → 
-  → 

### 禁止的依赖方向
-  → 
-  → 
-  → 任何其他模块

## Verification

- [x] 所有 18 个 ArchUnit 测试通过
- [x] mvn clean compile 通过
- [x] mvn checkstyle:check 通过

## Test Results



### 测试类统计
| 测试类 | 测试数 |
|--------|--------|
| LayeredArchitectureTest | 2 |
| PackageDependencyRulesTest | 3 |
| CircularDependencyRulesTest | 2 |
| NamingConventionRulesTest | 5 |
| ApiModuleRulesTest | 3 |
| DomainDependencyRulesTest | 3 |
| **总计** | **18** |

## Related

- ADR-0120: Introduce ArchUnit Testing
- Issue #547: ArchUnit 基础引入 (已完成)
- Issue #550: Phase 4.1 - 完善 ArchUnit 架构守护测试
- Issue #598

Closes #598