### PR TITLE
fix(docker): remove syntax directive to avoid registry timeout

### DIFF
--- a/koduck-auth/Dockerfile
+++ b/koduck-auth/Dockerfile
@@ -1,4 +1,3 @@
-# syntax=docker/dockerfile:1.7
 # Multi-stage build for koduck-auth
 
 # Stage 1: Builder


### PR DESCRIPTION
## Summary

移除 Dockerfile 中的  指令，避免在某些网络环境下构建失败。

## Problem

在某些网络环境下，Docker 无法连接到 registry-1.docker.io 下载 docker/dockerfile:1.7 镜像，导致构建失败：



## Solution

移除 syntax 指令，使用默认的 Dockerfile 语法版本。本项目不需要 Dockerfile 1.7 特有的功能。

## Changes

- 删除 Dockerfile 第一行的 

Refs #666