### PR TITLE
feat(auth): implement refresh_token and generate_token_pair in gRPC TokenService

### DIFF
--- a/koduck-auth/docs/ADR-0016-implement-token-refresh-methods.md
+++ b/koduck-auth/docs/ADR-0016-implement-token-refresh-methods.md
@@ -1,0 +1,132 @@
+# ADR-0016: Implement Token Refresh and Generation Methods
+
+- Status: Accepted
+- Date: 2026-04-08
+- Issue: #660
+
+## Context
+
+gRPC TokenService 有两个方法尚未实现：
+
+1. **refresh_token**: 用于刷新过期的 access token
+   - 当前返回 unimplemented 错误
+   - 需要调用 auth_service.refresh_token 完成实际的刷新逻辑
+
+2. **generate_token_pair**: 用于内部服务间直接生成 token 对
+   - 当前返回 unimplemented 错误
+   - 需要直接调用 jwt_service 生成 token，无需验证旧 token
+   - 这是内部服务调用，用于服务间 token 生成
+
+## Decision
+
+### 1. 依赖注入扩展
+
+GrpcTokenService 需要新增依赖：
+
+```rust
+pub struct GrpcTokenService {
+    token_service: TokenServiceImpl,
+    auth_service: AuthServiceImpl,  // 新增：用于 refresh_token
+    jwt_service: JwtService,        // 新增：用于 generate_token_pair
+}
+```
+
+### 2. refresh_token 实现
+
+流程：
+1. 从请求中提取 refresh_token
+2. 调用 auth_service.refresh_token 验证旧 token 并生成新 pair
+3. 返回新的 token pair
+
+```rust
+let refresh_req = RefreshTokenRequest {
+    refresh_token: req.refresh_token,
+};
+
+let token_response = self.auth_service.refresh_token(refresh_req).await?;
+
+RefreshTokenResponse {
+    tokens: Some(TokenPair {
+        access_token: token_response.tokens.access_token,
+        refresh_token: token_response.tokens.refresh_token,
+        token_type: token_response.tokens.token_type,
+        expires_in: token_response.tokens.expires_in,
+    }),
+}
+```
+
+### 3. generate_token_pair 实现
+
+流程：
+1. 从请求中提取用户信息（user_id, username, email, roles）
+2. 直接调用 jwt_service 生成 access_token 和 refresh_token
+3. 返回 token pair
+
+```rust
+let access_token = self.jwt_service.generate_access_token(
+    req.user_id,
+    &req.username,
+    &req.email,
+    &req.roles,
+)?;
+
+let refresh_token = self.jwt_service.generate_refresh_token(req.user_id)?;
+
+GenerateTokenPairResponse {
+    tokens: Some(TokenPair {
+        access_token,
+        refresh_token,
+        token_type: "Bearer".to_string(),
+        expires_in: self.jwt_service.access_expiration(),
+    }),
+}
+```
+
+### 4. JwtService 扩展
+
+需要添加方法获取 token 过期时间配置：
+
+```rust
+impl JwtService {
+    pub fn access_expiration(&self) -> i64 {
+        self.access_expiration
+    }
+    
+    pub fn refresh_expiration(&self) -> i64 {
+        self.refresh_expiration
+    }
+}
+```
+
+## Consequences
+
+### 正向影响
+
+1. **功能完整**: TokenService 所有方法都能正常工作
+2. **服务间协作**: 支持服务间 token 刷新和生成
+3. **内部调用**: generate_token_pair 可用于内部服务直接生成 token
+
+### 代价与风险
+
+1. **API 变更**: GrpcTokenService::new 签名变更，需要更新 server.rs 和 main.rs
+2. **循环依赖风险**: TokenService 依赖 AuthService，需要注意避免循环依赖
+
+### 兼容性影响
+
+- **破坏性变更**: GrpcTokenService::new 需要新增参数
+- **需要更新**: server.rs 和 main.rs 中创建 GrpcTokenService 的代码
+
+## Implementation Plan
+
+1. **JwtService**: 添加 access_expiration 和 refresh_expiration getter 方法
+2. **GrpcTokenService**:
+   - 修改结构体添加 auth_service 和 jwt_service 字段
+   - 更新构造函数
+   - 实现 refresh_token 和 generate_token_pair 方法
+3. **grpc/server.rs**: 更新 GrpcTokenService 创建代码
+4. **main.rs**: 注入新的依赖到 GrpcTokenService
+
+## References
+
+- 任务文档: `docs/implementation/koduck-auth-rust-grpc-tasks.md` Task 6.2
+- gRPC TokenService 设计: `docs/koduck-auth-rust-grpc-design.md`

--- a/koduck-auth/src/grpc/server.rs
+++ b/koduck-auth/src/grpc/server.rs
@@ -7,6 +7,7 @@ use crate::{
         token_service::GrpcTokenService,
     },
     jwt::JwksService,
+    jwt::JwtService,
     repository::UserRepository,
     service::{AuthService as AuthServiceImpl, TokenService as TokenServiceImpl},
 };
@@ -29,14 +30,19 @@ impl GrpcServer {
         token_service_impl: TokenServiceImpl,
         user_repo: UserRepository,
         jwks_service: JwksService,
+        jwt_service: JwtService,
     ) -> Self {
         let auth_service = GrpcAuthService::new(
-            auth_service_impl,
+            auth_service_impl.clone(),
             token_service_impl.clone(),
             user_repo,
             jwks_service,
         );
-        let token_service = GrpcTokenService::new(token_service_impl);
+        let token_service = GrpcTokenService::new(
+            token_service_impl,
+            auth_service_impl,
+            jwt_service,
+        );
 
         Self {
             addr,
@@ -66,8 +72,9 @@ pub async fn create_and_run_grpc_server(
     token_service: TokenServiceImpl,
     user_repo: UserRepository,
     jwks_service: JwksService,
+    jwt_service: JwtService,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let server = GrpcServer::new(addr, auth_service, token_service, user_repo, jwks_service);
+    let server = GrpcServer::new(addr, auth_service, token_service, user_repo, jwks_service, jwt_service);
     server.run().await
 }
 
@@ -77,14 +84,19 @@ pub fn create_grpc_services(
     token_service_impl: TokenServiceImpl,
     user_repo: UserRepository,
     jwks_service: JwksService,
+    jwt_service: JwtService,
 ) -> (AuthServiceServer<GrpcAuthService>, TokenServiceServer<GrpcTokenService>) {
     let auth_service = GrpcAuthService::new(
-        auth_service_impl,
+        auth_service_impl.clone(),
         token_service_impl.clone(),
         user_repo,
         jwks_service,
     );
-    let token_service = GrpcTokenService::new(token_service_impl);
+    let token_service = GrpcTokenService::new(
+        token_service_impl,
+        auth_service_impl,
+        jwt_service,
+    );
 
     (
         AuthServiceServer::new(auth_service),

--- a/koduck-auth/src/grpc/token_service.rs
+++ b/koduck-auth/src/grpc/token_service.rs
@@ -6,7 +6,8 @@ use crate::{
         token_service_server::TokenService,
         *,
     },
-    service::TokenService as TokenServiceImpl,
+    jwt::JwtService,
+    service::{AuthService as AuthServiceImpl, TokenService as TokenServiceImpl},
 };
 use tonic::{Request, Response, Status};
 use tracing::info;
@@ -15,12 +16,22 @@ use tracing::info;
 #[derive(Clone)]
 pub struct GrpcTokenService {
     token_service: TokenServiceImpl,
+    auth_service: AuthServiceImpl,
+    jwt_service: JwtService,
 }
 
 impl GrpcTokenService {
     /// Create new gRPC token service
-    pub fn new(token_service: TokenServiceImpl) -> Self {
-        Self { token_service }
+    pub fn new(
+        token_service: TokenServiceImpl,
+        auth_service: AuthServiceImpl,
+        jwt_service: JwtService,
+    ) -> Self {
+        Self {
+            token_service,
+            auth_service,
+            jwt_service,
+        }
     }
 
     /// Convert AppError to tonic::Status
@@ -89,12 +100,21 @@ impl TokenService for GrpcTokenService {
             refresh_token: req.refresh_token,
         };
 
-        // Note: This should use auth_service.refresh_token, not token_service
-        // For now, return unimplemented
-        let _ = refresh_req;
-        Err(Status::unimplemented(
-            "RefreshToken not yet fully implemented",
-        ))
+        // Call auth_service to refresh token
+        match self.auth_service.refresh_token(refresh_req).await {
+            Ok(token_response) => {
+                let response = RefreshTokenResponse {
+                    tokens: Some(proto::TokenPair {
+                        access_token: token_response.tokens.access_token,
+                        refresh_token: token_response.tokens.refresh_token,
+                        token_type: token_response.tokens.token_type,
+                        expires_in: token_response.tokens.expires_in,
+                    }),
+                };
+                Ok(Response::new(response))
+            }
+            Err(e) => Err(Self::to_status(e)),
+        }
     }
 
     async fn generate_token_pair(
@@ -104,11 +124,31 @@ impl TokenService for GrpcTokenService {
         let req = request.into_inner();
         info!("Generating token pair for user: {}", req.user_id);
 
-        // TODO: Implement token pair generation using JWT service
-        let _ = (req.user_id, req.username, req.email, req.roles);
+        // Generate access token using jwt_service
+        let access_token = self
+            .jwt_service
+            .generate_access_token(
+                req.user_id,
+                &req.username,
+                &req.email,
+                &req.roles,
+            )
+            .map_err(Self::to_status)?;
 
-        Err(Status::unimplemented(
-            "GenerateTokenPair not yet fully implemented",
-        ))
+        // Generate refresh token using jwt_service
+        let refresh_token = self
+            .jwt_service
+            .generate_refresh_token(req.user_id)
+            .map_err(Self::to_status)?;
+
+        let response = GenerateTokenPairResponse {
+            tokens: Some(proto::TokenPair {
+                access_token,
+                refresh_token,
+                token_type: "Bearer".to_string(),
+                expires_in: self.jwt_service.access_expiration(),
+            }),
+        };
+        Ok(Response::new(response))
     }
 }

--- a/koduck-auth/src/jwt/generator.rs
+++ b/koduck-auth/src/jwt/generator.rs
@@ -103,4 +103,14 @@ impl JwtService {
     pub fn key_id(&self) -> &str {
         &self.key_id
     }
+
+    /// Get access token expiration in seconds
+    pub fn access_expiration(&self) -> i64 {
+        self.access_expiration
+    }
+
+    /// Get refresh token expiration in seconds
+    pub fn refresh_expiration(&self) -> i64 {
+        self.refresh_expiration
+    }
 }

--- a/koduck-auth/src/main.rs
+++ b/koduck-auth/src/main.rs
@@ -62,6 +62,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     )?;
     let token_service_impl = TokenServiceImpl::new(token_repo, redis, jwt_validator);
 
+    // Clone jwt_service for token service
+    let jwt_service_for_token = state.jwt_service().clone();
+
     // Create HTTP service
     let http_addr: SocketAddr = config.server.http_addr.parse()?;
     let http_listener = TcpListener::bind(http_addr).await?;
@@ -74,6 +77,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         token_service_impl,
         user_repo,
         jwks_service,
+        jwt_service_for_token,
     );
 
     info!("HTTP server listening on {}", http_addr);


### PR DESCRIPTION
## Summary

实现 gRPC TokenService 中的 refresh_token 和 generate_token_pair 方法。

## Changes

### src/grpc/token_service.rs
- **refresh_token**: 调用 auth_service.refresh_token 完成刷新流程
- **generate_token_pair**: 使用 jwt_service 直接生成 token 对

### src/jwt/generator.rs
- 添加 access_expiration() 和 refresh_expiration() getter 方法

### src/grpc/server.rs & src/main.rs
- 更新依赖注入，传递 AuthServiceImpl 和 JwtService

### ADR
- 新增 ADR-0016 记录实现决策

## Acceptance Criteria

- [x] refresh_token 调用 auth_service.refresh_token 并返回新 tokens
- [x] generate_token_pair 使用 jwt_service 直接生成 tokens
- [x] 正确处理错误并返回适当状态码

Closes #660