### PR TITLE
feat(koduck-ai): implement config and secret management (Task 1.2)

### DIFF
--- a/koduck-ai/docs/adr/0002-config-and-secret-management.md
+++ b/koduck-ai/docs/adr/0002-config-and-secret-management.md
@@ -1,0 +1,121 @@
+# ADR-0002: 配置与 Secret 管理
+
+- Status: Accepted
+- Date: 2026-04-10
+- Issue: #719
+
+## Context
+
+`koduck-ai` 作为 AI Gateway/Orchestrator，需要灵活管理多种运行时配置：
+
+1. **南向 gRPC 客户端地址**：memory / tool / llm adapter 的 gRPC target（经由 APISIX 路由）
+2. **LLM 提供商参数**：默认提供商、超时时间
+3. **流式传输参数**：最大流式持续时间
+4. **敏感信息**：LLM API Key（如 `OPENAI_API_KEY`、`DEEPSEEK_API_KEY`、`ANTHROPIC_API_KEY`）等
+
+设计文档第 9 节明确了 Secret 管理约束：禁止在代码、配置样例、日志中明文落地密钥。
+
+### 现有参考
+
+`koduck-auth` 已建立成熟的配置管理模式，使用 `config` crate + `secrecy` crate 实现：
+
+- `config` crate：支持多层配置源（默认值 → 配置文件 → 环境变量），环境变量优先级最高
+- `secrecy::SecretString`：封装敏感字段，Debug/Display 输出自动脱敏为 `***`
+- 环境变量前缀：`KODUCK_AUTH__`，双下划线分隔嵌套层级
+
+## Decision
+
+### 配置结构设计
+
+采用与 `koduck-auth` 一致的模式，按职责域划分配置子结构：
+
+| 配置域 | 结构体 | 关键字段 |
+|--------|--------|----------|
+| 服务端口 | `ServerConfig` | `http_addr`, `grpc_addr`, `metrics_addr` |
+| LLM | `LlmConfig` | `default_provider`, `timeout_ms`, `api_keys` |
+| Memory | `MemoryConfig` | `grpc_target` |
+| Tool | `ToolConfig` | `grpc_target` |
+| Stream | `StreamConfig` | `max_duration_ms` |
+| Auth | `AuthConfig` | `jwks_url` |
+
+### 环境变量命名规范
+
+沿用 `KODUCK_AI__` 前缀 + 双下划线层级分隔：
+
+```
+KODUCK_AI__MEMORY__GRPC_TARGET
+KODUCK_AI__TOOLS__GRPC_TARGET
+KODUCK_AI__LLM__ADAPTER_GRPC_TARGET
+KODUCK_AI__LLM__DEFAULT_PROVIDER
+KODUCK_AI__LLM__TIMEOUT_MS
+KODUCK_AI__STREAM__MAX_DURATION_MS
+KODUCK_AI__AUTH__JWKS_URL
+```
+
+### Secret 管理
+
+- LLM API Key 使用 `secrecy::SecretString` 封装
+- Config 的 `Debug` / `Display` 实现中，Secret 字段统一输出 `***`
+- 按提供商分 Key（`openai_api_key`, `deepseek_api_key`, `anthropic_api_key`），由环境变量注入
+
+### 配置校验
+
+- 每个配置子结构实现 `validate()` 方法，启动时统一校验
+- 校验失败返回结构化 `ValidationError`，包含具体字段名和错误原因
+- 校验不通过则 fail-fast，服务拒绝启动
+
+### 配置加载优先级
+
+```
+默认值 → config/default.toml → config/local.toml → 环境变量（最高优先级）
+```
+
+## Consequences
+
+### 正向影响
+
+1. **与 koduck-auth 一致**：相同的配置模式和命名规范，降低团队认知成本
+2. **安全性**：Secret 类型确保密钥不会意外泄露到日志中
+3. **灵活性**：环境变量覆盖机制支持 K8s ConfigMap / Secret 注入
+4. **快速失败**：启动时校验避免运行时配置错误导致的不确定行为
+
+### 代价与风险
+
+1. **SecretString 开销**：每次访问密钥需显式调用 `expose_secret()`，增加少量代码复杂度
+2. **配置项增长**：后续 Phase 可能增加更多配置项，需保持结构清晰
+
+### 兼容性影响
+
+- **环境变量**：新增环境变量不影响现有服务（koduck-ai 为新服务）
+- **配置文件**：`config/default.toml` 和 `config/local.toml` 为可选文件，不存在时不影响启动
+- **API 兼容性**：配置变更不影响北向 API 契约
+
+## Alternatives Considered
+
+### 1. 使用 clap 进行 CLI 参数配置
+
+- **拒绝理由**：服务端应用主要通过环境变量和配置文件管理配置，CLI 参数不适合容器化部署
+
+### 2. 自定义配置解析
+
+- **拒绝理由**：`config` crate 已是 Rust 生态事实标准，支持多层配置源合并，无需重复造轮
+
+### 3. 使用 envy 直接从环境变量反序列化
+
+- **拒绝理由**：不支持配置文件，且缺少与 `config` crate 同等的分层覆盖能力
+
+## Verification
+
+- 配置校验失败时服务拒绝启动并输出具体错误信息
+- Secret 字段在 `Debug` / `Display` 输出中显示为 `***`
+- 环境变量正确覆盖默认值和配置文件值
+- `docker build -t koduck-ai:dev ./koduck-ai` 通过
+
+## References
+
+- 设计文档: [ai-decoupled-architecture.md](../../../docs/design/koduckai-rust-server/ai-decoupled-architecture.md) 第 9 节
+- API 定义: [koduck-ai-api.yaml](../../../docs/design/koduckai-rust-server/koduck-ai-api.yaml)
+- 任务清单: [koduck-ai-rust-grpc-tasks.md](../../../docs/implementation/koduck-ai-rust-grpc-tasks.md) Task 1.2
+- 前置 ADR: [ADR-0001](0001-init-rust-grpc-project-structure.md)
+- 参考: `koduck-auth/src/config.rs`
+- Issue: [#719](https://github.com/hailingu/koduck-quant/issues/719)

--- a/koduck-ai/src/clients/memory/mod.rs
+++ b/koduck-ai/src/clients/memory/mod.rs
@@ -1,0 +1,1 @@
+//! Memory service gRPC client

--- a/koduck-ai/src/config/mod.rs
+++ b/koduck-ai/src/config/mod.rs
@@ -1,21 +1,172 @@
 //! Configuration management for koduck-ai
+//!
+//! Supports layered configuration: defaults → config files → environment variables.
+//! Sensitive fields use `secrecy::SecretString` to prevent accidental log leakage.
 
 use config::{Config as ConfigBuilder, ConfigError, Environment, File};
+use secrecy::{ExposeSecret, SecretString};
 use serde::Deserialize;
+use std::fmt;
+
+/// Custom validation error for configuration
+#[derive(Debug)]
+pub struct ValidationError {
+    pub message: String,
+}
+
+impl std::error::Error for ValidationError {}
+
+impl fmt::Display for ValidationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Configuration validation error: {}", self.message)
+    }
+}
+
+impl From<ValidationError> for ConfigError {
+    fn from(err: ValidationError) -> Self {
+        ConfigError::Message(err.message)
+    }
+}
 
 /// Application configuration
 #[derive(Debug, Deserialize, Clone)]
 pub struct Config {
     pub server: ServerConfig,
+    pub memory: MemoryConfig,
+    pub tools: ToolConfig,
+    pub llm: LlmConfig,
+    pub stream: StreamConfig,
+    pub auth: AuthConfig,
 }
 
-/// Server configuration
+/// Server configuration (HTTP, gRPC, metrics)
 #[derive(Debug, Deserialize, Clone)]
 pub struct ServerConfig {
     pub http_addr: String,
     pub grpc_addr: String,
     pub metrics_addr: String,
 }
+
+/// Memory service gRPC client configuration
+#[derive(Debug, Deserialize, Clone)]
+pub struct MemoryConfig {
+    pub grpc_target: String,
+}
+
+/// Tool service gRPC client configuration
+#[derive(Debug, Deserialize, Clone)]
+pub struct ToolConfig {
+    pub grpc_target: String,
+}
+
+/// LLM adapter configuration
+#[derive(Debug, Deserialize, Clone)]
+pub struct LlmConfig {
+    pub adapter_grpc_target: String,
+    pub default_provider: String,
+    pub timeout_ms: u64,
+    /// API keys per provider — wrapped in SecretString to prevent log leakage.
+    #[serde(default)]
+    pub openai_api_key: Option<SecretString>,
+    #[serde(default)]
+    pub deepseek_api_key: Option<SecretString>,
+    #[serde(default)]
+    pub anthropic_api_key: Option<SecretString>,
+}
+
+/// Stream / SSE transport configuration
+#[derive(Debug, Deserialize, Clone)]
+pub struct StreamConfig {
+    pub max_duration_ms: u64,
+}
+
+/// Auth configuration (JWKS endpoint)
+#[derive(Debug, Deserialize, Clone)]
+pub struct AuthConfig {
+    pub jwks_url: String,
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+impl ServerConfig {
+    pub fn validate(&self) -> Result<(), ValidationError> {
+        validate_socket_addr(&self.http_addr, "server.http_addr")?;
+        validate_socket_addr(&self.grpc_addr, "server.grpc_addr")?;
+        validate_socket_addr(&self.metrics_addr, "server.metrics_addr")?;
+        Ok(())
+    }
+}
+
+impl MemoryConfig {
+    pub fn validate(&self) -> Result<(), ValidationError> {
+        if self.grpc_target.trim().is_empty() {
+            return Err(ValidationError {
+                message: "memory.grpc_target cannot be empty".to_string(),
+            });
+        }
+        Ok(())
+    }
+}
+
+impl ToolConfig {
+    pub fn validate(&self) -> Result<(), ValidationError> {
+        if self.grpc_target.trim().is_empty() {
+            return Err(ValidationError {
+                message: "tools.grpc_target cannot be empty".to_string(),
+            });
+        }
+        Ok(())
+    }
+}
+
+impl LlmConfig {
+    pub fn validate(&self) -> Result<(), ValidationError> {
+        if self.default_provider.trim().is_empty() {
+            return Err(ValidationError {
+                message: "llm.default_provider cannot be empty".to_string(),
+            });
+        }
+        if self.timeout_ms == 0 {
+            return Err(ValidationError {
+                message: "llm.timeout_ms must be greater than 0".to_string(),
+            });
+        }
+        if self.adapter_grpc_target.trim().is_empty() {
+            return Err(ValidationError {
+                message: "llm.adapter_grpc_target cannot be empty".to_string(),
+            });
+        }
+        Ok(())
+    }
+}
+
+impl StreamConfig {
+    pub fn validate(&self) -> Result<(), ValidationError> {
+        if self.max_duration_ms == 0 {
+            return Err(ValidationError {
+                message: "stream.max_duration_ms must be greater than 0".to_string(),
+            });
+        }
+        Ok(())
+    }
+}
+
+impl AuthConfig {
+    pub fn validate(&self) -> Result<(), ValidationError> {
+        if self.jwks_url.trim().is_empty() {
+            return Err(ValidationError {
+                message: "auth.jwks_url cannot be empty".to_string(),
+            });
+        }
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Defaults
+// ---------------------------------------------------------------------------
 
 impl Default for ServerConfig {
     fn default() -> Self {
@@ -27,23 +178,330 @@ impl Default for ServerConfig {
     }
 }
 
+impl Default for MemoryConfig {
+    fn default() -> Self {
+        Self {
+            grpc_target: "http://localhost:50052".to_string(),
+        }
+    }
+}
+
+impl Default for ToolConfig {
+    fn default() -> Self {
+        Self {
+            grpc_target: "http://localhost:50053".to_string(),
+        }
+    }
+}
+
+impl Default for LlmConfig {
+    fn default() -> Self {
+        Self {
+            adapter_grpc_target: "http://localhost:50054".to_string(),
+            default_provider: "openai".to_string(),
+            timeout_ms: 30_000,
+            openai_api_key: None,
+            deepseek_api_key: None,
+            anthropic_api_key: None,
+        }
+    }
+}
+
+impl Default for StreamConfig {
+    fn default() -> Self {
+        Self {
+            max_duration_ms: 300_000, // 5 minutes
+        }
+    }
+}
+
+impl Default for AuthConfig {
+    fn default() -> Self {
+        Self {
+            jwks_url: "http://localhost:8081/.well-known/jwks.json".to_string(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Config loading
+// ---------------------------------------------------------------------------
+
 impl Config {
-    /// Load configuration from environment variables and config files
+    /// Load configuration from environment variables and config files.
+    ///
+    /// Priority (highest wins): environment variables → config/local.toml → config/default.toml → defaults
+    ///
+    /// Fails fast if any validation rule is violated.
     pub fn from_env() -> Result<Self, ConfigError> {
+        let config = Self::load()?;
+        config.validate()?;
+        Ok(config)
+    }
+
+    /// Load configuration without validation (for testing).
+    pub(crate) fn load() -> Result<Self, ConfigError> {
         let _ = dotenvy::dotenv();
 
         let config = ConfigBuilder::builder()
-            // Default configuration
+            // Defaults — ServerConfig
             .set_default("server.http_addr", "0.0.0.0:8083")?
             .set_default("server.grpc_addr", "0.0.0.0:50051")?
             .set_default("server.metrics_addr", "0.0.0.0:9090")?
-            // Config file (optional)
+            // Defaults — MemoryConfig
+            .set_default("memory.grpc_target", "http://localhost:50052")?
+            // Defaults — ToolConfig
+            .set_default("tools.grpc_target", "http://localhost:50053")?
+            // Defaults — LlmConfig
+            .set_default("llm.adapter_grpc_target", "http://localhost:50054")?
+            .set_default("llm.default_provider", "openai")?
+            .set_default("llm.timeout_ms", 30_000)?
+            // Defaults — StreamConfig
+            .set_default("stream.max_duration_ms", 300_000)?
+            // Defaults — AuthConfig
+            .set_default("auth.jwks_url", "http://localhost:8081/.well-known/jwks.json")?
+            // Optional config files
             .add_source(File::with_name("config/default").required(false))
             .add_source(File::with_name("config/local").required(false))
-            // Environment variables with prefix KODUCK_AI
+            // Environment variables with prefix KODUCK_AI, separated by double underscore
             .add_source(Environment::with_prefix("KODUCK_AI").separator("__"))
             .build()?;
 
         config.try_deserialize()
+    }
+
+    /// Validate all configuration sections.
+    pub fn validate(&self) -> Result<(), ValidationError> {
+        self.server.validate()?;
+        self.memory.validate()?;
+        self.tools.validate()?;
+        self.llm.validate()?;
+        self.stream.validate()?;
+        self.auth.validate()?;
+        Ok(())
+    }
+
+    /// Expose a provider API key for use in LLM client initialization.
+    /// Returns `None` if the key is not configured.
+    pub fn openai_api_key(&self) -> Option<&str> {
+        self.llm.openai_api_key.as_ref().map(|k| k.expose_secret().as_str())
+    }
+
+    pub fn deepseek_api_key(&self) -> Option<&str> {
+        self.llm.deepseek_api_key.as_ref().map(|k| k.expose_secret().as_str())
+    }
+
+    pub fn anthropic_api_key(&self) -> Option<&str> {
+        self.llm.anthropic_api_key.as_ref().map(|k| k.expose_secret().as_str())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Display — Secret fields are masked as ***
+// ---------------------------------------------------------------------------
+
+impl fmt::Display for Config {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Config {{ server: {:?}, memory: {:?}, tools: {:?}, llm: LlmConfig {{ adapter_grpc_target: {:?}, default_provider: {:?}, timeout_ms: {}, api_keys: ***, ... }}, stream: {:?}, auth: {:?} }}",
+            self.server,
+            self.memory,
+            self.tools,
+            self.llm.adapter_grpc_target,
+            self.llm.default_provider,
+            self.llm.timeout_ms,
+            self.stream,
+            self.auth,
+        )
+    }
+}
+
+/// Validate that a string is a valid socket address (host:port).
+fn validate_socket_addr(addr: &str, field_name: &str) -> Result<(), ValidationError> {
+    match addr.parse::<std::net::SocketAddr>() {
+        Ok(socket_addr) => {
+            if socket_addr.port() == 0 {
+                return Err(ValidationError {
+                    message: format!("{}.port cannot be 0", field_name),
+                });
+            }
+            Ok(())
+        }
+        Err(e) => Err(ValidationError {
+            message: format!("{} ('{}') is not a valid socket address: {}", field_name, addr, e),
+        }),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_socket_addr_valid() {
+        assert!(validate_socket_addr("0.0.0.0:8083", "http_addr").is_ok());
+        assert!(validate_socket_addr("127.0.0.1:50051", "grpc_addr").is_ok());
+        assert!(validate_socket_addr("[::1]:9090", "metrics_addr").is_ok());
+    }
+
+    #[test]
+    fn test_validate_socket_addr_invalid() {
+        let result = validate_socket_addr("not-an-address", "http_addr");
+        assert!(result.is_err());
+
+        let result = validate_socket_addr("0.0.0.0", "http_addr");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_server_config_default_valid() {
+        let config = ServerConfig::default();
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_memory_config_default_valid() {
+        let config = MemoryConfig::default();
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_memory_config_empty_target() {
+        let config = MemoryConfig {
+            grpc_target: "".to_string(),
+        };
+        let result = config.validate();
+        assert!(result.is_err());
+        assert!(result.unwrap_err().message.contains("grpc_target"));
+    }
+
+    #[test]
+    fn test_tool_config_default_valid() {
+        let config = ToolConfig::default();
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_tool_config_empty_target() {
+        let config = ToolConfig {
+            grpc_target: "".to_string(),
+        };
+        let result = config.validate();
+        assert!(result.is_err());
+        assert!(result.unwrap_err().message.contains("grpc_target"));
+    }
+
+    #[test]
+    fn test_llm_config_default_valid() {
+        let config = LlmConfig::default();
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_llm_config_empty_provider() {
+        let config = LlmConfig {
+            default_provider: "".to_string(),
+            ..LlmConfig::default()
+        };
+        let result = config.validate();
+        assert!(result.is_err());
+        assert!(result.unwrap_err().message.contains("default_provider"));
+    }
+
+    #[test]
+    fn test_llm_config_zero_timeout() {
+        let config = LlmConfig {
+            timeout_ms: 0,
+            ..LlmConfig::default()
+        };
+        let result = config.validate();
+        assert!(result.is_err());
+        assert!(result.unwrap_err().message.contains("timeout_ms"));
+    }
+
+    #[test]
+    fn test_llm_config_empty_adapter_target() {
+        let config = LlmConfig {
+            adapter_grpc_target: "".to_string(),
+            ..LlmConfig::default()
+        };
+        let result = config.validate();
+        assert!(result.is_err());
+        assert!(result.unwrap_err().message.contains("adapter_grpc_target"));
+    }
+
+    #[test]
+    fn test_stream_config_default_valid() {
+        let config = StreamConfig::default();
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_stream_config_zero_duration() {
+        let config = StreamConfig { max_duration_ms: 0 };
+        let result = config.validate();
+        assert!(result.is_err());
+        assert!(result.unwrap_err().message.contains("max_duration_ms"));
+    }
+
+    #[test]
+    fn test_auth_config_default_valid() {
+        let config = AuthConfig::default();
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_auth_config_empty_jwks() {
+        let config = AuthConfig {
+            jwks_url: "".to_string(),
+        };
+        let result = config.validate();
+        assert!(result.is_err());
+        assert!(result.unwrap_err().message.contains("jwks_url"));
+    }
+
+    #[test]
+    fn test_config_display_masks_secrets() {
+        let config = Config {
+            server: ServerConfig::default(),
+            memory: MemoryConfig::default(),
+            tools: ToolConfig::default(),
+            llm: LlmConfig {
+                openai_api_key: Some(SecretString::from("sk-super-secret-key")),
+                deepseek_api_key: Some(SecretString::from("sk-another-secret")),
+                ..LlmConfig::default()
+            },
+            stream: StreamConfig::default(),
+            auth: AuthConfig::default(),
+        };
+        let display = format!("{}", config);
+        assert!(!display.contains("sk-super-secret-key"));
+        assert!(!display.contains("sk-another-secret"));
+        assert!(display.contains("***"));
+    }
+
+    #[test]
+    fn test_config_api_key_accessors() {
+        let config = Config {
+            server: ServerConfig::default(),
+            memory: MemoryConfig::default(),
+            tools: ToolConfig::default(),
+            llm: LlmConfig {
+                openai_api_key: Some(SecretString::from("sk-test")),
+                deepseek_api_key: None,
+                anthropic_api_key: Some(SecretString::from("sk-anthropic")),
+                ..LlmConfig::default()
+            },
+            stream: StreamConfig::default(),
+            auth: AuthConfig::default(),
+        };
+        assert_eq!(config.openai_api_key(), Some("sk-test"));
+        assert_eq!(config.deepseek_api_key(), None);
+        assert_eq!(config.anthropic_api_key(), Some("sk-anthropic"));
     }
 }

--- a/koduck-ai/src/main.rs
+++ b/koduck-ai/src/main.rs
@@ -30,8 +30,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         "Starting koduck-ai service"
     );
 
-    // Load configuration
+    // Load configuration (fails fast on validation errors)
     let config = koduck_ai::config::Config::from_env()?;
+
+    info!(config = %config, "Configuration loaded");
 
     // Create HTTP server
     let http_addr: SocketAddr = config.server.http_addr.parse()?;


### PR DESCRIPTION
## Summary

- Implement layered configuration system with environment variable override (`KODUCK_AI__*`)
- Add `SecretString` wrapping for LLM API keys (openai/deepseek/anthropic) with automatic log masking
- Add per-section validation with fail-fast on startup
- Create ADR-0002 documenting config/secret management decisions

## Configuration structure

| Section | Key env vars |
|---------|-------------|
| `server` | `KODUCK_AI__SERVER__HTTP_ADDR`, `GRPC_ADDR`, `METRICS_ADDR` |
| `memory` | `KODUCK_AI__MEMORY__GRPC_TARGET` |
| `tools` | `KODUCK_AI__TOOLS__GRPC_TARGET` |
| `llm` | `KODUCK_AI__LLM__ADAPTER_GRPC_TARGET`, `DEFAULT_PROVIDER`, `TIMEOUT_MS`, `OPENAI_API_KEY`, `DEEPSEEK_API_KEY`, `ANTHROPIC_API_KEY` |
| `stream` | `KODUCK_AI__STREAM__MAX_DURATION_MS` |
| `auth` | `KODUCK_AI__AUTH__JWKS_URL` |

## Test plan

- [x] `docker build -t koduck-ai:dev ./koduck-ai` passes
- [x] All config validation unit tests pass (15 tests covering empty/zero/invalid cases)
- [x] Secret fields masked as `***` in `Display` output
- [x] API key accessor methods return correct values
- [x] Config loaded log line shows masked secrets

Closes #719

🤖 Generated with [Claude Code](https://claude.com/claude-code)