### PR TITLE
feat(user): implement task 7.2 apisix route init script

### DIFF
--- a/docs/implementation/koduck-user-service-tasks.md
+++ b/docs/implementation/koduck-user-service-tasks.md
@@ -403,12 +403,12 @@
    - 内部路由启用 `key-auth` 并通过 `proxy-rewrite` 透传 `X-Consumer-Username`，同时清理 `apikey`
 
 **验收标准:**
-- [ ] 路由规则与设计文档 8.3 一致
-- [ ] 可重复执行且结果一致
-- [ ] 失败时可快速回滚或重放
-- [ ] 缺失/错误 apikey 的内部请求由 APISIX 返回 401
-- [ ] 权限不足的业务请求返回 403（由后端权限模型决定）
-- [ ] 路由脚本执行后，Admin API 可读到上述 `uri/priority/plugins/proxy-rewrite` 配置
+- [x] 路由规则与设计文档 8.3 一致
+- [x] 可重复执行且结果一致
+- [x] 失败时可快速回滚或重放
+- [x] 缺失/错误 apikey 的内部请求由 APISIX 返回 401
+- [x] 权限不足的业务请求返回 403（由后端权限模型决定）
+- [x] 路由脚本执行后，Admin API 可读到上述 `uri/priority/plugins/proxy-rewrite` 配置
 
 **参考文档:** 设计文档 8.3 节
 

--- a/koduck-user/docs/adr/0015-apisix-user-route-init-script.md
+++ b/koduck-user/docs/adr/0015-apisix-user-route-init-script.md
@@ -1,0 +1,145 @@
+# ADR-0015: Task 7.2 APISIX 用户路由初始化脚本
+
+## 元数据
+
+- **状态**: 已接受
+- **日期**: 2026-04-09
+- **作者**: @hailingu
+- **相关**: #703, docs/implementation/koduck-user-service-tasks.md Task 7.2, ADR-0014
+
+---
+
+## 背景与问题陈述
+
+Task 7.2 要求落地 `scripts/apisix-route-init-user.sh`，用于将 `koduck-user` 的公开与内部路由注册到 APISIX，并满足以下约束：
+
+1. 固化关键协议配置：
+   - 公开路由 `uri=/api/v1/users/*`、`priority=90`
+   - 内部路由 `uri=/internal/users/*`、`priority=100`
+   - 公开路由启用 `jwt-auth` 且通过 `proxy-rewrite` 注入 `X-User-Id`、`X-Username`、`X-Roles`
+   - 内部路由启用 `key-auth` 且通过 `proxy-rewrite` 注入 `X-Consumer-Username` 并清理 `apikey`
+2. 注册服务调用 Consumer 与 key。
+3. 脚本必须可幂等重放，并在失败时快速回滚。
+4. 路由写入后可通过 APISIX Admin API 验证关键配置。
+
+---
+
+## 决策驱动因素
+
+1. **可重复执行**: 支持环境重建、灰度发布与故障恢复时反复执行。
+2. **可回滚**: 初始化中任一步骤失败时，尽量恢复到执行前状态。
+3. **可验证**: 写入后应立即校验 Admin API 中的生效配置。
+4. **低耦合**: 以脚本方式实现，不强绑定 K8s Job 执行环境。
+
+---
+
+## 考虑的选项
+
+### 选项 1：仅使用 `PUT` 覆盖，不做备份和校验
+
+**优点**:
+- 实现最简单
+
+**缺点**:
+- 失败时无法恢复原配置
+- 无法证明写入结果与预期一致
+
+### 选项 2：`PUT` + 预备份 + 失败自动回滚 + 写后校验（选定）
+
+**优点**:
+- 满足幂等、回滚、可验证三项核心验收
+- 便于在不同环境重放
+
+**缺点**:
+- 脚本复杂度提升
+- 依赖 `jq` 处理 JSON
+
+### 选项 3：改为声明式 APISIX CRD（K8s 原生管理）
+
+**优点**:
+- 配置版本化更自然
+
+**缺点**:
+- 当前任务明确要求脚本实现
+- 引入新的运维模型，超出 Task 7.2 范围
+
+---
+
+## 决策结果
+
+采用 **选项 2**，在 `scripts/apisix-route-init-user.sh` 中实现：
+
+1. 对 `consumers/koduck-user-consumer`、`routes/user-service`、`routes/user-internal` 先做备份。
+2. 使用固定 ID 执行 `PUT`，确保幂等覆盖写入。
+3. 任一步骤失败时，按备份自动恢复（原来不存在的实体则删除）。
+4. 写入后通过 Admin API 读取并与预期 JSON 对比，确认关键字段与插件配置完全一致。
+
+---
+
+## 实施细节
+
+### 变更文件
+
+| 文件 | 变更说明 |
+|------|------|
+| `scripts/apisix-route-init-user.sh` | 新增 APISIX 初始化脚本（幂等、备份、回滚、校验） |
+
+### 核心实现点
+
+1. 环境变量契约：
+   - 必填：`ADMIN_KEY`、`INTERNAL_API_KEY_USER`
+   - 可选：`APISIX_ADMIN_URL`、`USER_SERVICE_UPSTREAM`、`ROLLBACK_ON_ERROR` 等
+2. 固化路由配置：
+   - 公开路由 `priority=90`，启用 `jwt-auth` + 用户身份头透传
+   - 内部路由 `priority=100`，启用 `key-auth` + `X-Consumer-Username` 注入与 `apikey` 清理
+3. 回滚策略：
+   - 备份存在则恢复原 `value`
+   - 备份缺失（原本不存在）则删除新建实体
+4. 写后验证：
+   - 对两个关键路由执行 GET，校验 `uri/priority/plugins/proxy-rewrite/upstream`
+
+---
+
+## 权衡与影响
+
+### 正向影响
+
+- 脚本可以安全重放，降低环境漂移风险。
+- 失败自动回滚，减少误配置窗口。
+- 运维排障时可通过 Admin API 校验快速定位问题。
+
+### 负向影响
+
+- 依赖 `jq` 与 `curl`，执行环境有最小工具要求。
+- 脚本逻辑更复杂，维护成本高于单纯 `curl PUT`。
+
+### 缓解措施
+
+- 在脚本启动阶段显式检查依赖并给出错误提示。
+- 保持路由/Consumer ID 与字段命名稳定，避免不必要变更。
+
+---
+
+## 兼容性影响
+
+1. **对外 API 兼容性**: 保持 `/api/v1/users/*` 路由，不影响既有调用路径。
+2. **内部 API 兼容性**: 保持 `/internal/users/*` 路由，未携带合法 key 的请求仍由 APISIX 返回 401。
+3. **权限语义**: 业务 403 仍由后端权限模型决定，与 Task 6.2 保持一致。
+4. **运维兼容性**: 支持重复执行与失败重放，适配 dev/prod 多环境。
+
+---
+
+## 相关文档
+
+- [koduck-auth-user-service-design.md](../../../docs/design/koduck-auth-user-service-design.md) 8.3 节
+- [koduck-user-jwt-design.md](../../../docs/design/koduck-user-jwt-design.md) 7.2 节
+- [koduck-user-service-tasks.md](../../../docs/implementation/koduck-user-service-tasks.md)
+- [ADR-0014](./0014-auth-and-permission-boundaries.md)
+
+---
+
+## 变更日志
+
+| 日期 | 变更 | 作者 |
+|------|------|------|
+| 2026-04-09 | 初始版本 | @hailingu |

--- a/scripts/apisix-route-init-user.sh
+++ b/scripts/apisix-route-init-user.sh
@@ -1,0 +1,295 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# APISIX route init script for koduck-user (Task 7.2)
+# Features:
+# 1) Idempotent PUT for consumer + routes
+# 2) Automatic backup before mutation
+# 3) Automatic rollback on failure
+# 4) Post-apply verification through APISIX Admin API
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "ERROR: curl is required." >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq is required for backup/rollback/verification." >&2
+  exit 1
+fi
+
+readonly APISIX_ADMIN_URL="${APISIX_ADMIN_URL:-http://apisix-admin:9180/apisix/admin}"
+readonly ADMIN_KEY="${ADMIN_KEY:?ADMIN_KEY is required}"
+readonly INTERNAL_API_KEY_USER="${INTERNAL_API_KEY_USER:?INTERNAL_API_KEY_USER is required}"
+readonly USER_SERVICE_UPSTREAM="${USER_SERVICE_UPSTREAM:-koduck-user:8082}"
+readonly USER_PUBLIC_ROUTE_ID="${USER_PUBLIC_ROUTE_ID:-user-service}"
+readonly USER_INTERNAL_ROUTE_ID="${USER_INTERNAL_ROUTE_ID:-user-internal}"
+readonly USER_CONSUMER_ID="${USER_CONSUMER_ID:-koduck_user_consumer}"
+readonly USER_CONSUMER_USERNAME="${USER_CONSUMER_USERNAME:-koduck_user_consumer}"
+readonly ROLLBACK_ON_ERROR="${ROLLBACK_ON_ERROR:-true}"
+readonly CURL_NO_PROXY="${CURL_NO_PROXY:-*}"
+
+readonly TMP_DIR="$(mktemp -d -t apisix-user-init-XXXXXX)"
+readonly BACKUP_DIR="${TMP_DIR}/backup"
+readonly PAYLOAD_DIR="${TMP_DIR}/payload"
+mkdir -p "${BACKUP_DIR}" "${PAYLOAD_DIR}"
+
+rollback_executed=false
+
+log() {
+  printf '[apisix-user-init] %s\n' "$*"
+}
+
+request() {
+  local method="$1"
+  local path="$2"
+  local output_file="$3"
+  local data_file="${4:-}"
+  local http_code
+
+  : > "${output_file}"
+
+  if [[ -n "${data_file}" ]]; then
+    http_code="$(curl -sS -o "${output_file}" -w '%{http_code}' \
+      --noproxy "${CURL_NO_PROXY}" \
+      -X "${method}" "${APISIX_ADMIN_URL}${path}" \
+      -H "X-API-KEY: ${ADMIN_KEY}" \
+      -H 'Content-Type: application/json' \
+      --data "@${data_file}")"
+  else
+    http_code="$(curl -sS -o "${output_file}" -w '%{http_code}' \
+      --noproxy "${CURL_NO_PROXY}" \
+      -X "${method}" "${APISIX_ADMIN_URL}${path}" \
+      -H "X-API-KEY: ${ADMIN_KEY}" \
+      -H 'Content-Type: application/json')"
+  fi
+
+  echo "${http_code}"
+}
+
+backup_entity() {
+  local kind="$1"
+  local entity_id="$2"
+  local out="${BACKUP_DIR}/${kind}-${entity_id}.json"
+  local raw="${TMP_DIR}/raw-${kind}-${entity_id}.json"
+  local code
+
+  code="$(request "GET" "/${kind}/${entity_id}" "${raw}")"
+
+  if [[ "${code}" == "404" ]]; then
+    printf '__ABSENT__\n' > "${out}"
+    log "No existing ${kind}/${entity_id}; backup mark as ABSENT."
+    return 0
+  fi
+
+  if [[ "${code}" != 2* ]]; then
+    echo "ERROR: Failed to backup ${kind}/${entity_id}, HTTP ${code}" >&2
+    cat "${raw}" >&2 || true
+    return 1
+  fi
+
+  jq -c '.value' "${raw}" > "${out}"
+  log "Backed up ${kind}/${entity_id}."
+}
+
+put_entity() {
+  local kind="$1"
+  local entity_id="$2"
+  local payload_file="$3"
+  local out="${TMP_DIR}/put-${kind}-${entity_id}.json"
+  local code
+
+  code="$(request "PUT" "/${kind}/${entity_id}" "${out}" "${payload_file}")"
+  if [[ "${code}" != 2* ]]; then
+    echo "ERROR: Failed to PUT ${kind}/${entity_id}, HTTP ${code}" >&2
+    cat "${out}" >&2 || true
+    return 1
+  fi
+  log "Applied ${kind}/${entity_id}."
+}
+
+delete_entity_if_exists() {
+  local kind="$1"
+  local entity_id="$2"
+  local out="${TMP_DIR}/delete-${kind}-${entity_id}.json"
+  local code
+
+  code="$(request "DELETE" "/${kind}/${entity_id}" "${out}")"
+  if [[ "${code}" == "404" ]]; then
+    return 0
+  fi
+  if [[ "${code}" != 2* ]]; then
+    echo "WARN: Failed to DELETE ${kind}/${entity_id}, HTTP ${code}" >&2
+    cat "${out}" >&2 || true
+    return 1
+  fi
+  return 0
+}
+
+rollback() {
+  if [[ "${rollback_executed}" == "true" ]]; then
+    return 0
+  fi
+  rollback_executed=true
+
+  if [[ "${ROLLBACK_ON_ERROR}" != "true" ]]; then
+    log "Rollback skipped (ROLLBACK_ON_ERROR=${ROLLBACK_ON_ERROR})."
+    return 0
+  fi
+
+  log "Failure detected, rolling back APISIX entities..."
+
+  local mappings=(
+    "consumers:${USER_CONSUMER_ID}"
+    "routes:${USER_PUBLIC_ROUTE_ID}"
+    "routes:${USER_INTERNAL_ROUTE_ID}"
+  )
+
+  local item kind entity_id backup_file
+  for item in "${mappings[@]}"; do
+    kind="${item%%:*}"
+    entity_id="${item##*:}"
+    backup_file="${BACKUP_DIR}/${kind}-${entity_id}.json"
+
+    if [[ ! -f "${backup_file}" ]]; then
+      log "Skip rollback for ${kind}/${entity_id}, no backup."
+      continue
+    fi
+
+    if grep -q '__ABSENT__' "${backup_file}"; then
+      delete_entity_if_exists "${kind}" "${entity_id}" || true
+      log "Rollback delete ${kind}/${entity_id} (entity absent before apply)."
+      continue
+    fi
+
+    put_entity "${kind}" "${entity_id}" "${backup_file}" || true
+    log "Rollback restore ${kind}/${entity_id}."
+  done
+}
+
+on_error() {
+  echo "ERROR: Script failed at line $1." >&2
+  rollback
+}
+trap 'on_error $LINENO' ERR
+
+create_payloads() {
+  jq -n \
+    --arg username "${USER_CONSUMER_USERNAME}" \
+    --arg key "${INTERNAL_API_KEY_USER}" \
+    '{
+      username: $username,
+      plugins: {
+        "key-auth": {
+          key: $key
+        }
+      }
+    }' > "${PAYLOAD_DIR}/consumer.json"
+
+  jq -n \
+    --arg upstream "${USER_SERVICE_UPSTREAM}" \
+    '{
+      uri: "/api/v1/users/*",
+      priority: 90,
+      plugins: {
+        "jwt-auth": {},
+        "proxy-rewrite": {
+          headers: {
+            "X-User-Id": "$jwt_claim_user_id",
+            "X-Username": "$jwt_claim_username",
+            "X-Roles": "$jwt_claim_roles"
+          }
+        }
+      },
+      upstream: {
+        type: "roundrobin",
+        nodes: {
+          ($upstream): 1
+        }
+      }
+    }' > "${PAYLOAD_DIR}/public-route.json"
+
+  jq -n \
+    --arg upstream "${USER_SERVICE_UPSTREAM}" \
+    '{
+      uri: "/internal/users/*",
+      priority: 100,
+      plugins: {
+        "key-auth": {},
+        "proxy-rewrite": {
+          headers: {
+            "X-Consumer-Username": "$consumer_name",
+            apikey: ""
+          }
+        }
+      },
+      upstream: {
+        type: "roundrobin",
+        nodes: {
+          ($upstream): 1
+        }
+      }
+    }' > "${PAYLOAD_DIR}/internal-route.json"
+}
+
+verify_entity_with_jq() {
+  local kind="$1"
+  local entity_id="$2"
+  local jq_expr="$3"
+  local description="$4"
+  local raw="${TMP_DIR}/verify-${kind}-${entity_id}.json"
+  local code
+
+  code="$(request "GET" "/${kind}/${entity_id}" "${raw}")"
+  if [[ "${code}" != 2* ]]; then
+    echo "ERROR: Verification GET failed for ${kind}/${entity_id}, HTTP ${code}" >&2
+    cat "${raw}" >&2 || true
+    return 1
+  fi
+
+  if ! jq -e "${jq_expr}" "${raw}" >/dev/null; then
+    echo "ERROR: Verification mismatch for ${kind}/${entity_id}: ${description}" >&2
+    cat "${raw}" >&2 || true
+    return 1
+  fi
+  log "Verified ${kind}/${entity_id}: ${description}"
+}
+
+main() {
+  log "APISIX admin endpoint: ${APISIX_ADMIN_URL}"
+  log "Start backup..."
+  backup_entity "consumers" "${USER_CONSUMER_ID}"
+  backup_entity "routes" "${USER_PUBLIC_ROUTE_ID}"
+  backup_entity "routes" "${USER_INTERNAL_ROUTE_ID}"
+
+  log "Build payloads..."
+  create_payloads
+
+  log "Apply consumer + routes (idempotent PUT)..."
+  put_entity "consumers" "${USER_CONSUMER_ID}" "${PAYLOAD_DIR}/consumer.json"
+  put_entity "routes" "${USER_PUBLIC_ROUTE_ID}" "${PAYLOAD_DIR}/public-route.json"
+  put_entity "routes" "${USER_INTERNAL_ROUTE_ID}" "${PAYLOAD_DIR}/internal-route.json"
+
+  log "Verify applied config by Admin API..."
+  verify_entity_with_jq \
+    "consumers" \
+    "${USER_CONSUMER_ID}" \
+    ".value.username == \"${USER_CONSUMER_USERNAME}\" and .value.plugins[\"key-auth\"].key == \"${INTERNAL_API_KEY_USER}\"" \
+    "consumer username/key-auth key"
+  verify_entity_with_jq \
+    "routes" \
+    "${USER_PUBLIC_ROUTE_ID}" \
+    ".value.uri == \"/api/v1/users/*\" and .value.priority == 90 and (.value.plugins | has(\"jwt-auth\")) and .value.plugins[\"proxy-rewrite\"].headers[\"X-User-Id\"] == \"\$jwt_claim_user_id\" and .value.plugins[\"proxy-rewrite\"].headers[\"X-Username\"] == \"\$jwt_claim_username\" and .value.plugins[\"proxy-rewrite\"].headers[\"X-Roles\"] == \"\$jwt_claim_roles\" and .value.upstream.nodes[\"${USER_SERVICE_UPSTREAM}\"] == 1" \
+    "public route uri/priority/jwt-auth/proxy-rewrite/upstream"
+  verify_entity_with_jq \
+    "routes" \
+    "${USER_INTERNAL_ROUTE_ID}" \
+    ".value.uri == \"/internal/users/*\" and .value.priority == 100 and (.value.plugins | has(\"key-auth\")) and .value.plugins[\"proxy-rewrite\"].headers[\"X-Consumer-Username\"] == \"\$consumer_name\" and .value.plugins[\"proxy-rewrite\"].headers[\"apikey\"] == \"\" and .value.upstream.nodes[\"${USER_SERVICE_UPSTREAM}\"] == 1" \
+    "internal route uri/priority/key-auth/proxy-rewrite/upstream"
+
+  log "Task 7.2 APISIX route init completed successfully."
+  log "Replay command: ADMIN_KEY=*** INTERNAL_API_KEY_USER=*** ${BASH_SOURCE[0]}"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- add scripts/apisix-route-init-user.sh for koduck-user APISIX route initialization
- support idempotent apply, pre-change backup, automatic rollback and Admin API verification
- add ADR-0015 for Task 7.2 decision/tradeoff/compatibility notes

## Validation
- docker build -t koduck-user:dev ./koduck-user
- kubectl -n koduck-dev rollout restart deploy/dev-koduck-user
- kubectl -n koduck-dev rollout status deploy/dev-koduck-user --timeout=180s
- run scripts/apisix-route-init-user.sh against APISIX Admin via kubectl port-forward
- demo/demo123 login regression passed through APISIX gateway
- internal API key-auth regression: missing/wrong apikey => 401, correct apikey => 200

Closes #703