### PR TITLE
feat(auth): implement missing gRPC methods in AuthService

### DIFF
--- a/koduck-auth/docs/ADR-0015-implement-grpc-auth-methods.md
+++ b/koduck-auth/docs/ADR-0015-implement-grpc-auth-methods.md
@@ -1,0 +1,129 @@
+# ADR-0015: Implement Missing gRPC AuthService Methods
+
+- Status: Accepted
+- Date: 2026-04-08
+- Issue: #658
+
+## Context
+
+koduck-auth gRPC AuthService 有 4 个方法尚未完全实现：
+
+1. **get_user**: 需要根据 identifier（user_id/username/email）查询用户信息
+2. **get_user_roles**: 需要返回用户的角色和权限列表
+3. **get_jwks**: 需要返回真实的 JWKS 公钥数据
+4. **validate_token**: 需要从 token 自省结果中提取完整的用户信息
+
+当前实现都是占位符，返回 unimplemented 错误或空数据。
+
+## Decision
+
+### 1. 依赖注入扩展
+
+GrpcAuthService 需要新增依赖：
+
+```rust
+pub struct GrpcAuthService {
+    auth_service: AuthServiceImpl,
+    token_service: TokenServiceImpl,
+    user_repo: UserRepository,      // 新增：查询用户信息
+    jwks_service: JwksService,      // 新增：获取 JWKS
+}
+```
+
+### 2. get_user 实现
+
+支持三种 identifier 类型：
+
+```rust
+match req.identifier {
+    Some(get_user_request::Identifier::UserId(id)) => {
+        self.user_repo.find_by_id(id).await
+    }
+    Some(get_user_request::Identifier::Username(name)) => {
+        self.user_repo.find_by_username(&name).await
+    }
+    Some(get_user_request::Identifier::Email(email)) => {
+        self.user_repo.find_by_email(&email).await
+    }
+    None => Err(Status::invalid_argument("Identifier required")),
+}
+```
+
+### 3. get_user_roles 实现
+
+调用 repository 获取角色和权限：
+
+```rust
+let roles = self.user_repo.get_user_roles(req.user_id).await?;
+let permissions = self.user_repo.get_user_permissions(req.user_id).await?;
+```
+
+注意：需要在 UserRepository 中新增 `get_user_permissions` 方法。
+
+### 4. get_jwks 实现
+
+使用 JwksService 获取真实公钥数据：
+
+```rust
+let jwks_json = self.jwks_service.get_jwks()?;
+// Parse JSON and convert to proto Jwk messages
+```
+
+### 5. validate_token 实现
+
+从 introspect_token 结果提取完整字段：
+
+```rust
+match self.token_service.introspect_token(&req.token).await {
+    Ok(result) if result.active => {
+        let user_id = result.sub
+            .as_ref()
+            .and_then(|s| s.parse::<i64>().ok())
+            .unwrap_or(0);
+        
+        ValidateTokenResponse {
+            user_id,
+            username: result.username.unwrap_or_default(),
+            email: result.email.unwrap_or_default(),
+            roles: result.roles,
+            expires_at: result.exp.map(to_timestamp),
+            issued_at: result.iat.map(to_timestamp),
+            token_id: result.jti.unwrap_or_default(),
+            token_type: TokenType::Access as i32,
+        }
+    }
+    _ => Err(Status::unauthenticated("Invalid token")),
+}
+```
+
+## Consequences
+
+### 正向影响
+
+1. **功能完整**: AuthService 所有方法都能正常工作
+2. **服务间调用**: 其他服务可以通过 gRPC 获取用户信息和验证 token
+3. **标准兼容**: JWKS 端点提供标准公钥查询
+
+### 代价与风险
+
+1. **API 变更**: GrpcAuthService::new 签名变更，需要更新 main.rs
+2. **新增依赖**: 需要注入 UserRepository 和 JwksService
+
+### 兼容性影响
+
+- **破坏性变更**: GrpcAuthService::new 需要新增参数
+- **需要更新**: main.rs 中创建 GrpcAuthService 的代码
+
+## Implementation Plan
+
+1. **UserRepository**: 添加 `get_user_permissions` 方法
+2. **GrpcAuthService**: 
+   - 修改结构体添加 user_repo 和 jwks_service 字段
+   - 更新构造函数
+   - 实现 4 个缺失的方法
+3. **main.rs**: 更新 GrpcAuthService 创建代码，注入新依赖
+
+## References
+
+- 任务文档: `docs/implementation/koduck-auth-rust-grpc-tasks.md` Task 6.1
+- gRPC AuthService 设计: `docs/koduck-auth-rust-grpc-design.md`

--- a/koduck-auth/src/grpc/auth_service.rs
+++ b/koduck-auth/src/grpc/auth_service.rs
@@ -7,7 +7,9 @@ use crate::{
         auth_service_server::AuthService,
         *,
     },
-    model::UserStatus,
+    jwt::JwksService,
+    model::{Permission, UserStatus, UserInfo},
+    repository::UserRepository,
     service::{AuthService as AuthServiceImpl, TokenService as TokenServiceImpl},
 };
 use prost_types::Timestamp;
@@ -19,14 +21,23 @@ use tracing::{info, warn};
 pub struct GrpcAuthService {
     auth_service: AuthServiceImpl,
     token_service: TokenServiceImpl,
+    user_repo: UserRepository,
+    jwks_service: JwksService,
 }
 
 impl GrpcAuthService {
     /// Create new gRPC auth service
-    pub fn new(auth_service: AuthServiceImpl, token_service: TokenServiceImpl) -> Self {
+    pub fn new(
+        auth_service: AuthServiceImpl,
+        token_service: TokenServiceImpl,
+        user_repo: UserRepository,
+        jwks_service: JwksService,
+    ) -> Self {
         Self {
             auth_service,
             token_service,
+            user_repo,
+            jwks_service,
         }
     }
 
@@ -54,7 +65,7 @@ impl GrpcAuthService {
         }
     }
 
-    fn to_proto_user_info(user: crate::model::UserInfo) -> proto::UserInfo {
+    fn to_proto_user_info(user: UserInfo) -> proto::UserInfo {
         proto::UserInfo {
             id: user.id,
             username: user.username,
@@ -66,6 +77,23 @@ impl GrpcAuthService {
             created_at: None,
             updated_at: None,
         }
+    }
+
+    fn to_proto_permission(perm: Permission) -> proto::Permission {
+        proto::Permission {
+            id: perm.id,
+            name: perm.name,
+            resource: perm.resource,
+            action: perm.action,
+        }
+    }
+
+    /// Convert i64 timestamp seconds to prost Timestamp
+    fn to_timestamp(seconds: i64) -> Option<Timestamp> {
+        Some(Timestamp {
+            seconds,
+            nanos: 0,
+        })
     }
 }
 
@@ -117,21 +145,27 @@ impl AuthService for GrpcAuthService {
 
         // Use token service to introspect the token
         match self.token_service.introspect_token(&req.token).await {
-            Ok(true) => {
-                // Token is valid, extract claims (simplified for now)
+            Ok(result) if result.active => {
+                // Extract user_id from sub claim
+                let user_id = result
+                    .sub
+                    .as_ref()
+                    .and_then(|s| s.parse::<i64>().ok())
+                    .unwrap_or(0);
+
                 let response = ValidateTokenResponse {
-                    user_id: 0, // TODO: Extract from token claims
-                    username: String::new(),
-                    email: String::new(),
-                    roles: vec![],
-                    expires_at: None,
-                    token_id: String::new(),
-                    issued_at: None,
+                    user_id,
+                    username: result.username.unwrap_or_default(),
+                    email: result.email.unwrap_or_default(),
+                    roles: result.roles,
+                    expires_at: result.exp.and_then(|exp| Self::to_timestamp(exp)),
+                    issued_at: result.iat.and_then(|iat| Self::to_timestamp(iat)),
+                    token_id: result.jti.unwrap_or_default(),
                     token_type: proto::TokenType::Access as i32,
                 };
                 Ok(Response::new(response))
             }
-            Ok(false) => Err(Status::unauthenticated("Invalid or expired token")),
+            Ok(_) => Err(Status::unauthenticated("Invalid or expired token")),
             Err(e) => Err(Self::to_status(e)),
         }
     }
@@ -142,10 +176,37 @@ impl AuthService for GrpcAuthService {
     ) -> std::result::Result<Response<GetUserResponse>, Status> {
         let req = request.into_inner();
 
-        // TODO: Implement user lookup based on identifier
-        let _ = req.identifier;
+        // Find user based on identifier type
+        let user_result = match req.identifier {
+            Some(get_user_request::Identifier::UserId(id)) => {
+                self.user_repo.find_by_id(id).await
+            }
+            Some(get_user_request::Identifier::Username(username)) => {
+                self.user_repo.find_by_username(&username).await
+            }
+            Some(get_user_request::Identifier::Email(email)) => {
+                self.user_repo.find_by_email(&email).await
+            }
+            None => {
+                return Err(Status::invalid_argument("Identifier required"));
+            }
+        };
 
-        Err(Status::unimplemented("GetUser not yet implemented"))
+        match user_result {
+            Ok(Some(user)) => {
+                // Get user roles
+                let roles = self.user_repo.get_user_roles(user.id).await
+                    .map_err(Self::to_status)?;
+
+                let response = GetUserResponse {
+                    user: Some(Self::to_proto_user_info(UserInfo::from(user))),
+                    roles,
+                };
+                Ok(Response::new(response))
+            }
+            Ok(None) => Err(Status::not_found("User not found")),
+            Err(e) => Err(Self::to_status(e)),
+        }
     }
 
     async fn get_user_roles(
@@ -154,10 +215,20 @@ impl AuthService for GrpcAuthService {
     ) -> std::result::Result<Response<GetUserRolesResponse>, Status> {
         let req = request.into_inner();
 
-        // TODO: Implement user roles lookup
-        let _ = req.user_id;
+        // Get user roles
+        let roles = self.user_repo.get_user_roles(req.user_id).await
+            .map_err(Self::to_status)?;
 
-        Err(Status::unimplemented("GetUserRoles not yet implemented"))
+        // Get user permissions
+        let permissions = self.user_repo.get_user_permissions(req.user_id).await
+            .map_err(Self::to_status)?;
+
+        let response = GetUserRolesResponse {
+            user_id: req.user_id,
+            roles,
+            permissions: permissions.into_iter().map(Self::to_proto_permission).collect(),
+        };
+        Ok(Response::new(response))
     }
 
     async fn revoke_token(
@@ -232,8 +303,30 @@ impl AuthService for GrpcAuthService {
         &self,
         _request: Request<()>,
     ) -> std::result::Result<Response<JwksResponse>, Status> {
-        // TODO: Implement JWKS retrieval from JWT service
-        let response = JwksResponse { keys: vec![] };
+        // Get JWKS from JwksService
+        let jwks_json = self.jwks_service.get_jwks()
+            .map_err(|e| Status::internal(format!("Failed to get JWKS: {}", e)))?;
+
+        // Parse the JWKS JSON and convert to proto messages
+        let keys = if let Some(keys_array) = jwks_json.get("keys").and_then(|k| k.as_array()) {
+            keys_array
+                .iter()
+                .filter_map(|key| {
+                    Some(proto::Jwk {
+                        kty: key.get("kty")?.as_str()?.to_string(),
+                        kid: key.get("kid")?.as_str()?.to_string(),
+                        r#use: key.get("use")?.as_str()?.to_string(),
+                        n: key.get("n")?.as_str()?.to_string(),
+                        e: key.get("e")?.as_str()?.to_string(),
+                        alg: key.get("alg")?.as_str()?.to_string(),
+                    })
+                })
+                .collect()
+        } else {
+            vec![]
+        };
+
+        let response = JwksResponse { keys };
         Ok(Response::new(response))
     }
 

--- a/koduck-auth/src/grpc/server.rs
+++ b/koduck-auth/src/grpc/server.rs
@@ -6,6 +6,8 @@ use crate::{
         proto::{auth_service_server::AuthServiceServer, token_service_server::TokenServiceServer},
         token_service::GrpcTokenService,
     },
+    jwt::JwksService,
+    repository::UserRepository,
     service::{AuthService as AuthServiceImpl, TokenService as TokenServiceImpl},
 };
 use std::net::SocketAddr;
@@ -25,8 +27,15 @@ impl GrpcServer {
         addr: SocketAddr,
         auth_service_impl: AuthServiceImpl,
         token_service_impl: TokenServiceImpl,
+        user_repo: UserRepository,
+        jwks_service: JwksService,
     ) -> Self {
-        let auth_service = GrpcAuthService::new(auth_service_impl, token_service_impl.clone());
+        let auth_service = GrpcAuthService::new(
+            auth_service_impl,
+            token_service_impl.clone(),
+            user_repo,
+            jwks_service,
+        );
         let token_service = GrpcTokenService::new(token_service_impl);
 
         Self {
@@ -55,8 +64,10 @@ pub async fn create_and_run_grpc_server(
     addr: SocketAddr,
     auth_service: AuthServiceImpl,
     token_service: TokenServiceImpl,
+    user_repo: UserRepository,
+    jwks_service: JwksService,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let server = GrpcServer::new(addr, auth_service, token_service);
+    let server = GrpcServer::new(addr, auth_service, token_service, user_repo, jwks_service);
     server.run().await
 }
 
@@ -64,8 +75,15 @@ pub async fn create_and_run_grpc_server(
 pub fn create_grpc_services(
     auth_service_impl: AuthServiceImpl,
     token_service_impl: TokenServiceImpl,
+    user_repo: UserRepository,
+    jwks_service: JwksService,
 ) -> (AuthServiceServer<GrpcAuthService>, TokenServiceServer<GrpcTokenService>) {
-    let auth_service = GrpcAuthService::new(auth_service_impl, token_service_impl.clone());
+    let auth_service = GrpcAuthService::new(
+        auth_service_impl,
+        token_service_impl.clone(),
+        user_repo,
+        jwks_service,
+    );
     let token_service = GrpcTokenService::new(token_service_impl);
 
     (

--- a/koduck-auth/src/jwt/jwks.rs
+++ b/koduck-auth/src/jwt/jwks.rs
@@ -3,11 +3,12 @@
 use crate::error::{AppError, Result};
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use rsa::{traits::PublicKeyParts, RsaPublicKey, pkcs8::DecodePublicKey};
+use std::sync::Arc;
 
 /// JWKS service
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct JwksService {
-    public_key: RsaPublicKey,
+    public_key: Arc<RsaPublicKey>,
     key_id: String,
 }
 
@@ -18,7 +19,7 @@ impl JwksService {
             .map_err(|e| AppError::Jwt(format!("Failed to parse public key: {}", e)))?;
 
         Ok(Self {
-            public_key,
+            public_key: Arc::new(public_key),
             key_id,
         })
     }

--- a/koduck-auth/src/main.rs
+++ b/koduck-auth/src/main.rs
@@ -10,7 +10,7 @@ use koduck_auth::{
     grpc::create_grpc_services,
     http::create_router,
     init_state,
-    jwt::JwtValidator,
+    jwt::{JwksService, JwtValidator},
     repository::{PasswordResetRepository, RedisCache, RefreshTokenRepository, UserRepository},
     service::{AuthService as AuthServiceImpl, TokenService as TokenServiceImpl},
 };
@@ -37,7 +37,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let password_reset_repo = PasswordResetRepository::new(state.db_pool().clone());
     let redis = RedisCache::new(state.redis_pool().clone());
 
-    // Load public key for JWT validation
+    // Load public key for JWT validation and JWKS
     let public_key = load_public_key(&config.jwt.public_key_path).await?;
 
     // Create JWT validator for token introspection
@@ -46,6 +46,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         config.jwt.audience.clone(),
         config.jwt.issuer.clone(),
     )?;
+
+    // Create JWKS service
+    let jwks_service = JwksService::new(&public_key, config.jwt.key_id.clone())?;
 
     // Create services
     let auth_service_impl = AuthServiceImpl::new(
@@ -66,7 +69,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Create gRPC services
     let grpc_addr: SocketAddr = config.server.grpc_addr.parse()?;
-    let (auth_grpc_service, token_grpc_service) = create_grpc_services(auth_service_impl, token_service_impl);
+    let (auth_grpc_service, token_grpc_service) = create_grpc_services(
+        auth_service_impl,
+        token_service_impl,
+        user_repo,
+        jwks_service,
+    );
 
     info!("HTTP server listening on {}", http_addr);
     info!("gRPC server listening on {}", grpc_addr);

--- a/koduck-auth/src/model/user.rs
+++ b/koduck-auth/src/model/user.rs
@@ -78,3 +78,12 @@ pub struct UpdateUserDto {
     pub nickname: Option<String>,
     pub avatar_url: Option<String>,
 }
+
+/// Permission entity
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
+pub struct Permission {
+    pub id: i64,
+    pub name: String,
+    pub resource: String,
+    pub action: String,
+}

--- a/koduck-auth/src/repository/user_repository.rs
+++ b/koduck-auth/src/repository/user_repository.rs
@@ -216,6 +216,25 @@ impl UserRepository {
         Ok(roles)
     }
 
+    /// Get user permissions
+    pub async fn get_user_permissions(&self, user_id: i64) -> Result<Vec<crate::model::Permission>> {
+        let permissions = sqlx::query_as::<_, crate::model::Permission>(
+            r#"
+            SELECT DISTINCT p.id, p.name, p.resource, p.action
+            FROM permissions p
+            JOIN role_permissions rp ON p.id = rp.permission_id
+            JOIN user_roles ur ON rp.role_id = ur.role_id
+            WHERE ur.user_id = $1
+            "#,
+        )
+        .bind(user_id)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(AppError::Database)?;
+
+        Ok(permissions)
+    }
+
     /// Assign role to user
     pub async fn assign_role(&self, user_id: i64, role_name: &str) -> Result<()> {
         sqlx::query(


### PR DESCRIPTION
## Summary

实现 gRPC AuthService 中缺失的 4 个方法。

## Changes

### src/grpc/auth_service.rs
- **get_user**: 根据 identifier 类型（user_id/username/email）查询用户信息
- **get_user_roles**: 获取用户角色和权限列表
- **get_jwks**: 从 JwksService 返回真实 JWKS 数据
- **validate_token**: 从 introspect_token 结果提取完整字段

### src/repository/user_repository.rs
- 新增 get_user_permissions 方法

### src/model/user.rs
- 新增 Permission 模型

### src/jwt/jwks.rs
- 使用 Arc<RsaPublicKey> 支持 Clone

### src/grpc/server.rs & src/main.rs
- 更新依赖注入，传递 UserRepository 和 JwksService

### ADR
- 新增 ADR-0015 记录实现决策

## Acceptance Criteria

- [x] get_user 实现支持多种 identifier 类型
- [x] get_user_roles 返回角色和权限
- [x] get_jwks 返回真实公钥数据
- [x] validate_token 提取所有字段

Closes #658