### PR TITLE
feat(auth): Task 1.3 错误处理框架改进

### DIFF
--- a/koduck-auth/docs/ADR-0005-error-response-format.md
+++ b/koduck-auth/docs/ADR-0005-error-response-format.md
@@ -1,0 +1,128 @@
+# ADR-0005: 错误响应格式改进
+
+- Status: Accepted
+- Date: 2026-04-08
+- Issue: #638
+
+## Context
+
+koduck-auth 服务已实现基本的错误处理框架，但存在以下问题需要改进：
+
+1. **错误 code 字段类型不一致**: 当前响应中的 `code` 是数字（HTTP 状态码），而设计文档和 API 规范期望字符串形式的错误代码（如 `"UNAUTHORIZED"`、`"VALIDATION_ERROR"` 等），便于客户端识别和处理特定错误类型。
+
+2. **内部错误日志记录不完整**: 虽然 `client_message()` 方法正确隐藏了内部错误细节，但 `into_response()` 实现中没有显式记录完整错误信息，依赖上层中间件或调用方来记录。这可能导致内部错误信息丢失，不利于故障排查。
+
+## Decision
+
+### 错误响应格式改进
+
+将错误响应结构从：
+```json
+{
+  "success": false,
+  "code": 401,
+  "message": "Authentication failed",
+  "timestamp": "2026-04-08T12:00:00Z"
+}
+```
+
+改为：
+```json
+{
+  "success": false,
+  "code": "UNAUTHORIZED",
+  "message": "Authentication failed",
+  "timestamp": "2026-04-08T12:00:00Z"
+}
+```
+
+使用 `error_code()` 方法提供的字符串错误代码，而非 HTTP 状态码数字。
+
+### 内部错误日志记录
+
+在 `into_response()` 中增加内部错误日志记录：
+
+```rust
+impl IntoResponse for AppError {
+    fn into_response(self) -> Response {
+        // 记录内部错误详情（仅内部错误类型）
+        match &self {
+            AppError::Internal(_) | 
+            AppError::Database(_) | 
+            AppError::Config(_) | 
+            AppError::PasswordHash(_) | 
+            AppError::Io(_) => {
+                tracing::error!(error = %self, error_code = %self.error_code(), "Internal error occurred");
+            }
+            _ => {}
+        }
+        
+        // ... 构建响应
+    }
+}
+```
+
+### 错误类型映射
+
+| 错误类型 | HTTP 状态码 | 错误代码 (code) |
+|---------|------------|----------------|
+| Unauthorized | 401 | UNAUTHORIZED |
+| Forbidden | 403 | FORBIDDEN |
+| NotFound | 404 | NOT_FOUND |
+| Validation | 400 | VALIDATION_ERROR |
+| Conflict | 409 | CONFLICT |
+| Locked | 423 | RESOURCE_LOCKED |
+| TooManyRequests | 429 | RATE_LIMIT_EXCEEDED |
+| Internal | 500 | INTERNAL_ERROR |
+| ServiceUnavailable | 503 | SERVICE_UNAVAILABLE |
+| Database | 500 | DATABASE_ERROR |
+| Config | 500 | CONFIG_ERROR |
+| Jwt | 401 | JWT_ERROR |
+| PasswordHash | 500 | PASSWORD_HASH_ERROR |
+| Io | 500 | IO_ERROR |
+
+## Consequences
+
+### 正向影响
+
+1. **API 一致性**: 错误响应格式与设计文档和 API 规范保持一致
+2. **客户端友好**: 字符串错误代码更易于客户端识别和处理
+3. **可观测性**: 内部错误自动记录，便于故障排查和监控
+4. **安全性**: 内部错误详情不会暴露给客户端，但会记录到日志
+
+### 代价与风险
+
+1. **破坏性变更**: 如果已有客户端依赖数字 code 字段，需要更新
+2. **日志量增加**: 内部错误会额外产生 error 级别日志
+
+### 兼容性影响
+
+- **API 响应变更**: `code` 字段从数字变为字符串，需要通知客户端开发者
+- **向后不兼容**: 已有客户端如果依赖 `code` 的数字类型，需要更新
+
+## Alternatives Considered
+
+### 1. 同时返回数字和字符串 code
+
+- **方案**: 保留 `code`（数字），新增 `error_code`（字符串）
+- **拒绝理由**: 增加响应体积，不够简洁；已有 `error_code()` 方法，直接替换更合理
+
+### 2. 使用中间件统一记录错误
+
+- **方案**: 不在 `into_response()` 中记录，而是通过 Tower 中间件统一处理
+- **拒绝理由**: 增加了架构复杂度；当前方案更直接，且不会丢失上下文信息
+
+## Implementation Plan
+
+1. 修改 `ErrorResponse` 结构体，`code` 字段从 `u16` 改为 `String`
+2. 更新 `into_response()` 实现：
+   - 使用 `error_code()` 获取字符串 code
+   - 添加内部错误日志记录
+3. 更新相关测试用例
+4. 更新 API 文档
+
+## References
+
+- 任务文档: `docs/implementation/koduck-auth-rust-grpc-tasks.md` Task 1.3
+- 设计文档: `docs/design/koduck-auth-rust-grpc-design.md`
+- tracing crate: https://docs.rs/tracing/

--- a/koduck-auth/src/error.rs
+++ b/koduck-auth/src/error.rs
@@ -9,6 +9,7 @@ use serde::Serialize;
 use serde_json::json;
 use thiserror::Error;
 use tonic::Status;
+use tracing::error;
 
 /// Application error types
 #[derive(Error, Debug)]
@@ -60,7 +61,7 @@ pub enum AppError {
 #[derive(Serialize, Debug)]
 pub struct ErrorResponse {
     pub success: bool,
-    pub code: u16,
+    pub code: String,
     pub message: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub timestamp: Option<String>,
@@ -126,7 +127,32 @@ impl IntoResponse for AppError {
     fn into_response(self) -> Response {
         let status = self.status_code();
         let message = self.client_message();
-        let code = status.as_u16();
+        let code = self.error_code().to_string();
+
+        // Log internal errors for debugging
+        // Only log errors that indicate system issues, not user errors
+        match &self {
+            AppError::Internal(msg) => {
+                error!(error = %self, error_code = %code, message = %msg, "Internal server error occurred");
+            }
+            AppError::Database(err) => {
+                error!(error = %self, error_code = %code, error_source = %err, "Database error occurred");
+            }
+            AppError::Config(msg) => {
+                error!(error = %self, error_code = %code, message = %msg, "Configuration error occurred");
+            }
+            AppError::PasswordHash(msg) => {
+                error!(error = %self, error_code = %code, message = %msg, "Password hash error occurred");
+            }
+            AppError::Io(err) => {
+                error!(error = %self, error_code = %code, error_source = %err, "I/O error occurred");
+            }
+            // User errors are not logged at error level to avoid noise
+            // They can be traced at debug level if needed
+            _ => {
+                tracing::debug!(error = %self, error_code = %code, "User-facing error occurred");
+            }
+        }
 
         let body = Json(json!({
             "success": false,
@@ -199,3 +225,111 @@ impl From<Box<dyn std::error::Error>> for AppError {
 
 /// Result type alias for the application
 pub type Result<T> = std::result::Result<T, AppError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_error_code_mapping() {
+        // Test that all error types have correct error codes
+        assert_eq!(AppError::Unauthorized("test".to_string()).error_code(), "UNAUTHORIZED");
+        assert_eq!(AppError::Forbidden("test".to_string()).error_code(), "FORBIDDEN");
+        assert_eq!(AppError::NotFound("test".to_string()).error_code(), "NOT_FOUND");
+        assert_eq!(AppError::Validation("test".to_string()).error_code(), "VALIDATION_ERROR");
+        assert_eq!(AppError::Conflict("test".to_string()).error_code(), "CONFLICT");
+        assert_eq!(AppError::Locked("test".to_string()).error_code(), "RESOURCE_LOCKED");
+        assert_eq!(AppError::TooManyRequests("test".to_string()).error_code(), "RATE_LIMIT_EXCEEDED");
+        assert_eq!(AppError::Internal("test".to_string()).error_code(), "INTERNAL_ERROR");
+        assert_eq!(AppError::ServiceUnavailable("test".to_string()).error_code(), "SERVICE_UNAVAILABLE");
+        assert_eq!(AppError::Config("test".to_string()).error_code(), "CONFIG_ERROR");
+        assert_eq!(AppError::Jwt("test".to_string()).error_code(), "JWT_ERROR");
+        assert_eq!(AppError::PasswordHash("test".to_string()).error_code(), "PASSWORD_HASH_ERROR");
+    }
+
+    #[test]
+    fn test_status_code_mapping() {
+        assert_eq!(AppError::Unauthorized("test".to_string()).status_code(), StatusCode::UNAUTHORIZED);
+        assert_eq!(AppError::Forbidden("test".to_string()).status_code(), StatusCode::FORBIDDEN);
+        assert_eq!(AppError::NotFound("test".to_string()).status_code(), StatusCode::NOT_FOUND);
+        assert_eq!(AppError::Validation("test".to_string()).status_code(), StatusCode::BAD_REQUEST);
+        assert_eq!(AppError::Conflict("test".to_string()).status_code(), StatusCode::CONFLICT);
+        assert_eq!(AppError::Internal("test".to_string()).status_code(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[test]
+    fn test_client_message_hides_internal_details() {
+        // Internal errors should hide details
+        let internal = AppError::Internal("sensitive database password: secret123".to_string());
+        assert_eq!(internal.client_message(), "An internal error occurred");
+        
+        let db_error = AppError::Database(sqlx::Error::RowNotFound);
+        assert_eq!(db_error.client_message(), "A database error occurred");
+        
+        let config_error = AppError::Config("secret key: abc".to_string());
+        assert_eq!(config_error.client_message(), "A configuration error occurred");
+        
+        // User errors should show details
+        let validation = AppError::Validation("Invalid email format".to_string());
+        assert!(validation.client_message().contains("Invalid email format"));
+        
+        let unauthorized = AppError::Unauthorized("Invalid credentials".to_string());
+        assert!(unauthorized.client_message().contains("Invalid credentials"));
+    }
+
+    #[test]
+    fn test_error_response_format() {
+        // Create an error and verify the response structure
+        let error = AppError::Validation("Field 'email' is required".to_string());
+        
+        // Verify error code is string
+        assert_eq!(error.error_code(), "VALIDATION_ERROR");
+        
+        // Verify status code
+        assert_eq!(error.status_code(), StatusCode::BAD_REQUEST);
+        
+        // Verify client message
+        assert!(error.client_message().contains("email"));
+    }
+
+    #[test]
+    fn test_tonic_status_conversion() {
+        let app_error = AppError::Unauthorized("token expired".to_string());
+        let tonic_status: Status = app_error.into();
+        assert_eq!(tonic_status.code(), tonic::Code::Unauthenticated);
+        
+        let app_error = AppError::NotFound("user not found".to_string());
+        let tonic_status: Status = app_error.into();
+        assert_eq!(tonic_status.code(), tonic::Code::NotFound);
+        
+        let app_error = AppError::Validation("invalid input".to_string());
+        let tonic_status: Status = app_error.into();
+        assert_eq!(tonic_status.code(), tonic::Code::InvalidArgument);
+    }
+
+    #[test]
+    fn test_from_argon2_error() {
+        // This tests the From implementation compiles correctly
+        // We can't easily create a real argon2::password_hash::Error in test
+        // So we just verify the conversion exists
+        fn _verify_from_impl(err: argon2::password_hash::Error) -> AppError {
+            err.into()
+        }
+    }
+
+    #[test]
+    fn test_from_jwt_error() {
+        // Similar to above, verify the conversion exists
+        fn _verify_from_impl(err: jsonwebtoken::errors::Error) -> AppError {
+            err.into()
+        }
+    }
+
+    #[test]
+    fn test_error_chaining_display() {
+        let error = AppError::Internal("database connection failed".to_string());
+        let display = format!("{}", error);
+        assert!(display.contains("database connection failed"));
+        assert!(display.contains("Internal server error"));
+    }
+}


### PR DESCRIPTION
## 功能描述

改进 koduck-auth 错误处理框架，使错误响应符合设计文档要求。

## 主要变更

### 1. 错误响应格式改进
- `code` 字段从数字（HTTP 状态码）改为字符串错误代码
- 使用 `error_code()` 方法获取字符串形式（如 "UNAUTHORIZED", "VALIDATION_ERROR"）

**变更前:**
```json
{ "success": false, "code": 401, "message": "..." }
```

**变更后:**
```json
{ "success": false, "code": "UNAUTHORIZED", "message": "..." }
```

### 2. 内部错误日志记录
- 在 `into_response()` 中添加 `tracing::error!` 日志
- 自动记录 Internal、Database、Config、PasswordHash、Io 错误
- 包含完整错误信息和错误代码，便于故障排查
- 用户错误（如 Validation、Unauthorized）使用 debug 级别，避免日志噪音

### 3. 测试覆盖
- error_code 映射测试
- status_code 映射测试
- client_message 隐藏内部详情测试
- tonic Status 转换测试

## 验收标准

- [x] 所有错误类型定义完整
- [x] impl IntoResponse for AppError 实现
- [x] 错误响应 code 字段为字符串形式（ERROR_CODE）
- [x] 内部错误隐藏详细信息，同时记录 tracing::error! 日志
- [x] 支持错误链追踪
- [x] 单元测试覆盖错误响应格式

## 兼容性说明

⚠️ **破坏性变更**: `code` 字段从数字变为字符串，客户端需要更新

## 相关文档

- ADR-0005: koduck-auth/docs/ADR-0005-error-response-format.md

Closes #638