### PR TITLE
feat(koduck-ai): init Rust project skeleton for AI gateway

### DIFF
--- a/koduck-ai/.dockerignore
+++ b/koduck-ai/.dockerignore
@@ -1,0 +1,11 @@
+target/
+.git/
+.gitignore
+*.md
+!README.md
+tests/
+benches/
+k8s/
+scripts/
+.env
+.env.*

--- a/koduck-ai/Cargo.toml
+++ b/koduck-ai/Cargo.toml
@@ -1,0 +1,80 @@
+[package]
+name = "koduck-ai"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.75"
+authors = ["Koduck Team <dev@koduck.com>"]
+description = "Koduck AI Gateway / Orchestrator - Rust + gRPC implementation"
+license = "MIT"
+
+[dependencies]
+# 异步运行时
+tokio = { version = "1.35", features = ["full"] }
+
+# HTTP 框架
+axum = { version = "0.7", features = ["http2", "macros"] }
+tower = { version = "0.4", features = ["full"] }
+tower-http = { version = "0.5", features = [
+    "cors",
+    "trace",
+    "compression-full",
+    "request-id",
+    "sensitive-headers",
+    "util",
+] }
+hyper = { version = "1.0", features = ["full"] }
+
+# gRPC
+tonic = { version = "0.11", features = ["tls", "gzip"] }
+tonic-health = "0.11"
+tonic-reflection = "0.11"
+prost = "0.12"
+prost-types = "0.12"
+
+# 序列化
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+
+# 配置
+config = "0.14"
+dotenvy = "0.15"
+
+# 日志和监控
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = [
+    "env-filter",
+    "json",
+    "time",
+] }
+
+# 错误处理
+thiserror = "1.0"
+anyhow = "1.0"
+
+# 时间和 UUID
+chrono = { version = "0.4", features = ["serde"] }
+uuid = { version = "1.6", features = ["v4", "serde"] }
+
+# 安全
+secrecy = { version = "0.8", features = ["serde"] }
+
+# 工具
+once_cell = "1.19"
+async-trait = "0.1"
+futures = "0.3"
+
+[build-dependencies]
+tonic-build = "0.11"
+
+[dev-dependencies]
+tokio-test = "0.4"
+
+[profile.release]
+opt-level = 3
+lto = true
+codegen-units = 1
+strip = true
+
+[profile.dev]
+opt-level = 0
+debug = true

--- a/koduck-ai/Dockerfile
+++ b/koduck-ai/Dockerfile
@@ -1,0 +1,76 @@
+# Multi-stage build for koduck-ai
+
+# Stage 1: Builder
+FROM docker.m.daocloud.io/library/rust:1.88-slim-bookworm AS builder
+
+WORKDIR /app
+ENV CARGO_HOME=/usr/local/cargo
+
+# Configure Cargo to use rsproxy.cn (China mirror) for crates index/downloads
+RUN mkdir -p /usr/local/cargo && \
+    printf '[source.crates-io]\nreplace-with = "rsproxy"\n\n[source.rsproxy]\nregistry = "sparse+https://rsproxy.cn/index/"\n' > /usr/local/cargo/config.toml
+
+# Install dependencies (use Tsinghua mirror for Debian repositories)
+RUN sed -i 's|http://deb.debian.org/debian|https://mirrors.tuna.tsinghua.edu.cn/debian|g' /etc/apt/sources.list.d/debian.sources \
+ && sed -i 's|http://deb.debian.org/debian-security|https://mirrors.tuna.tsinghua.edu.cn/debian-security|g' /etc/apt/sources.list.d/debian.sources \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends \
+    pkg-config \
+    libssl-dev \
+    protobuf-compiler \
+    libprotobuf-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+# Copy manifests
+COPY Cargo.toml ./
+COPY build.rs ./
+COPY proto ./proto
+
+# Create minimal source tree for dependency caching build.
+RUN mkdir -p src && echo "fn main() {}" > src/main.rs
+
+# Resolve and fetch deps with persistent cache (only new deps will download).
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    cargo generate-lockfile && cargo fetch --locked
+
+# Copy source code
+COPY src ./src
+
+# Build application
+RUN cargo build --release --locked && \
+    cp /app/target/release/koduck-ai /app/koduck-ai && \
+    strip --strip-all /app/koduck-ai
+
+# Stage 2: Runtime
+FROM docker.m.daocloud.io/library/debian:bookworm-slim
+
+WORKDIR /app
+
+# Install minimal runtime dependencies
+RUN sed -i 's|http://deb.debian.org/debian|http://mirrors.tuna.tsinghua.edu.cn/debian|g' /etc/apt/sources.list.d/debian.sources \
+ && sed -i 's|http://deb.debian.org/debian-security|http://mirrors.tuna.tsinghua.edu.cn/debian-security|g' /etc/apt/sources.list.d/debian.sources \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    libssl3 \
+    wget \
+ && rm -rf /var/lib/apt/lists/*
+
+# Create non-root user
+RUN groupadd -g 1000 koduck && \
+    useradd -u 1000 -g 1000 -m -s /usr/sbin/nologin koduck
+
+# Copy binary from builder
+COPY --from=builder /app/koduck-ai /usr/local/bin/koduck-ai
+
+USER koduck
+
+# Expose ports
+EXPOSE 8083 50051 9090
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
+    CMD wget --quiet --tries=1 --spider http://localhost:8083/healthz || exit 1
+
+ENTRYPOINT ["koduck-ai"]

--- a/koduck-ai/build.rs
+++ b/koduck-ai/build.rs
@@ -1,0 +1,18 @@
+use std::io::Result;
+
+fn main() -> Result<()> {
+    println!("cargo:rerun-if-changed=proto/koduck/contract/v1/shared.proto");
+    let out_dir = std::env::var("OUT_DIR").expect("OUT_DIR must be set by Cargo");
+    let descriptor_path = std::path::Path::new(&out_dir).join("koduck_ai.bin");
+
+    tonic_build::configure()
+        .build_server(true)
+        .build_client(true)
+        .file_descriptor_set_path(descriptor_path)
+        .compile(
+            &["proto/koduck/contract/v1/shared.proto"],
+            &["proto", "/usr/include"],
+        )?;
+
+    Ok(())
+}

--- a/koduck-ai/docs/adr/0001-init-rust-grpc-project-structure.md
+++ b/koduck-ai/docs/adr/0001-init-rust-grpc-project-structure.md
@@ -1,0 +1,143 @@
+# ADR-0001: 初始化 koduck-ai Rust + gRPC 项目目录结构
+
+- Status: Accepted
+- Date: 2026-04-10
+- Issue: #717
+
+## Context
+
+根据解耦架构设计文档 `docs/design/koduckai-rust-server/ai-decoupled-architecture.md`，`koduck-ai` 需要从"内聚过多能力的 AI 服务"收敛为"AI Gateway / Orchestrator"。其核心职责包括：
+
+1. **AI 编排网关**：chat / stream 编排、上下文拼装
+2. **南向 gRPC 客户端**：调用 memory / tool / llm 能力服务
+3. **北向 HTTP API**：对前端提供 chat / stream 接口
+4. **流式可靠性**：SSE 传输、断点续流、背压控制
+5. **统一错误与降级**：错误码归一、重试预算、降级语义
+
+### 技术选型决策
+
+| 领域 | 技术选择 | 理由 |
+|------|----------|------|
+| 语言 | Rust 1.88+ | 高性能、内存安全、团队已有 Rust 基础 |
+| HTTP 框架 | axum 0.7 | 基于 tokio 和 tower，与 koduck-auth 保持一致 |
+| gRPC | tonic 0.11 | Rust 主流 gRPC 实现，南向客户端调用 |
+| 异步运行时 | tokio 1.x | Rust 事实标准异步运行时 |
+| 日志 | tracing + tracing-subscriber | 结构化日志，支持 JSON 输出 |
+| 配置 | config + secrecy | 环境变量注入 + Secret 脱敏 |
+| 构建 | Docker 多阶段构建 | 与 koduck-auth 保持一致的 CI/CD 流程 |
+
+## Decision
+
+### 项目目录结构
+
+遵循设计文档第 10 节目录建议，按职责分层：
+
+```
+koduck-ai/
+├── Cargo.toml              # 项目配置和依赖
+├── build.rs                # tonic-build 编译 proto
+├── Dockerfile              # 多阶段构建镜像
+├── .dockerignore           # Docker 构建排除规则
+├── proto/                  # gRPC proto 定义（预留，Phase 2 填充）
+│   └── koduck/
+│       └── contract/
+│           └── v1/
+│               └── shared.proto
+├── src/
+│   ├── main.rs             # 服务入口：配置加载、服务启动、优雅停机
+│   ├── lib.rs              # 库入口：模块声明
+│   ├── app/                # 启动与生命周期管理
+│   │   └── mod.rs
+│   ├── api/                # chat/stream handler（北向 API）
+│   │   └── mod.rs
+│   ├── orchestrator/       # 编排核心
+│   │   └── mod.rs
+│   ├── llm/                # 提供商适配与路由
+│   │   └── mod.rs
+│   ├── auth/               # auth 适配（对接 koduck-auth）
+│   │   └── mod.rs
+│   ├── clients/            # 南向 gRPC 客户端
+│   │   ├── mod.rs
+│   │   ├── memory/         # memory service client
+│   │   │   └── mod.rs
+│   │   ├── tool/           # tool service client
+│   │   │   └── mod.rs
+│   │   └── llm/            # llm adapter client
+│   │       └── mod.rs
+│   ├── stream/             # SSE/WS transport 与队列
+│   │   └── mod.rs
+│   ├── reliability/        # retry/circuit/degrade
+│   │   └── mod.rs
+│   ├── observe/            # logging/trace/metrics
+│   │   └── mod.rs
+│   └── config/             # 配置与 secret 解析
+│       └── mod.rs
+└── docs/
+    └── adr/                # 架构决策记录
+```
+
+### 端口规划
+
+| 端口 | 用途 | 协议 |
+|------|------|------|
+| 8083 | 北向 HTTP API (chat/stream/healthz) | HTTP/1.1, HTTP/2 |
+| 50051 | gRPC Server（预留，供内部服务调用） | HTTP/2 |
+| 9090 | Metrics (Prometheus) | HTTP/1.1 |
+
+### 启动流程
+
+```
+加载配置 → 初始化日志 → 启动 HTTP Server → 启动 Metrics Server → 等待信号 → 优雅停机
+```
+
+启动日志输出：版本号、运行环境（dev/staging/prod）、监听端口列表。
+
+## Consequences
+
+### 正向影响
+
+1. **架构清晰**：按设计文档职责分层，与 koduck-auth 保持一致的工程规范
+2. **可扩展性**：目录结构预留了 Phase 2-8 所需的所有模块位置
+3. **容器化构建**：Docker 多阶段构建，与现有 CI/CD 流程兼容
+4. **快速启动**：最小骨架可独立编译和运行，为后续开发提供基础
+
+### 代价与风险
+
+1. **空模块开销**：首期创建大量空 mod.rs 文件，但这是必要的结构预留
+2. **构建时间**：Rust 编译时间较长，通过 Docker 层缓存和增量编译缓解
+3. **proto 暂为占位**：build.rs 和 proto 目录在 Phase 2 才填充完整契约
+
+### 兼容性影响
+
+- **API 兼容性**：北向 API 路径（`/api/v1/ai/chat`、`/api/v1/ai/chat/stream`、`/healthz`）与现有前端保持一致
+- **端口规划**：HTTP 8083 不与 koduck-auth(8081) / koduck-user(8082) 冲突
+- **技术栈一致**：与 koduck-auth 使用相同的 Rust 版本和核心依赖，降低维护成本
+
+## Alternatives Considered
+
+### 1. 使用 Go 实现
+
+- **拒绝理由**：团队已有 Rust 基础（koduck-auth），且 Rust 在内存安全和零成本抽象方面更优
+
+### 2. 本地 cargo 构建
+
+- **拒绝理由**：团队约定使用容器构建，确保环境一致性
+
+### 3. 嵌套在 koduck-backend 内
+
+- **拒绝理由**：设计文档明确 koduck-ai 为独立服务，与其他微服务平级
+
+## Verification
+
+- `docker build -t koduck-ai:dev ./koduck-ai` 构建成功
+- 启动后日志输出版本、环境、监听端口
+- 优雅停机（Ctrl+C）正常工作
+- 目录结构与设计文档第 10 节一致
+
+## References
+
+- 设计文档: [ai-decoupled-architecture.md](../../../docs/design/koduckai-rust-server/ai-decoupled-architecture.md)
+- API 定义: [koduck-ai-api.yaml](../../../docs/design/koduckai-rust-server/koduck-ai-api.yaml)
+- 任务清单: [koduck-ai-rust-grpc-tasks.md](../../../docs/implementation/koduck-ai-rust-grpc-tasks.md)
+- 参考: koduck-auth 项目结构
+- Issue: [#717](https://github.com/hailingu/koduck-quant/issues/717)

--- a/koduck-ai/proto/koduck/contract/v1/shared.proto
+++ b/koduck-ai/proto/koduck/contract/v1/shared.proto
@@ -1,0 +1,31 @@
+syntax = "proto3";
+package koduck.contract.v1;
+
+option go_package = "github.com/hailingu/koduck-quant/proto/koduck/contract/v1;contractv1";
+
+message RequestMeta {
+  string request_id = 1;
+  string session_id = 2;
+  string user_id = 3;
+  string tenant_id = 4;
+  string trace_id = 5;
+  string idempotency_key = 6;
+  int64 deadline_ms = 7;
+  string api_version = 8;
+}
+
+message ErrorDetail {
+  string code = 1;
+  string message = 2;
+  bool retryable = 3;
+  bool degraded = 4;
+  string upstream = 5;
+  int64 retry_after_ms = 6;
+}
+
+message Capability {
+  string service = 1;
+  repeated string contract_versions = 2;
+  map<string, string> features = 3;
+  map<string, string> limits = 4;
+}

--- a/koduck-ai/src/api/mod.rs
+++ b/koduck-ai/src/api/mod.rs
@@ -1,0 +1,1 @@
+//! North-facing API handlers (chat/stream)

--- a/koduck-ai/src/app/mod.rs
+++ b/koduck-ai/src/app/mod.rs
@@ -1,0 +1,30 @@
+//! Application startup and lifecycle management
+
+use axum::{routing::get, Router};
+
+/// Health check response
+#[derive(serde::Serialize)]
+pub struct HealthResponse {
+    pub status: &'static str,
+    pub service: &'static str,
+    pub version: &'static str,
+}
+
+/// Create the main HTTP router
+pub fn create_router() -> Router {
+    Router::new()
+        .route("/healthz", get(health_handler))
+}
+
+/// Create the metrics router
+pub fn create_metrics_router() -> Router {
+    Router::new()
+}
+
+async fn health_handler() -> axum::Json<HealthResponse> {
+    axum::Json(HealthResponse {
+        status: "ok",
+        service: "koduck-ai",
+        version: env!("CARGO_PKG_VERSION"),
+    })
+}

--- a/koduck-ai/src/auth/mod.rs
+++ b/koduck-ai/src/auth/mod.rs
@@ -1,0 +1,1 @@
+//! Auth adapter (integration with koduck-auth)

--- a/koduck-ai/src/clients/llm/mod.rs
+++ b/koduck-ai/src/clients/llm/mod.rs
@@ -1,0 +1,1 @@
+//! LLM adapter gRPC client

--- a/koduck-ai/src/clients/mod.rs
+++ b/koduck-ai/src/clients/mod.rs
@@ -1,0 +1,5 @@
+//! South-facing gRPC clients
+
+pub mod llm;
+pub mod memory;
+pub mod tool;

--- a/koduck-ai/src/clients/tool/mod.rs
+++ b/koduck-ai/src/clients/tool/mod.rs
@@ -1,0 +1,1 @@
+//! Tool service gRPC client

--- a/koduck-ai/src/config/mod.rs
+++ b/koduck-ai/src/config/mod.rs
@@ -1,0 +1,49 @@
+//! Configuration management for koduck-ai
+
+use config::{Config as ConfigBuilder, ConfigError, Environment, File};
+use serde::Deserialize;
+
+/// Application configuration
+#[derive(Debug, Deserialize, Clone)]
+pub struct Config {
+    pub server: ServerConfig,
+}
+
+/// Server configuration
+#[derive(Debug, Deserialize, Clone)]
+pub struct ServerConfig {
+    pub http_addr: String,
+    pub grpc_addr: String,
+    pub metrics_addr: String,
+}
+
+impl Default for ServerConfig {
+    fn default() -> Self {
+        Self {
+            http_addr: "0.0.0.0:8083".to_string(),
+            grpc_addr: "0.0.0.0:50051".to_string(),
+            metrics_addr: "0.0.0.0:9090".to_string(),
+        }
+    }
+}
+
+impl Config {
+    /// Load configuration from environment variables and config files
+    pub fn from_env() -> Result<Self, ConfigError> {
+        let _ = dotenvy::dotenv();
+
+        let config = ConfigBuilder::builder()
+            // Default configuration
+            .set_default("server.http_addr", "0.0.0.0:8083")?
+            .set_default("server.grpc_addr", "0.0.0.0:50051")?
+            .set_default("server.metrics_addr", "0.0.0.0:9090")?
+            // Config file (optional)
+            .add_source(File::with_name("config/default").required(false))
+            .add_source(File::with_name("config/local").required(false))
+            // Environment variables with prefix KODUCK_AI
+            .add_source(Environment::with_prefix("KODUCK_AI").separator("__"))
+            .build()?;
+
+        config.try_deserialize()
+    }
+}

--- a/koduck-ai/src/lib.rs
+++ b/koduck-ai/src/lib.rs
@@ -1,0 +1,17 @@
+//! Koduck AI - AI Gateway / Orchestrator
+//!
+//! An AI orchestration gateway written in Rust,
+//! providing chat/stream interfaces and coordinating memory/tool/llm services.
+
+pub mod api;
+pub mod app;
+pub mod auth;
+pub mod clients;
+pub mod config;
+pub mod llm;
+pub mod observe;
+pub mod orchestrator;
+pub mod reliability;
+pub mod stream;
+
+pub use config::Config;

--- a/koduck-ai/src/llm/mod.rs
+++ b/koduck-ai/src/llm/mod.rs
@@ -1,0 +1,1 @@
+//! LLM provider adapter and routing

--- a/koduck-ai/src/main.rs
+++ b/koduck-ai/src/main.rs
@@ -1,0 +1,87 @@
+use std::net::SocketAddr;
+
+use tokio::net::TcpListener;
+use tokio::sync::broadcast;
+use tracing::{error, info};
+use tracing_subscriber::EnvFilter;
+
+use koduck_ai::app;
+
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Initialize structured JSON logging for container/k8s environments.
+    let env_filter = EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| EnvFilter::new("info,koduck_ai=info,tower_http=warn"));
+    tracing_subscriber::fmt()
+        .json()
+        .with_ansi(false)
+        .with_current_span(false)
+        .with_span_list(false)
+        .with_env_filter(env_filter)
+        .init();
+
+    let env = std::env::var("APP_ENV").unwrap_or_else(|_| "dev".to_string());
+
+    info!(
+        version = VERSION,
+        env = %env,
+        "Starting koduck-ai service"
+    );
+
+    // Load configuration
+    let config = koduck_ai::config::Config::from_env()?;
+
+    // Create HTTP server
+    let http_addr: SocketAddr = config.server.http_addr.parse()?;
+    let http_listener = TcpListener::bind(http_addr).await?;
+    let http_app = app::create_router();
+
+    // Create metrics server
+    let metrics_addr: SocketAddr = config.server.metrics_addr.parse()?;
+    let metrics_listener = TcpListener::bind(metrics_addr).await?;
+    let metrics_app = app::create_metrics_router();
+
+    info!(
+        http_addr = %http_addr,
+        metrics_addr = %metrics_addr,
+        grpc_addr = %config.server.grpc_addr,
+        "Servers listening"
+    );
+
+    let (shutdown_tx, _) = broadcast::channel::<()>(1);
+    let mut http_shutdown_rx = shutdown_tx.subscribe();
+    let mut metrics_shutdown_rx = shutdown_tx.subscribe();
+
+    // Run HTTP + metrics services concurrently
+    tokio::select! {
+        result = axum::serve(
+            http_listener,
+            http_app.into_make_service_with_connect_info::<SocketAddr>(),
+        ).with_graceful_shutdown(async move {
+            let _ = http_shutdown_rx.recv().await;
+        }) => {
+            if let Err(e) = result {
+                error!("HTTP server error: {}", e);
+            }
+        }
+        result = axum::serve(metrics_listener, metrics_app).with_graceful_shutdown(async move {
+            let _ = metrics_shutdown_rx.recv().await;
+        }) => {
+            if let Err(e) = result {
+                error!("Metrics server error: {}", e);
+            }
+        }
+        result = tokio::signal::ctrl_c() => {
+            match result {
+                Ok(()) => info!("Received Ctrl+C, shutting down all services..."),
+                Err(e) => error!("Failed to listen for Ctrl+C: {}", e),
+            }
+        }
+    }
+
+    let _ = shutdown_tx.send(());
+    info!("Shutting down koduck-ai service...");
+    Ok(())
+}

--- a/koduck-ai/src/observe/mod.rs
+++ b/koduck-ai/src/observe/mod.rs
@@ -1,0 +1,1 @@
+//! Logging, tracing, and metrics

--- a/koduck-ai/src/orchestrator/mod.rs
+++ b/koduck-ai/src/orchestrator/mod.rs
@@ -1,0 +1,1 @@
+//! Orchestration core (chat/stream pipeline)

--- a/koduck-ai/src/reliability/mod.rs
+++ b/koduck-ai/src/reliability/mod.rs
@@ -1,0 +1,1 @@
+//! Retry, circuit breaker, and degradation

--- a/koduck-ai/src/stream/mod.rs
+++ b/koduck-ai/src/stream/mod.rs
@@ -1,0 +1,1 @@
+//! SSE/WS transport and queue management


### PR DESCRIPTION
## Summary

- 建立 `koduck-ai` Rust 项目骨架，遵循 [ai-decoupled-architecture.md](docs/design/koduckai-rust-server/ai-decoupled-architecture.md) 第 10 节目录建议
- 包含 Cargo.toml、build.rs、Dockerfile（多阶段构建）、shared.proto 占位
- 实现启动流程：配置加载、HTTP(8083)/Metrics(9090) 服务启动、优雅停机
- 实现 `/healthz` 健康检查端点
- 添加 ADR-0001 记录项目结构决策

## 目录结构

```
koduck-ai/
├── Cargo.toml / build.rs / Dockerfile / .dockerignore
├── proto/koduck/contract/v1/shared.proto
├── src/{app,api,orchestrator,llm,auth,clients,stream,reliability,observe,config}
└── docs/adr/0001-init-rust-grpc-project-structure.md
```

## Test plan

- [x] `docker build -t koduck-ai:dev ./koduck-ai` 构建成功
- [x] 启动日志输出版本、环境、监听端口
- [x] 优雅停机（Ctrl+C）正常工作
- [x] 目录结构与设计文档第 10 节一致

Closes #717

🤖 Generated with [Claude Code](https://claude.com/claude-code)