### PR TITLE
feat(architecture): Phase 3.3 domain event mechanism

### DIFF
--- a/koduck-backend/docs/ADR-0143-domain-event-mechanism.md
+++ b/koduck-backend/docs/ADR-0143-domain-event-mechanism.md
@@ -1,0 +1,379 @@
+# ADR-0143: 领域事件机制
+
+- Status: Accepted
+- Date: 2026-04-06
+- Issue: #618
+
+## Context
+
+随着 Phase 2 完成，各业务领域模块已拆分完成：
+
+- `koduck-market-impl`
+- `koduck-portfolio-impl`
+- `koduck-community-impl`
+- `koduck-ai-impl`
+
+当前模块间通信主要通过 ACL 接口直接调用，存在以下问题：
+
+1. **耦合度高**：调用方需要知道被调用方的接口
+2. **同步阻塞**：调用是同步的，影响响应时间
+3. **难以扩展**：新增消费者需要修改调用方代码
+4. **无法审计**：没有事件历史记录
+
+### 当前通信方式
+
+```java
+// AI 模块直接调用 Portfolio ACL
+@Service
+public class AiAnalysisServiceImpl {
+    private final PortfolioQueryService portfolioQueryService;
+    
+    public void analyze(Long portfolioId) {
+        PortfolioSnapshot snapshot = portfolioQueryService.getSnapshot(portfolioId);
+        // 分析逻辑
+    }
+}
+```
+
+### 期望的通信方式
+
+```java
+// Portfolio 模块发布事件
+@Service
+public class PortfolioCommandServiceImpl {
+    private final DomainEventPublisher eventPublisher;
+    
+    public void createPortfolio(CreatePortfolioRequest request) {
+        // 创建组合
+        Portfolio portfolio = portfolioRepository.save(...);
+        
+        // 发布事件
+        eventPublisher.publish(new PortfolioCreatedEvent(
+            portfolio.getId(),
+            portfolio.getName(),
+            portfolio.getUserId()
+        ));
+    }
+}
+
+// AI 模块订阅事件
+@Component
+public class AiAnalysisEventListener {
+    @EventListener
+    public void onPortfolioCreated(PortfolioCreatedEvent event) {
+        // 自动分析新创建的组合
+        aiAnalysisService.analyze(event.getPortfolioId());
+    }
+}
+```
+
+## Decision
+
+### 1. 领域事件架构
+
+采用 Spring Event 作为基础，未来可扩展至 RabbitMQ：
+
+```
+koduck-common
+└── event/
+    ├── DomainEvent.java (基础事件类)
+    └── DomainEventPublisher.java (发布器接口)
+
+koduck-*-api
+└── event/
+    └── {Domain}Event.java (各领域事件)
+
+koduck-infrastructure
+└── event/
+    ├── SpringDomainEventPublisher.java (Spring 实现)
+    └── EventListenerSupport.java (监听器支持)
+```
+
+### 2. 基础事件类设计
+
+```java
+package com.koduck.common.event;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * 领域事件基类。
+ *
+ * <p>所有领域事件必须继承此类。</p>
+ */
+public abstract class DomainEvent {
+    
+    private final String eventId;
+    private final Instant occurredOn;
+    private final String eventType;
+    
+    protected DomainEvent() {
+        this.eventId = UUID.randomUUID().toString();
+        this.occurredOn = Instant.now();
+        this.eventType = this.getClass().getSimpleName();
+    }
+    
+    // Getters
+    public String getEventId() { return eventId; }
+    public Instant getOccurredOn() { return occurredOn; }
+    public String getEventType() { return eventType; }
+}
+```
+
+### 3. 事件发布器接口
+
+```java
+package com.koduck.common.event;
+
+/**
+ * 领域事件发布器。
+ */
+public interface DomainEventPublisher {
+    
+    /**
+     * 发布领域事件。
+     *
+     * @param event 事件对象
+     */
+    void publish(DomainEvent event);
+}
+```
+
+### 4. Spring 实现
+
+```java
+package com.koduck.infrastructure.event;
+
+import com.koduck.common.event.DomainEvent;
+import com.koduck.common.event.DomainEventPublisher;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SpringDomainEventPublisher implements DomainEventPublisher {
+    
+    private final ApplicationEventPublisher applicationEventPublisher;
+    
+    @Override
+    public void publish(DomainEvent event) {
+        applicationEventPublisher.publishEvent(event);
+    }
+}
+```
+
+### 5. 各领域事件定义
+
+#### Portfolio 领域
+
+```java
+package com.koduck.portfolio.event;
+
+import com.koduck.common.event.DomainEvent;
+import lombok.Getter;
+
+/**
+ * 投资组合创建事件。
+ */
+@Getter
+public class PortfolioCreatedEvent extends DomainEvent {
+    
+    private final Long portfolioId;
+    private final String portfolioName;
+    private final Long userId;
+    
+    public PortfolioCreatedEvent(Long portfolioId, String portfolioName, Long userId) {
+        super();
+        this.portfolioId = portfolioId;
+        this.portfolioName = portfolioName;
+        this.userId = userId;
+    }
+}
+```
+
+#### Community 领域
+
+```java
+package com.koduck.community.event;
+
+import com.koduck.common.event.DomainEvent;
+import lombok.Getter;
+
+/**
+ * 信号发布事件。
+ */
+@Getter
+public class SignalPublishedEvent extends DomainEvent {
+    
+    private final Long signalId;
+    private final String symbol;
+    private final String signalType;
+    private final Long publisherId;
+    
+    public SignalPublishedEvent(Long signalId, String symbol, 
+                                String signalType, Long publisherId) {
+        super();
+        this.signalId = signalId;
+        this.symbol = symbol;
+        this.signalType = signalType;
+        this.publisherId = publisherId;
+    }
+}
+```
+
+#### Market 领域
+
+```java
+package com.koduck.market.event;
+
+import com.koduck.common.event.DomainEvent;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+/**
+ * 行情数据更新事件。
+ */
+@Getter
+public class MarketDataUpdatedEvent extends DomainEvent {
+    
+    private final String symbol;
+    private final BigDecimal currentPrice;
+    private final BigDecimal changePercent;
+    
+    public MarketDataUpdatedEvent(String symbol, BigDecimal currentPrice, 
+                                   BigDecimal changePercent) {
+        super();
+        this.symbol = symbol;
+        this.currentPrice = currentPrice;
+        this.changePercent = changePercent;
+    }
+}
+```
+
+### 6. 事件监听器示例
+
+```java
+package com.koduck.ai.event;
+
+import com.koduck.community.event.SignalPublishedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AiAnalysisEventListener {
+    
+    private final AiAnalysisService aiAnalysisService;
+    
+    /**
+     * 监听信号发布事件，自动进行分析。
+     */
+    @Async
+    @EventListener
+    public void onSignalPublished(SignalPublishedEvent event) {
+        log.info("Received SignalPublishedEvent: signalId={}", event.getSignalId());
+        
+        // 异步分析信号
+        aiAnalysisService.analyzeSignal(event.getSignalId());
+    }
+}
+```
+
+### 7. 试点场景
+
+选择 **信号发布通知** 作为试点场景：
+
+1. 用户发布信号
+2. `CommunitySignalService` 发布 `SignalPublishedEvent`
+3. `AiAnalysisEventListener` 订阅并分析信号
+4. `NotificationEventListener` 订阅并发送通知
+
+### 8. 配置
+
+```java
+package com.koduck.infrastructure.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class EventConfig {
+    // 异步事件配置
+}
+```
+
+## Consequences
+
+### 正向影响
+
+1. **模块解耦**：发布方不需要知道谁订阅了事件
+2. **异步处理**：事件处理是异步的，不阻塞主流程
+3. **易于扩展**：新增消费者只需添加监听器
+4. **可审计**：事件可以持久化用于审计
+5. **支持 Saga**：为分布式事务奠定基础
+
+### 代价与风险
+
+1. **最终一致性**：事件处理是异步的，数据可能短暂不一致
+2. **调试困难**：异步流程调试比同步困难
+3. **事件风暴**：可能产生大量事件，需要限流
+4. **顺序保证**：需要额外机制保证事件顺序
+
+### 兼容性影响
+
+- **现有代码**：ACL 接口保留，逐步迁移到事件驱动
+- **数据库**：无变化
+- **API**：无变化
+- **部署**：需要配置异步线程池
+
+## Alternatives Considered
+
+1. **直接使用 RabbitMQ**
+   - 拒绝：引入外部依赖，增加复杂度
+   - 当前方案：先使用 Spring Event，未来可扩展至 RabbitMQ
+
+2. **使用 Axon Framework**
+   - 拒绝：学习成本高，过度工程
+   - 当前方案：轻量级实现，满足当前需求
+
+3. **保持直接调用**
+   - 拒绝：耦合度高，难以扩展
+   - 当前方案：引入事件机制解耦
+
+## Implementation
+
+### 交付物
+
+1. **ADR-0143**: 本决策记录
+2. **DomainEvent.java**: 基础事件类
+3. **DomainEventPublisher.java**: 发布器接口
+4. **SpringDomainEventPublisher.java**: Spring 实现
+5. **各领域事件类**:
+   - `PortfolioCreatedEvent`
+   - `SignalPublishedEvent`
+   - `MarketDataUpdatedEvent`
+6. **EventConfig.java**: 配置类
+7. **示例监听器**: `AiAnalysisEventListener`
+
+### 验证清单
+
+- [x] DomainEvent 基础类创建
+- [ ] 各领域事件定义完成
+- [ ] 事件发布/订阅机制运行正常
+- [ ] 至少一个业务场景使用事件驱动
+- [ ] 质量检查脚本全绿
+- [ ] 代码编译通过
+
+## References
+
+- [ARCHITECTURE-TASKS.md](./ARCHITECTURE-TASKS.md) - Task 3.3
+- [Spring Events](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/context/event/package-summary.html) - Spring 事件文档
+- [DDD 领域事件](https://ddd-practitioners.com/domain-event) - DDD 领域事件模式

--- a/koduck-backend/koduck-ai/koduck-ai-impl/src/main/java/com/koduck/ai/event/AiAnalysisEventListener.java
+++ b/koduck-backend/koduck-ai/koduck-ai-impl/src/main/java/com/koduck/ai/event/AiAnalysisEventListener.java
@@ -1,0 +1,81 @@
+package com.koduck.ai.event;
+
+import com.koduck.community.event.SignalPublishedEvent;
+import com.koduck.portfolio.event.PortfolioCreatedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+/**
+ * AI 分析事件监听器。
+ *
+ * <p>监听领域事件并触发 AI 分析。</p>
+ *
+ * @author Koduck Team
+ * @since 0.1.0
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AiAnalysisEventListener {
+
+    /**
+     * 监听信号发布事件。
+     *
+     * <p>异步分析新发布的信号。</p>
+     *
+     * @param event 信号发布事件
+     */
+    @Async
+    @EventListener
+    public void onSignalPublished(SignalPublishedEvent event) {
+        log.info("Received SignalPublishedEvent: signalId={}, symbol={}",
+            event.getSignalId(), event.getSymbol());
+
+        try {
+            // 异步分析信号
+            // TODO: 调用 AI 分析服务
+            log.info("Analyzing signal {} for symbol {}",
+                event.getSignalId(), event.getSymbol());
+
+            // 模拟分析延迟
+            Thread.sleep(100);
+
+            log.info("Signal analysis completed: signalId={}", event.getSignalId());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.error("Signal analysis interrupted: signalId={}", event.getSignalId());
+        }
+    }
+
+    /**
+     * 监听投资组合创建事件。
+     *
+     * <p>异步分析新创建的投资组合。</p>
+     *
+     * @param event 投资组合创建事件
+     */
+    @Async
+    @EventListener
+    public void onPortfolioCreated(PortfolioCreatedEvent event) {
+        log.info("Received PortfolioCreatedEvent: portfolioId={}, name={}",
+            event.getPortfolioId(), event.getPortfolioName());
+
+        try {
+            // 异步分析投资组合
+            // TODO: 调用 AI 分析服务
+            log.info("Analyzing portfolio {} for user {}",
+                event.getPortfolioId(), event.getUserId());
+
+            // 模拟分析延迟
+            Thread.sleep(100);
+
+            log.info("Portfolio analysis completed: portfolioId={}", event.getPortfolioId());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.error("Portfolio analysis interrupted: portfolioId={}", event.getPortfolioId());
+        }
+    }
+}

--- a/koduck-backend/koduck-common/src/main/java/com/koduck/common/event/DomainEvent.java
+++ b/koduck-backend/koduck-common/src/main/java/com/koduck/common/event/DomainEvent.java
@@ -1,0 +1,76 @@
+package com.koduck.common.event;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * 领域事件基类。
+ *
+ * <p>所有领域事件必须继承此类。领域事件用于模块间解耦通信，
+ * 采用发布-订阅模式。</p>
+ *
+ * <p>特性：</p>
+ * <ul>
+ *   <li>自动生成唯一事件ID</li>
+ *   <li>自动记录发生时间</li>
+ *   <li>自动识别事件类型</li>
+ * </ul>
+ *
+ * @author Koduck Team
+ * @since 0.1.0
+ */
+public abstract class DomainEvent {
+
+    /** 事件唯一标识。 */
+    private final String eventId;
+
+    /** 事件发生时间。 */
+    private final Instant occurredOn;
+
+    /** 事件类型（类名）。 */
+    private final String eventType;
+
+    /**
+     * 构造领域事件。
+     *
+     * <p>自动生成事件ID、发生时间和事件类型。</p>
+     */
+    protected DomainEvent() {
+        this.eventId = UUID.randomUUID().toString();
+        this.occurredOn = Instant.now();
+        this.eventType = this.getClass().getSimpleName();
+    }
+
+    /**
+     * 获取事件ID。
+     *
+     * @return 事件唯一标识
+     */
+    public String getEventId() {
+        return eventId;
+    }
+
+    /**
+     * 获取事件发生时间。
+     *
+     * @return 发生时间
+     */
+    public Instant getOccurredOn() {
+        return occurredOn;
+    }
+
+    /**
+     * 获取事件类型。
+     *
+     * @return 事件类型（类名）
+     */
+    public String getEventType() {
+        return eventType;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s[eventId=%s, occurredOn=%s]",
+            eventType, eventId, occurredOn);
+    }
+}

--- a/koduck-backend/koduck-common/src/main/java/com/koduck/common/event/DomainEventPublisher.java
+++ b/koduck-backend/koduck-common/src/main/java/com/koduck/common/event/DomainEventPublisher.java
@@ -1,0 +1,37 @@
+package com.koduck.common.event;
+
+/**
+ * 领域事件发布器接口。
+ *
+ * <p>定义领域事件的发布契约。实现类负责将事件传递给所有订阅者。</p>
+ *
+ * <p>使用示例：</p>
+ * <pre>
+ * &#64;Service
+ * public class PortfolioService {
+ *     private final DomainEventPublisher eventPublisher;
+ *
+ *     public void createPortfolio(CreatePortfolioRequest request) {
+ *         // 业务逻辑...
+ *
+ *         // 发布事件
+ *         eventPublisher.publish(new PortfolioCreatedEvent(portfolioId, name, userId));
+ *     }
+ * }
+ * </pre>
+ *
+ * @author Koduck Team
+ * @since 0.1.0
+ */
+public interface DomainEventPublisher {
+
+    /**
+     * 发布领域事件。
+     *
+     * <p>事件将被异步分发给所有订阅者。</p>
+     *
+     * @param event 领域事件对象，不能为 null
+     * @throws IllegalArgumentException 如果 event 为 null
+     */
+    void publish(DomainEvent event);
+}

--- a/koduck-backend/koduck-community/koduck-community-api/src/main/java/com/koduck/community/event/SignalPublishedEvent.java
+++ b/koduck-backend/koduck-community/koduck-community-api/src/main/java/com/koduck/community/event/SignalPublishedEvent.java
@@ -1,48 +1,56 @@
 package com.koduck.community.event;
 
+import com.koduck.common.event.DomainEvent;
 import lombok.Getter;
-import org.springframework.context.ApplicationEvent;
-
-import java.time.Instant;
 
 /**
  * 信号发布事件。
  *
- * <p>当新信号被发布时发布。</p>
+ * <p>当用户发布新的交易信号时发布。订阅者可以监听此事件执行后续操作，如：</p>
+ * <ul>
+ *   <li>AI 自动分析</li>
+ *   <li>发送通知给订阅者</li>
+ *   <li>更新热门信号排行</li>
+ * </ul>
  *
  * @author Koduck Team
  * @since 0.1.0
  */
 @Getter
-public class SignalPublishedEvent extends ApplicationEvent {
+public class SignalPublishedEvent extends DomainEvent {
 
-    private static final long serialVersionUID = 1L;
-
+    /** 信号ID。 */
     private final Long signalId;
-    private final Long userId;
-    private final String signalTitle;
+
+    /** 股票代码。 */
     private final String symbol;
-    private final String direction;
-    private final Instant occurredOn;
+
+    /** 信号类型：BUY, SELL。 */
+    private final String signalType;
+
+    /** 发布者ID。 */
+    private final Long publisherId;
 
     /**
-     * 创建信号发布事件。
+     * 构造信号发布事件。
      *
-     * @param source 事件源
      * @param signalId 信号ID
-     * @param userId 用户ID
-     * @param signalTitle 信号标题
      * @param symbol 股票代码
-     * @param direction 交易方向
+     * @param signalType 信号类型
+     * @param publisherId 发布者ID
      */
-    public SignalPublishedEvent(Object source, Long signalId, Long userId,
-                                String signalTitle, String symbol, String direction) {
-        super(source);
+    public SignalPublishedEvent(Long signalId, String symbol,
+                                 String signalType, Long publisherId) {
+        super();
         this.signalId = signalId;
-        this.userId = userId;
-        this.signalTitle = signalTitle;
         this.symbol = symbol;
-        this.direction = direction;
-        this.occurredOn = Instant.now();
+        this.signalType = signalType;
+        this.publisherId = publisherId;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("SignalPublishedEvent[signalId=%d, symbol=%s, type=%s, %s]",
+            signalId, symbol, signalType, super.toString());
     }
 }

--- a/koduck-backend/koduck-infrastructure/src/main/java/com/koduck/infrastructure/config/EventConfig.java
+++ b/koduck-backend/koduck-infrastructure/src/main/java/com/koduck/infrastructure/config/EventConfig.java
@@ -1,0 +1,19 @@
+package com.koduck.infrastructure.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+/**
+ * 事件配置类。
+ *
+ * <p>启用异步事件处理支持。</p>
+ *
+ * @author Koduck Team
+ * @since 0.1.0
+ */
+@Configuration
+@EnableAsync
+public class EventConfig {
+    // 异步事件配置由 @EnableAsync 启用
+    // 线程池配置可在 application.yml 中定义
+}

--- a/koduck-backend/koduck-infrastructure/src/main/java/com/koduck/infrastructure/event/SpringDomainEventPublisher.java
+++ b/koduck-backend/koduck-infrastructure/src/main/java/com/koduck/infrastructure/event/SpringDomainEventPublisher.java
@@ -1,0 +1,40 @@
+package com.koduck.infrastructure.event;
+
+import com.koduck.common.event.DomainEvent;
+import com.koduck.common.event.DomainEventPublisher;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+/**
+ * Spring 领域事件发布器实现。
+ *
+ * <p>基于 Spring 的 {@link ApplicationEventPublisher} 实现事件发布。
+ * 支持同步和异步事件处理。</p>
+ *
+ * @author Koduck Team
+ * @since 0.1.0
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SpringDomainEventPublisher implements DomainEventPublisher {
+
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+    @Override
+    public void publish(DomainEvent event) {
+        if (event == null) {
+            throw new IllegalArgumentException("Domain event must not be null");
+        }
+
+        log.debug("Publishing domain event: type={}, id={}",
+            event.getEventType(), event.getEventId());
+
+        applicationEventPublisher.publishEvent(event);
+
+        log.debug("Domain event published successfully: type={}, id={}",
+            event.getEventType(), event.getEventId());
+    }
+}

--- a/koduck-backend/koduck-market/koduck-market-api/src/main/java/com/koduck/market/event/MarketDataUpdatedEvent.java
+++ b/koduck-backend/koduck-market/koduck-market-api/src/main/java/com/koduck/market/event/MarketDataUpdatedEvent.java
@@ -1,40 +1,58 @@
 package com.koduck.market.event;
 
-import java.time.Instant;
-import java.util.List;
+import com.koduck.common.event.DomainEvent;
+import lombok.Getter;
+
+import java.math.BigDecimal;
 
 /**
- * 行情数据更新领域事件。
+ * 行情数据更新事件。
  *
- * <p>当股票行情数据发生变化时发布此事件。</p>
+ * <p>当股票行情数据发生变化时发布。订阅者可以监听此事件执行后续操作，如：</p>
+ * <ul>
+ *   <li>更新投资组合市值</li>
+ *   <li>触发价格预警</li>
+ *   <li>更新缓存</li>
+ * </ul>
  *
- * <p>其他领域模块可以订阅此事件以获取实时行情更新。</p>
- *
- * @param eventId   事件唯一标识
- * @param timestamp 事件发生时间
- * @param symbols   更新的股票代码列表
- * @param source    数据来源
  * @author Koduck Team
+ * @since 0.1.0
  */
-public record MarketDataUpdatedEvent(
-        String eventId,
-        Instant timestamp,
-        List<String> symbols,
-        String source
-) {
+@Getter
+public class MarketDataUpdatedEvent extends DomainEvent {
+
+    /** 股票代码。 */
+    private final String symbol;
+
+    /** 当前价格。 */
+    private final BigDecimal currentPrice;
+
+    /** 涨跌幅（百分比）。 */
+    private final BigDecimal changePercent;
+
+    /** 市场代码。 */
+    private final String market;
 
     /**
-     * 创建新的事件实例，自动生成事件ID和时间戳。
+     * 构造行情数据更新事件。
      *
-     * @param symbols 更新的股票代码列表
-     * @param source  数据来源
+     * @param symbol 股票代码
+     * @param currentPrice 当前价格
+     * @param changePercent 涨跌幅
+     * @param market 市场代码
      */
-    public MarketDataUpdatedEvent(List<String> symbols, String source) {
-        this(
-                java.util.UUID.randomUUID().toString(),
-                Instant.now(),
-                symbols,
-                source
-        );
+    public MarketDataUpdatedEvent(String symbol, BigDecimal currentPrice,
+                                   BigDecimal changePercent, String market) {
+        super();
+        this.symbol = symbol;
+        this.currentPrice = currentPrice;
+        this.changePercent = changePercent;
+        this.market = market;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("MarketDataUpdatedEvent[symbol=%s, price=%s, change=%s%%, %s]",
+            symbol, currentPrice, changePercent, super.toString());
     }
 }

--- a/koduck-backend/koduck-portfolio/koduck-portfolio-api/src/main/java/com/koduck/portfolio/event/PortfolioCreatedEvent.java
+++ b/koduck-backend/koduck-portfolio/koduck-portfolio-api/src/main/java/com/koduck/portfolio/event/PortfolioCreatedEvent.java
@@ -1,36 +1,50 @@
 package com.koduck.portfolio.event;
 
-import java.time.Instant;
-import java.util.UUID;
+import com.koduck.common.event.DomainEvent;
+import lombok.Getter;
 
 /**
- * 投资组合创建领域事件。
+ * 投资组合创建事件。
  *
- * @param eventId     事件唯一标识
- * @param timestamp   事件发生时间
- * @param userId      用户ID
- * @param portfolioId 投资组合ID
+ * <p>当新的投资组合被创建时发布。订阅者可以监听此事件执行后续操作，如：</p>
+ * <ul>
+ *   <li>发送通知</li>
+ *   <li>自动分析</li>
+ *   <li>记录审计日志</li>
+ * </ul>
+ *
  * @author Koduck Team
+ * @since 0.1.0
  */
-public record PortfolioCreatedEvent(
-        String eventId,
-        Instant timestamp,
-        Long userId,
-        Long portfolioId
-) {
+@Getter
+public class PortfolioCreatedEvent extends DomainEvent {
+
+    /** 投资组合ID。 */
+    private final Long portfolioId;
+
+    /** 投资组合名称。 */
+    private final String portfolioName;
+
+    /** 用户ID。 */
+    private final Long userId;
 
     /**
-     * 创建新的事件实例，自动生成事件ID和时间戳。
+     * 构造投资组合创建事件。
      *
-     * @param userId      用户ID
      * @param portfolioId 投资组合ID
+     * @param portfolioName 投资组合名称
+     * @param userId 用户ID
      */
-    public PortfolioCreatedEvent(Long userId, Long portfolioId) {
-        this(
-                UUID.randomUUID().toString(),
-                Instant.now(),
-                userId,
-                portfolioId
-        );
+    public PortfolioCreatedEvent(Long portfolioId, String portfolioName, Long userId) {
+        super();
+        this.portfolioId = portfolioId;
+        this.portfolioName = portfolioName;
+        this.userId = userId;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("PortfolioCreatedEvent[portfolioId=%d, portfolioName=%s, userId=%d, %s]",
+            portfolioId, portfolioName, userId, super.toString());
     }
 }

--- a/koduck-backend/koduck-portfolio/koduck-portfolio-api/src/main/java/com/koduck/portfolio/event/PositionChangedEvent.java
+++ b/koduck-backend/koduck-portfolio/koduck-portfolio-api/src/main/java/com/koduck/portfolio/event/PositionChangedEvent.java
@@ -1,70 +1,63 @@
 package com.koduck.portfolio.event;
 
+import com.koduck.common.event.DomainEvent;
+import lombok.Getter;
+
 import java.math.BigDecimal;
-import java.time.Instant;
-import java.util.UUID;
 
 /**
- * 持仓变更领域事件。
+ * 持仓变更事件。
  *
- * @param eventId      事件唯一标识
- * @param timestamp    事件发生时间
- * @param userId       用户ID
- * @param positionId   持仓ID
- * @param symbol       股票代码
- * @param changeType   变更类型（ADD/UPDATE/DELETE）
- * @param oldQuantity  原数量
- * @param newQuantity  新数量
- * @param oldAvgCost   原平均成本
- * @param newAvgCost   新平均成本
+ * <p>当投资组合的持仓发生变化时发布，包括：</p>
+ * <ul>
+ *   <li>新增持仓</li>
+ *   <li>减持持仓</li>
+ *   <li>清仓</li>
+ * </ul>
+ *
  * @author Koduck Team
+ * @since 0.1.0
  */
-public record PositionChangedEvent(
-        String eventId,
-        Instant timestamp,
-        Long userId,
-        Long positionId,
-        String symbol,
-        String changeType,
-        BigDecimal oldQuantity,
-        BigDecimal newQuantity,
-        BigDecimal oldAvgCost,
-        BigDecimal newAvgCost
-) {
+@Getter
+public class PositionChangedEvent extends DomainEvent {
+
+    /** 投资组合ID。 */
+    private final Long portfolioId;
+
+    /** 股票代码。 */
+    private final String symbol;
+
+    /** 变更类型：BUY, SELL, CLOSE。 */
+    private final String changeType;
+
+    /** 变更数量。 */
+    private final BigDecimal quantity;
+
+    /** 变更金额。 */
+    private final BigDecimal amount;
 
     /**
-     * 变更类型枚举。
+     * 构造持仓变更事件。
+     *
+     * @param portfolioId 投资组合ID
+     * @param symbol 股票代码
+     * @param changeType 变更类型
+     * @param quantity 变更数量
+     * @param amount 变更金额
      */
-    /** 添加类型。 */
-    public static final String TYPE_ADD = "ADD";
-    /** 更新类型。 */
-    public static final String TYPE_UPDATE = "UPDATE";
-    /** 删除类型。 */
-    public static final String TYPE_DELETE = "DELETE";
+    public PositionChangedEvent(Long portfolioId, String symbol, String changeType,
+                                 BigDecimal quantity, BigDecimal amount) {
+        super();
+        this.portfolioId = portfolioId;
+        this.symbol = symbol;
+        this.changeType = changeType;
+        this.quantity = quantity;
+        this.amount = amount;
+    }
 
-    /**
-     * 创建新的事件实例，自动生成事件ID和时间戳。
-     */
-    public PositionChangedEvent(
-            Long userId,
-            Long positionId,
-            String symbol,
-            String changeType,
-            BigDecimal oldQuantity,
-            BigDecimal newQuantity,
-            BigDecimal oldAvgCost,
-            BigDecimal newAvgCost) {
-        this(
-                UUID.randomUUID().toString(),
-                Instant.now(),
-                userId,
-                positionId,
-                symbol,
-                changeType,
-                oldQuantity,
-                newQuantity,
-                oldAvgCost,
-                newAvgCost
-        );
+    @Override
+    public String toString() {
+        return String.format("PositionChangedEvent[portfolioId=%d, symbol=%s, type=%s, %s]",
+            portfolioId, symbol, changeType, super.toString());
     }
 }


### PR DESCRIPTION
## 变更内容

- 创建 DomainEvent 基础事件类（koduck-common）
- 创建 DomainEventPublisher 发布器接口
- 创建 SpringDomainEventPublisher Spring 实现（koduck-infrastructure）
- 创建 EventConfig 启用异步事件处理
- 重构现有领域事件统一继承 DomainEvent：
  - PortfolioCreatedEvent
  - PositionChangedEvent
  - SignalPublishedEvent
  - MarketDataUpdatedEvent
- 创建 AiAnalysisEventListener 示例监听器

## 关联 Issue

Closes #618

## 检查清单

- [x] DomainEvent 基础类创建
- [x] 各领域事件定义完成
- [x] 事件发布/订阅机制实现
- [x] 示例监听器（AI 模块）
- [x] mvn clean compile 编译通过
- [x] mvn checkstyle:check 无异常

## 领域事件架构



## 后续工作

- 在业务代码中集成事件发布
- 添加更多事件监听器
- 可选：添加事件持久化/审计