### PR TITLE
feat(frontend): replace koduckai component from frontend-new

### DIFF
--- a/koduck-frontend/docs/adr/0003-replace-koduckai-component-from-frontend-new.md
+++ b/koduck-frontend/docs/adr/0003-replace-koduckai-component-from-frontend-new.md
@@ -1,0 +1,49 @@
+# ADR-0003: 使用 frontend-new 的 KoduckAi 组件替换现有实现
+
+## 元数据
+
+- **状态**: 已接受
+- **日期**: 2026-04-09
+- **作者**: @hailingu
+- **相关 Issue**: #712
+
+---
+
+## 背景与问题陈述
+
+当前 `koduck-frontend` 中的 `KoduckAi` 组件需要与 `koduck-quant-frontend-new` 保持一致，以复用新版本页面结构和交互细节，减少两套前端实现差异。
+
+---
+
+## 决策
+
+将 `koduck-quant-frontend-new/src/app/components/KoduckAi.tsx` 原样替换到
+`koduck-frontend/src/app/components/KoduckAi.tsx`。
+
+---
+
+## 权衡
+
+### 优点
+
+- 快速对齐新版本 AI 页面实现。
+- 降低维护两套组件差异的成本。
+- 组件依赖不新增，迁移风险可控。
+
+### 代价
+
+- 当前仓库内原有 `KoduckAi` 样式细节会被新实现覆盖。
+
+---
+
+## 兼容性影响
+
+- 路由与登录流程不变，仍使用 `/koduck-ai` 作为 AI 页面入口。
+- 仅替换组件内部渲染与样式，不变更接口契约。
+
+---
+
+## 实施摘要
+
+- 复制替换 `KoduckAi.tsx`。
+- 执行构建、部署重启和登录回归验证。

--- a/koduck-frontend/src/app/components/KoduckAi.tsx
+++ b/koduck-frontend/src/app/components/KoduckAi.tsx
@@ -1,7 +1,5 @@
 import { useState } from "react";
-import { 
-  Send,
-} from "lucide-react";
+import { Send } from "lucide-react";
 import { Input } from "./ui/input";
 
 export function KoduckAi() {
@@ -15,35 +13,29 @@ export function KoduckAi() {
   };
 
   return (
-    <main className="flex-1 flex flex-col bg-white">
-      {/* Top Bar */}
-      <header className="border-b border-gray-200 bg-white">
-        <div className="flex items-center justify-between px-4 h-14">
-          <div className="flex items-center gap-3">
-            {/* Empty - content removed */}
-          </div>
-          <div className="flex items-center gap-2">
-            {/* Empty - content removed */}
-          </div>
-        </div>
-      </header>
-
+    <main className="flex-1 flex flex-col bg-white overflow-hidden">
       {/* Chat Messages */}
       <div className="flex-1 overflow-y-auto">
-        <div className="h-full flex flex-col px-4">
-          {/* Top spacer - smaller to move content up */}
-          <div className="flex-[0.8]"></div>
-          
+        <div className="min-h-full flex flex-col items-center justify-start pt-[28vh] px-4">
           {/* Centered Input Area */}
           <div className="w-full max-w-3xl mx-auto">
-            <h1 className="text-4xl font-normal text-gray-800 text-center mb-12">Hi!</h1>
-            
+            <h1 className="text-3xl font-normal text-gray-800 text-center mb-8">
+              Hi!
+            </h1>
+
             <div className="relative">
-              <div className="flex items-center gap-2 bg-white border border-gray-300 rounded-3xl shadow-sm hover:shadow-md focus-within:shadow-md transition-shadow">
-                <button className="p-3 text-gray-400 hover:text-gray-600">
-                  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                    <line x1="12" y1="5" x2="12" y2="19"/>
-                    <line x1="5" y1="12" x2="19" y2="12"/>
+              <div className="flex items-center gap-2 bg-white border border-gray-300 rounded-3xl shadow-sm hover:shadow-md transition-shadow focus-within:shadow-md">
+                <button className="p-2.5 text-gray-400 hover:text-gray-600">
+                  <svg
+                    width="20"
+                    height="20"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                  >
+                    <line x1="12" y1="5" x2="12" y2="19" />
+                    <line x1="5" y1="12" x2="19" y2="12" />
                   </svg>
                 </button>
                 <Input
@@ -52,21 +44,28 @@ export function KoduckAi() {
                   value={chatMessage}
                   onChange={(e) => setChatMessage(e.target.value)}
                   onKeyPress={(e) => e.key === "Enter" && handleSendMessage()}
-                  className="flex-1 border-0 bg-transparent focus:outline-none focus-visible:ring-0 focus-visible:border-0 text-base py-4 px-0"
+                  className="flex-1 border-0 bg-transparent focus:outline-none focus:ring-0 focus-visible:ring-0 focus-visible:border-0 text-base py-2.5 px-0"
                 />
-                <button className="p-3 text-gray-400 hover:text-gray-600">
-                  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                    <path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z"/>
-                    <path d="M19 10v2a7 7 0 0 1-14 0v-2"/>
+                <button className="p-2.5 text-gray-400 hover:text-gray-600">
+                  <svg
+                    width="20"
+                    height="20"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                  >
+                    <path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z" />
+                    <path d="M19 10v2a7 7 0 0 1-14 0v-2" />
                   </svg>
                 </button>
                 <button
                   onClick={handleSendMessage}
                   disabled={!chatMessage.trim()}
-                  className={`m-2 w-8 h-8 rounded-lg flex items-center justify-center transition-colors ${
-                    chatMessage.trim() 
-                      ? 'bg-[#10a37f] text-white hover:bg-[#0d8b6d]' 
-                      : 'bg-gray-200 text-gray-400 cursor-not-allowed'
+                  className={`m-1.5 w-8 h-8 rounded-lg flex items-center justify-center transition-colors ${
+                    chatMessage.trim()
+                      ? "bg-[#10a37f] text-white hover:bg-[#0d8b6d]"
+                      : "bg-gray-200 text-gray-400 cursor-not-allowed"
                   }`}
                 >
                   <Send className="w-4 h-4" />
@@ -74,9 +73,6 @@ export function KoduckAi() {
               </div>
             </div>
           </div>
-          
-          {/* Bottom spacer - larger to move content up */}
-          <div className="flex-[2]"></div>
         </div>
       </div>
     </main>


### PR DESCRIPTION
## Summary
- replace `koduck-frontend` KoduckAi component with the implementation from `koduck-quant-frontend-new`
- keep existing login and `/koduck-ai` routing behavior unchanged
- add ADR `0003-replace-koduckai-component-from-frontend-new.md`

## Verification
- docker build -t koduck-frontend:dev ./koduck-frontend
- kubectl -n koduck-dev rollout restart deploy/dev-koduck-frontend
- browser regression: login with demo/demo123 succeeds and lands at `/koduck-ai`

Closes #712
