### PR TITLE
feat(user): implement AuthClient for token introspection via APISIX (Task 5.3)

### DIFF
--- a/koduck-user/docs/adr/0012-auth-client-introspection-via-apisix.md
+++ b/koduck-user/docs/adr/0012-auth-client-introspection-via-apisix.md
@@ -1,0 +1,172 @@
+# ADR-0012: AuthClient Token 自省通过 APISIX 调用（Task 5.3）
+
+## 元数据
+
+- **状态**: 已接受
+- **日期**: 2026-04-09
+- **作者**: @hailingu
+- **相关**: #697, docs/implementation/koduck-user-service-tasks.md Task 5.3, ADR-0008
+
+---
+
+## 背景与问题陈述
+
+默认主链路为 `koduck-auth -> koduck-user`（auth 调用 user 的内部 API），koduck-user 作为纯被调用方。但在某些场景下 koduck-user 需要反向调用 koduck-auth：
+
+1. **Token 自省**：高风险操作（如删除账户）需实时验证 Token 有效性
+2. **会话强制失效**：密码修改后需要吊销所有活跃 Token
+
+本任务为可选链路，需明确：调用路径、认证方式、开关策略、失败处理。
+
+---
+
+## 决策驱动因素
+
+1. **默认不调用**：大多数场景 koduck-user 无需调用 auth，必须支持完全关闭
+2. **网关统一认证**：服务间调用必须经过 APISIX，禁止直连 auth 服务
+3. **安全性**：apikey 缺失或错误时必须快速失败并记录审计日志
+4. **可靠性**：区分认证失败（不重试）和瞬态错误（有限重试）
+
+---
+
+## 考虑的选项
+
+### 选项 1：RestTemplate + Spring Retry（选定）
+
+**描述**: 使用 Spring 自带的 `RestTemplate` 发起 HTTP 调用，配合自定义重试逻辑。
+
+**优点**:
+- 无需额外依赖（`spring-boot-starter-web` 已包含 RestTemplate）
+- 同步模型，调用逻辑简单直观
+- 可精确控制重试策略
+- 与现有 Spring Boot 3.4 生态一致
+
+**缺点**:
+- 阻塞式调用，在高并发场景下可能占用线程
+- 需手动管理超时和重试逻辑
+
+### 选项 2：WebClient（响应式）
+
+**优点**:
+- 非阻塞，资源利用率高
+- 内置重试机制
+
+**缺点**:
+- 需引入 `spring-boot-starter-webflux`，增加依赖
+- 项目当前为同步架构（JPA + Spring MVC），引入响应式增加复杂度
+- 大部分代码仍为同步，仅 AuthClient 为响应式造成风格不一致
+
+### 选项 3：Spring Cloud OpenFeign
+
+**优点**:
+- 声明式客户端，代码简洁
+
+**缺点**:
+- 需引入 Spring Cloud 依赖，重量级
+- 当前阶段不需要服务发现等 Cloud 特性
+- 过度工程化
+
+---
+
+## 决策结果
+
+采用 **选项 1**：`RestTemplate` + 自定义重试逻辑。
+
+### 核心设计
+
+1. **AuthClient**：封装调用 koduck-auth 的 HTTP 客户端
+2. **AuthClientConfig**：配置 RestTemplate Bean 和相关属性
+3. **Feature Toggle**：`auth.introspection.enabled=false` 默认关闭
+4. **路由策略**：所有调用通过 `AUTH_BASE_URL`（默认 APISIX 地址），禁止直连 auth
+5. **认证方式**：每次请求携带 `apikey` header
+6. **失败策略**：
+   - 401/403（认证失败）：不重试，记录安全审计日志
+   - 5xx/网络错误：最多重试 2 次，指数退避
+   - 4xx 其他：不重试
+
+---
+
+## 实施细节
+
+### 配置项
+
+```yaml
+auth:
+  introspection:
+    enabled: ${AUTH_INTROSPECTION_ENABLED:false}
+  base-url: ${AUTH_BASE_URL:http://apisix:9080}
+  api-key: ${AUTH_API_KEY:}
+  connect-timeout: 3000
+  read-timeout: 5000
+  retry:
+    max-attempts: 2
+    backoff-millis: 500
+```
+
+### 新增文件
+
+| 文件 | 说明 |
+|------|------|
+| `client/AuthClient.java` | 调用 auth 的客户端接口 |
+| `client/AuthClientImpl.java` | 客户端实现（RestTemplate + 重试） |
+| `client/AuthClientConfig.java` | RestTemplate Bean 配置 |
+| `client/dto/TokenIntrospectionRequest.java` | Token 自省请求 |
+| `client/dto/TokenIntrospectionResponse.java` | Token 自省响应 |
+| `client/dto/TokenRevocationRequest.java` | Token 吊销请求 |
+| `client/exception/AuthClientException.java` | 客户端异常 |
+
+### 测试覆盖
+
+- 开关关闭时，AuthClient 不发起任何 HTTP 调用
+- 开关开启时，调用走 APISIX 地址
+- apikey 缺失/错误 -> 记录安全日志并失败
+- 成功响应 -> 正确解析
+- 401/403 -> 不重试
+- 5xx -> 有限重试
+
+---
+
+## 权衡与影响
+
+### 正向影响
+
+- 提供可选的反向调用能力，支持高风险场景
+- 通过 APISIX 统一认证，复用网关安全能力
+- Feature toggle 确保默认行为不变
+
+### 负向影响
+
+- 新增出站 HTTP 调用，增加 koduck-user 的外部依赖面
+- 需要管理 apikey 的安全存储和轮换
+
+### 缓解措施
+
+- 默认关闭开关，仅在明确需要时启用
+- apikey 通过 K8s Secret 注入，禁止硬编码
+- 安全审计日志确保调用可追踪
+
+---
+
+## 兼容性影响
+
+1. **API 路由兼容**: 无新增/删除路由，仅新增出站调用
+2. **响应语义兼容**: 不影响现有 API 行为
+3. **配置兼容**: 新增配置项均有默认值，不影响现有部署
+4. **依赖兼容**: 无新增外部依赖
+
+---
+
+## 相关文档
+
+- [koduck-user-jwt-design.md](../../../docs/design/koduck-user-jwt-design.md) 5.2~5.5 节
+- [koduck-auth-user-service-design.md](../../../docs/design/koduck-auth-user-service-design.md)
+- [koduck-user-api.yaml](../../../docs/design/koduck-user-api.yaml)
+- [ADR-0008](./0008-internal-user-controller-implementation.md)
+
+---
+
+## 变更日志
+
+| 日期 | 变更 | 作者 |
+|------|------|------|
+| 2026-04-09 | 初始版本 | @hailingu |

--- a/koduck-user/src/main/java/com/koduck/client/AuthClient.java
+++ b/koduck-user/src/main/java/com/koduck/client/AuthClient.java
@@ -1,0 +1,28 @@
+package com.koduck.client;
+
+import com.koduck.client.dto.TokenIntrospectionResponse;
+import com.koduck.client.dto.TokenRevocationRequest;
+
+/**
+ * Auth 服务客户端接口。
+ *
+ * <p>封装 koduck-user 对 koduck-auth 的反向调用（Token 自省/吊销）。
+ * 所有调用通过 APISIX 网关进行，受 {@code auth.introspection.enabled} 开关控制。</p>
+ */
+public interface AuthClient {
+
+    /**
+     * 自省 Token 有效性。
+     *
+     * @param token JWT access token
+     * @return 自省结果，包含有效性、用户信息等
+     */
+    TokenIntrospectionResponse introspectToken(String token);
+
+    /**
+     * 吊销指定用户的所有 Token。
+     *
+     * @param request 吊销请求（包含用户ID和原因）
+     */
+    void revokeTokens(TokenRevocationRequest request);
+}

--- a/koduck-user/src/main/java/com/koduck/client/AuthClientConfig.java
+++ b/koduck-user/src/main/java/com/koduck/client/AuthClientConfig.java
@@ -1,0 +1,27 @@
+package com.koduck.client;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * AuthClient 配置类。
+ *
+ * <p>仅在 {@code auth.introspection.enabled=true} 时激活，配置 RestTemplate Bean 和属性绑定。</p>
+ */
+@Configuration
+@EnableConfigurationProperties(AuthClientProperties.class)
+@ConditionalOnProperty(prefix = "auth.introspection", name = "enabled", havingValue = "true")
+public class AuthClientConfig {
+
+    @Bean
+    public RestTemplate authRestTemplate(AuthClientProperties properties) {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(properties.getConnectTimeout());
+        factory.setReadTimeout(properties.getReadTimeout());
+        return new RestTemplate(factory);
+    }
+}

--- a/koduck-user/src/main/java/com/koduck/client/AuthClientImpl.java
+++ b/koduck-user/src/main/java/com/koduck/client/AuthClientImpl.java
@@ -1,0 +1,130 @@
+package com.koduck.client;
+
+import com.koduck.client.dto.TokenIntrospectionResponse;
+import com.koduck.client.dto.TokenRevocationRequest;
+import com.koduck.client.exception.AuthClientException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+/**
+ * AuthClient 实现。
+ *
+ * <p>通过 APISIX 网关调用 koduck-auth 内部 API，携带 apikey 进行 key-auth 认证。
+ * 401/403 不重试并记录安全审计日志；5xx/网络错误有限重试。</p>
+ */
+@Component
+@ConditionalOnProperty(prefix = "auth.introspection", name = "enabled", havingValue = "true")
+public class AuthClientImpl implements AuthClient {
+
+    private static final Logger log = LoggerFactory.getLogger(AuthClientImpl.class);
+    private static final String INTROSPECT_PATH = "/internal/tokens/validate";
+    private static final String REVOKE_PATH = "/internal/tokens/revoke";
+
+    private final RestTemplate restTemplate;
+    private final AuthClientProperties properties;
+
+    public AuthClientImpl(RestTemplate authRestTemplate, AuthClientProperties properties) {
+        this.restTemplate = authRestTemplate;
+        this.properties = properties;
+    }
+
+    @Override
+    public TokenIntrospectionResponse introspectToken(String token) {
+        validateApiKey();
+        HttpHeaders headers = buildAuthHeaders();
+
+        Map<String, String> body = Map.of("token", token);
+        HttpEntity<Map<String, String>> entity = new HttpEntity<>(body, headers);
+
+        return executeWithRetry(INTROSPECT_PATH, HttpMethod.POST, entity,
+                TokenIntrospectionResponse.class, "introspectToken");
+    }
+
+    @Override
+    public void revokeTokens(TokenRevocationRequest request) {
+        validateApiKey();
+        HttpHeaders headers = buildAuthHeaders();
+
+        HttpEntity<TokenRevocationRequest> entity = new HttpEntity<>(request, headers);
+
+        executeWithRetry(REVOKE_PATH, HttpMethod.POST, entity, Void.class, "revokeTokens");
+    }
+
+    private HttpHeaders buildAuthHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.set("apikey", properties.getApiKey());
+        return headers;
+    }
+
+    private void validateApiKey() {
+        if (properties.getApiKey() == null || properties.getApiKey().isBlank()) {
+            String msg = "AuthClient apikey 未配置，无法调用 koduck-auth";
+            logSecurity(msg);
+            throw new AuthClientException(msg);
+        }
+    }
+
+    private <T> T executeWithRetry(String path, HttpMethod method, HttpEntity<?> entity,
+                                    Class<T> responseType, String operation) {
+        String url = properties.getBaseUrl() + path;
+        int maxAttempts = properties.getRetry().getMaxAttempts();
+        long backoff = properties.getRetry().getBackoffMillis();
+        AuthClientException lastException = null;
+
+        for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+            try {
+                ResponseEntity<T> response = restTemplate.exchange(url, method, entity, responseType);
+                return response.getBody();
+            } catch (HttpClientErrorException.Unauthorized | HttpClientErrorException.Forbidden e) {
+                // 401/403: 认证失败，不重试，记录安全审计日志
+                String msg = String.format("AuthClient %s 认证失败: %d %s - %s",
+                        operation, e.getStatusCode().value(), e.getStatusCode(), e.getResponseBodyAsString());
+                logSecurity(msg);
+                throw new AuthClientException(msg, e);
+            } catch (HttpClientErrorException e) {
+                // 其他 4xx: 不重试
+                log.warn("AuthClient {} 客户端错误: {} - {}", operation, e.getStatusCode(), e.getResponseBodyAsString());
+                throw new AuthClientException("AuthClient " + operation + " 客户端错误: " + e.getStatusCode(), e);
+            } catch (HttpServerErrorException e) {
+                lastException = new AuthClientException("AuthClient " + operation + " 服务端错误: " + e.getStatusCode(), e);
+                log.warn("AuthClient {} 服务端错误 (attempt {}/{}): {}",
+                        operation, attempt, maxAttempts, e.getStatusCode());
+                if (attempt < maxAttempts) {
+                    sleep(backoff * attempt);
+                }
+            } catch (ResourceAccessException e) {
+                lastException = new AuthClientException("AuthClient " + operation + " 网络错误: " + e.getMessage(), e);
+                log.warn("AuthClient {} 网络错误 (attempt {}/{}): {}",
+                        operation, attempt, maxAttempts, e.getMessage());
+                if (attempt < maxAttempts) {
+                    sleep(backoff * attempt);
+                }
+            }
+        }
+
+        throw lastException;
+    }
+
+    private void sleep(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new AuthClientException("AuthClient 重试等待被中断", e);
+        }
+    }
+
+    private void logSecurity(String message) {
+        log.warn("[SECURITY-AUDIT] {}", message);
+    }
+}

--- a/koduck-user/src/main/java/com/koduck/client/AuthClientNoOp.java
+++ b/koduck-user/src/main/java/com/koduck/client/AuthClientNoOp.java
@@ -1,0 +1,32 @@
+package com.koduck.client;
+
+import com.koduck.client.dto.TokenIntrospectionResponse;
+import com.koduck.client.dto.TokenRevocationRequest;
+import com.koduck.client.exception.AuthClientException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+/**
+ * AuthClient 空实现。
+ *
+ * <p>当 {@code auth.introspection.enabled=false}（默认）时使用，
+ * 确保 koduck-user 不会发起任何到 koduck-auth 的调用。</p>
+ */
+@Component
+@ConditionalOnProperty(prefix = "auth.introspection", name = "enabled", havingValue = "false", matchIfMissing = true)
+public class AuthClientNoOp implements AuthClient {
+
+    private static final Logger log = LoggerFactory.getLogger(AuthClientNoOp.class);
+
+    @Override
+    public TokenIntrospectionResponse introspectToken(String token) {
+        throw new AuthClientException("AuthClient introspection 未启用（auth.introspection.enabled=false）");
+    }
+
+    @Override
+    public void revokeTokens(TokenRevocationRequest request) {
+        throw new AuthClientException("AuthClient introspection 未启用（auth.introspection.enabled=false）");
+    }
+}

--- a/koduck-user/src/main/java/com/koduck/client/AuthClientProperties.java
+++ b/koduck-user/src/main/java/com/koduck/client/AuthClientProperties.java
@@ -1,0 +1,100 @@
+package com.koduck.client;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * AuthClient 配置属性。
+ *
+ * <p>绑定 {@code auth.*} 前缀的配置项。</p>
+ */
+@ConfigurationProperties(prefix = "auth")
+public class AuthClientProperties {
+
+    private String baseUrl = "http://apisix:9080";
+    private String apiKey = "";
+    private int connectTimeout = 3000;
+    private int readTimeout = 5000;
+    private Retry retry = new Retry();
+    private Introspection introspection = new Introspection();
+
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    public void setBaseUrl(String baseUrl) {
+        this.baseUrl = baseUrl;
+    }
+
+    public String getApiKey() {
+        return apiKey;
+    }
+
+    public void setApiKey(String apiKey) {
+        this.apiKey = apiKey;
+    }
+
+    public int getConnectTimeout() {
+        return connectTimeout;
+    }
+
+    public void setConnectTimeout(int connectTimeout) {
+        this.connectTimeout = connectTimeout;
+    }
+
+    public int getReadTimeout() {
+        return readTimeout;
+    }
+
+    public void setReadTimeout(int readTimeout) {
+        this.readTimeout = readTimeout;
+    }
+
+    public Retry getRetry() {
+        return retry;
+    }
+
+    public void setRetry(Retry retry) {
+        this.retry = retry;
+    }
+
+    public Introspection getIntrospection() {
+        return introspection;
+    }
+
+    public void setIntrospection(Introspection introspection) {
+        this.introspection = introspection;
+    }
+
+    public static class Retry {
+        private int maxAttempts = 2;
+        private long backoffMillis = 500;
+
+        public int getMaxAttempts() {
+            return maxAttempts;
+        }
+
+        public void setMaxAttempts(int maxAttempts) {
+            this.maxAttempts = maxAttempts;
+        }
+
+        public long getBackoffMillis() {
+            return backoffMillis;
+        }
+
+        public void setBackoffMillis(long backoffMillis) {
+            this.backoffMillis = backoffMillis;
+        }
+    }
+
+    public static class Introspection {
+        private boolean enabled = false;
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+    }
+}

--- a/koduck-user/src/main/java/com/koduck/client/dto/TokenIntrospectionRequest.java
+++ b/koduck-user/src/main/java/com/koduck/client/dto/TokenIntrospectionRequest.java
@@ -1,0 +1,20 @@
+package com.koduck.client.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Token 自省请求。
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TokenIntrospectionRequest {
+
+    @JsonProperty("token")
+    private String token;
+}

--- a/koduck-user/src/main/java/com/koduck/client/dto/TokenIntrospectionResponse.java
+++ b/koduck-user/src/main/java/com/koduck/client/dto/TokenIntrospectionResponse.java
@@ -1,0 +1,40 @@
+package com.koduck.client.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Token 自省响应。
+ *
+ * <p>与 koduck-auth {@code POST /internal/tokens/validate} 返回结构对齐。</p>
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TokenIntrospectionResponse {
+
+    @JsonProperty("valid")
+    private boolean valid;
+
+    @JsonProperty("user_id")
+    private Long userId;
+
+    @JsonProperty("username")
+    private String username;
+
+    @JsonProperty("roles")
+    private List<String> roles;
+
+    @JsonProperty("expires_at")
+    private Instant expiresAt;
+
+    @JsonProperty("error_message")
+    private String errorMessage;
+}

--- a/koduck-user/src/main/java/com/koduck/client/dto/TokenRevocationRequest.java
+++ b/koduck-user/src/main/java/com/koduck/client/dto/TokenRevocationRequest.java
@@ -1,0 +1,23 @@
+package com.koduck.client.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Token 吊销请求。
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TokenRevocationRequest {
+
+    @JsonProperty("user_id")
+    private Long userId;
+
+    @JsonProperty("reason")
+    private String reason;
+}

--- a/koduck-user/src/main/java/com/koduck/client/exception/AuthClientException.java
+++ b/koduck-user/src/main/java/com/koduck/client/exception/AuthClientException.java
@@ -1,0 +1,20 @@
+package com.koduck.client.exception;
+
+/**
+ * AuthClient 调用异常。
+ *
+ * <p>封装 koduck-user 调用 koduck-auth 过程中发生的错误，
+ * 包括认证失败、网络错误、服务端错误等。</p>
+ */
+public class AuthClientException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public AuthClientException(String message) {
+        super(message);
+    }
+
+    public AuthClientException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/koduck-user/src/main/resources/application.yml
+++ b/koduck-user/src/main/resources/application.yml
@@ -72,6 +72,18 @@ logging:
     root: INFO
     com.koduck: DEBUG
 
+# Auth 服务调用配置（可选链路，默认关闭）
+auth:
+  base-url: ${AUTH_BASE_URL:http://apisix:9080}
+  api-key: ${AUTH_API_KEY:}
+  connect-timeout: 3000
+  read-timeout: 5000
+  retry:
+    max-attempts: 2
+    backoff-millis: 500
+  introspection:
+    enabled: ${AUTH_INTROSPECTION_ENABLED:false}
+
 # Koduck User 自定义配置
 koduck:
   user:

--- a/koduck-user/src/test/java/com/koduck/client/AuthClientTest.java
+++ b/koduck-user/src/test/java/com/koduck/client/AuthClientTest.java
@@ -1,0 +1,237 @@
+package com.koduck.client;
+
+import com.koduck.client.dto.TokenIntrospectionResponse;
+import com.koduck.client.dto.TokenRevocationRequest;
+import com.koduck.client.exception.AuthClientException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.*;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class AuthClientTest {
+
+    private RestTemplate restTemplate;
+    private AuthClientProperties properties;
+    private AuthClientImpl authClient;
+
+    @BeforeEach
+    void setUp() {
+        restTemplate = mock(RestTemplate.class);
+        properties = new AuthClientProperties();
+        properties.setBaseUrl("http://apisix:9080");
+        properties.setApiKey("uk_test_key_12345678");
+        properties.getRetry().setMaxAttempts(2);
+        properties.getRetry().setBackoffMillis(100);
+        authClient = new AuthClientImpl(restTemplate, properties);
+    }
+
+    // === Feature toggle: NoOp ===
+
+    @Test
+    void noOpShouldRejectIntrospection() {
+        AuthClientNoOp noOp = new AuthClientNoOp();
+        assertThrows(AuthClientException.class,
+                () -> noOp.introspectToken("some-token"));
+    }
+
+    @Test
+    void noOpShouldRejectRevocation() {
+        AuthClientNoOp noOp = new AuthClientNoOp();
+        assertThrows(AuthClientException.class,
+                () -> noOp.revokeTokens(TokenRevocationRequest.builder().userId(1L).build()));
+    }
+
+    // === apikey validation ===
+
+    @Test
+    void shouldThrowWhenApiKeyMissing() {
+        properties.setApiKey("");
+        assertThrows(AuthClientException.class,
+                () -> authClient.introspectToken("some-token"));
+    }
+
+    @Test
+    void shouldThrowWhenApiKeyBlank() {
+        properties.setApiKey("   ");
+        assertThrows(AuthClientException.class,
+                () -> authClient.introspectToken("some-token"));
+    }
+
+    // === Successful introspection ===
+
+    @Test
+    void shouldIntrospectTokenSuccessfully() {
+        TokenIntrospectionResponse expected = TokenIntrospectionResponse.builder()
+                .valid(true)
+                .userId(1001L)
+                .username("demo")
+                .roles(List.of("ROLE_USER"))
+                .expiresAt(Instant.now().plusSeconds(900))
+                .build();
+
+        when(restTemplate.exchange(
+                eq("http://apisix:9080/internal/tokens/validate"),
+                eq(HttpMethod.POST),
+                any(HttpEntity.class),
+                eq(TokenIntrospectionResponse.class)))
+                .thenReturn(ResponseEntity.ok(expected));
+
+        TokenIntrospectionResponse result = authClient.introspectToken("valid-token");
+
+        assertTrue(result.isValid());
+        assertEquals(1001L, result.getUserId());
+        assertEquals("demo", result.getUsername());
+
+        // Verify apikey header was set
+        @SuppressWarnings("unchecked")
+        HttpEntity<Map<String, String>> captured = captureHttpEntity();
+        assertEquals("uk_test_key_12345678", captured.getHeaders().getFirst("apikey"));
+    }
+
+    // === Successful revocation ===
+
+    @Test
+    void shouldRevokeTokensSuccessfully() {
+        when(restTemplate.exchange(
+                eq("http://apisix:9080/internal/tokens/revoke"),
+                eq(HttpMethod.POST),
+                any(HttpEntity.class),
+                eq(Void.class)))
+                .thenReturn(ResponseEntity.ok().build());
+
+        assertDoesNotThrow(() -> authClient.revokeTokens(
+                TokenRevocationRequest.builder().userId(1001L).reason("password-changed").build()));
+    }
+
+    // === 401: no retry, security log ===
+
+    @Test
+    void shouldNotRetryOn401() {
+        HttpClientErrorException ex = HttpClientErrorException.create(
+                HttpStatus.UNAUTHORIZED, "Unauthorized",
+                HttpHeaders.EMPTY, "{\"error\":\"invalid key\"}".getBytes(), null);
+
+        when(restTemplate.exchange(anyString(), any(), any(), any(Class.class)))
+                .thenThrow(ex);
+
+        AuthClientException thrown = assertThrows(AuthClientException.class,
+                () -> authClient.introspectToken("token"));
+
+        assertTrue(thrown.getMessage().contains("认证失败"));
+        assertTrue(thrown.getMessage().contains("401"));
+
+        // Verify only one call (no retry)
+        verify(restTemplate, times(1)).exchange(anyString(), any(), any(), any(Class.class));
+    }
+
+    // === 403: no retry, security log ===
+
+    @Test
+    void shouldNotRetryOn403() {
+        HttpClientErrorException ex = HttpClientErrorException.create(
+                HttpStatus.FORBIDDEN, "Forbidden",
+                HttpHeaders.EMPTY, "{\"error\":\"access denied\"}".getBytes(), null);
+
+        when(restTemplate.exchange(anyString(), any(), any(), any(Class.class)))
+                .thenThrow(ex);
+
+        AuthClientException thrown = assertThrows(AuthClientException.class,
+                () -> authClient.introspectToken("token"));
+
+        assertTrue(thrown.getMessage().contains("认证失败"));
+        assertTrue(thrown.getMessage().contains("403"));
+
+        verify(restTemplate, times(1)).exchange(anyString(), any(), any(), any(Class.class));
+    }
+
+    // === 400: no retry (other 4xx) ===
+
+    @Test
+    void shouldNotRetryOn400() {
+        HttpClientErrorException ex = HttpClientErrorException.create(
+                HttpStatus.BAD_REQUEST, "Bad Request",
+                HttpHeaders.EMPTY, "{\"error\":\"invalid token\"}".getBytes(), null);
+
+        when(restTemplate.exchange(anyString(), any(), any(), any(Class.class)))
+                .thenThrow(ex);
+
+        AuthClientException thrown = assertThrows(AuthClientException.class,
+                () -> authClient.introspectToken("token"));
+
+        assertTrue(thrown.getMessage().contains("客户端错误"));
+        verify(restTemplate, times(1)).exchange(anyString(), any(), any(), any(Class.class));
+    }
+
+    // === 5xx: retry with backoff ===
+
+    @Test
+    void shouldRetryOn5xx() {
+        HttpServerErrorException ex = HttpServerErrorException.create(
+                HttpStatus.INTERNAL_SERVER_ERROR, "Internal Server Error",
+                HttpHeaders.EMPTY, "{\"error\":\"upstream failure\"}".getBytes(), null);
+
+        when(restTemplate.exchange(anyString(), any(), any(), any(Class.class)))
+                .thenThrow(ex);
+
+        AuthClientException thrown = assertThrows(AuthClientException.class,
+                () -> authClient.introspectToken("token"));
+
+        assertTrue(thrown.getMessage().contains("服务端错误"));
+        // maxAttempts=2, so should be called twice
+        verify(restTemplate, times(2)).exchange(anyString(), any(), any(), any(Class.class));
+    }
+
+    // === Network error: retry with backoff ===
+
+    @Test
+    void shouldRetryOnNetworkError() {
+        ResourceAccessException ex = new ResourceAccessException("Connection refused");
+
+        when(restTemplate.exchange(anyString(), any(), any(), any(Class.class)))
+                .thenThrow(ex);
+
+        AuthClientException thrown = assertThrows(AuthClientException.class,
+                () -> authClient.introspectToken("token"));
+
+        assertTrue(thrown.getMessage().contains("网络错误"));
+        verify(restTemplate, times(2)).exchange(anyString(), any(), any(), any(Class.class));
+    }
+
+    // === APISIX routing (not direct auth connection) ===
+
+    @Test
+    void shouldCallViaApisixBaseUrl() {
+        properties.setBaseUrl("http://apisix-gateway:9080");
+
+        when(restTemplate.exchange(
+                eq("http://apisix-gateway:9080/internal/tokens/validate"),
+                any(), any(), eq(TokenIntrospectionResponse.class)))
+                .thenReturn(ResponseEntity.ok(TokenIntrospectionResponse.builder().valid(true).build()));
+
+        authClient.introspectToken("token");
+
+        // Verify URL goes through APISIX, not directly to koduck-auth
+        verify(restTemplate).exchange(
+                eq("http://apisix-gateway:9080/internal/tokens/validate"),
+                any(), any(), any(Class.class));
+    }
+
+    @SuppressWarnings("unchecked")
+    private HttpEntity<Map<String, String>> captureHttpEntity() {
+        @SuppressWarnings("unchecked")
+        org.mockito.ArgumentCaptor<HttpEntity> captor = org.mockito.ArgumentCaptor.forClass(HttpEntity.class);
+        verify(restTemplate).exchange(anyString(), any(HttpMethod.class), captor.capture(), any(Class.class));
+        return (HttpEntity<Map<String, String>>) captor.getValue();
+    }
+}


### PR DESCRIPTION
## Summary

- 实现 `AuthClient`，使 koduck-user 能通过 APISIX 网关调用 koduck-auth 内部 API（Token 自省/吊销）
- 默认关闭（`auth.introspection.enabled=false`），不影响现有行为
- 401/403 不重试并记录安全审计日志；5xx/网络错误有限重试（最多 2 次）
- 所有调用通过 APISIX 地址（`AUTH_BASE_URL`），禁止直连 koduck-auth

## 新增文件

| 文件 | 说明 |
|------|------|
| `client/AuthClient.java` | 客户端接口 |
| `client/AuthClientImpl.java` | RestTemplate 实现 + 重试 + apikey |
| `client/AuthClientNoOp.java` | 空实现（默认） |
| `client/AuthClientConfig.java` | RestTemplate Bean 配置 |
| `client/AuthClientProperties.java` | 配置属性绑定 |
| `client/dto/` | TokenIntrospection/Revocation DTO |
| `client/exception/AuthClientException.java` | 客户端异常 |
| `client/AuthClientTest.java` | 12 个单元测试 |
| `docs/adr/0012-*.md` | 架构决策记录 |

## 配置变更

```yaml
auth:
  base-url: ${AUTH_BASE_URL:http://apisix:9080}
  api-key: ${AUTH_API_KEY:}
  introspection:
    enabled: ${AUTH_INTROSPECTION_ENABLED:false}
  retry:
    max-attempts: 2
    backoff-millis: 500
```

## Test plan

- [x] `mvn -f koduck-user/pom.xml -DskipTests compile` 通过
- [x] `mvn -f koduck-user/pom.xml test` 27 个测试全部通过（含 12 个新 AuthClient 测试）
- [ ] `docker build -t koduck-user:dev ./koduck-user` 通过
- [ ] `kubectl -n koduck-dev rollout restart deploy/dev-koduck-user` 后 demo/demo123 login 回归通过

Closes #697

🤖 Generated with [Claude Code](https://claude.com/claude-code)