### PR TITLE
feat(koduck-ai): add apisix gateway plugin baseline

### DIFF
--- a/docs/implementation/koduck-ai-rust-grpc-tasks.md
+++ b/docs/implementation/koduck-ai-rust-grpc-tasks.md
@@ -291,9 +291,9 @@ cd koduck-ai
 3. `grpc-transcode` 仅迁移窗口可选开启
 
 **验收标准:**
-- [ ] 网关侧限流生效
-- [ ] 指标与 trace 可串起全链路
-- [ ] 迁移完成后可关闭 transcode
+- [x] 网关侧限流生效
+- [x] 指标与 trace 可串起全链路
+- [x] 迁移完成后可关闭 transcode
 
 ---
 

--- a/k8s/overlays/dev/apisix-route-init.yaml
+++ b/k8s/overlays/dev/apisix-route-init.yaml
@@ -54,6 +54,10 @@ spec:
               value: "dev-tool-service:50051"
             - name: LLM_GRPC_SERVICE
               value: "dev-koduck-agent:50054"
+            - name: APISIX_SERVICE_NAME
+              value: "koduck-apisix-dev"
+            - name: ENABLE_AI_GRPC_TRANSCODE
+              value: "false"
           command:
             - /bin/sh
             - -ec
@@ -184,6 +188,9 @@ spec:
                 sleep 2
               done
 
+              echo "Registering opentelemetry plugin metadata"
+              upsert_resource "plugin_metadata" "opentelemetry" "$(printf '{"trace_id_source":"random","set_ngx_var":true,"resource":{"service.name":"%s"},"additional_attributes":["route_id","service_id","upstream_addr","status"],"additional_header_prefix_attributes":["x-request-id","x-session-id","x-user-id"]}' "$APISIX_SERVICE_NAME")"
+
               echo "Registering JWT consumer: koduck_user"
               curl -fsS -X PUT "${ADMIN}/consumers/koduck_user" \
                 -H "$KEY" -H 'Content-Type: application/json' \
@@ -246,7 +253,7 @@ spec:
                 echo "Registering AI route: ${URI} -> koduck-ai (openid-connect)"
                 curl -fsS -X PUT "${ADMIN}/routes/${AI_ROUTE}" \
                   -H "$KEY" -H 'Content-Type: application/json' \
-                  -d "$(printf '{"uri":"%s","priority":10,"plugins":{"openid-connect":{"client_id":"koduck-ai","client_secret":"%s","discovery":"http://%s/.well-known/openid-configuration","scope":"openid","ssl_verify":false,"timeout":10,"bearer_only":true,"use_jwks":true,"token_signing_alg_values_expected":"RS256","set_access_token_header":true,"access_token_in_authorization_header":true,"set_id_token_header":false,"set_userinfo_header":false,"jwk_expires_in":3600},"proxy-rewrite":{"headers":{"set":{"X-Auth-Provider":"apisix-oidc"}}}},"upstream":{"type":"roundrobin","nodes":{"%s":1}}}' "$URI" "$JWT_SECRET" "$AUTH_SERVICE" "$AI_SERVICE")"
+                  -d "$(printf '{"uri":"%s","priority":10,"plugins":{"openid-connect":{"client_id":"koduck-ai","client_secret":"%s","discovery":"http://%s/.well-known/openid-configuration","scope":"openid","ssl_verify":false,"timeout":10,"bearer_only":true,"use_jwks":true,"token_signing_alg_values_expected":"RS256","set_access_token_header":true,"access_token_in_authorization_header":true,"set_id_token_header":false,"set_userinfo_header":false,"jwk_expires_in":3600},"limit-count":{"count":120,"time_window":60,"key":"$consumer_name $uri","key_type":"var_combination","rejected_code":429,"rejected_msg":"ai gateway quota exceeded"},"limit-req":{"rate":20,"burst":10,"key":"$consumer_name $uri","key_type":"var_combination","rejected_code":429,"rejected_msg":"ai gateway burst limited","nodelay":true},"opentelemetry":{"sampler":{"name":"always_on"}},"proxy-rewrite":{"headers":{"set":{"X-Auth-Provider":"apisix-oidc","X-Request-Id":"$request_id","X-Trace-Id":"$opentelemetry_trace_id","traceparent":"$opentelemetry_context_traceparent","X-User-Id":"$consumer_name","X-Session-Id":"$http_x_session_id"}}}},"upstream":{"type":"roundrobin","nodes":{"%s":1}}}' "$URI" "$JWT_SECRET" "$AUTH_SERVICE" "$AI_SERVICE")"
               done
 
               # ── Southbound gRPC 治理路由（供 koduck-ai 访问 memory/tool/llm） ──
@@ -258,10 +265,16 @@ spec:
               upsert_resource "upstreams" "ai-llm-stream-grpc" "$(printf '{"name":"ai-llm-stream-grpc","type":"roundrobin","scheme":"grpc","retries":1,"timeout":{"connect":1,"send":5,"read":310},"keepalive_pool":{"size":256,"idle_timeout":60000,"requests":1000},"checks":{"passive":{"type":"tcp","healthy":{"successes":1},"unhealthy":{"tcp_failures":2,"timeouts":2}}},"nodes":{"%s":1}}' "$LLM_GRPC_SERVICE")"
 
               echo "Registering gRPC routes for memory/tool/llm"
-              upsert_resource "routes" "ai-memory-grpc-route" '{"uri":"/koduck.memory.v1.MemoryService/*","priority":200,"upstream_id":"ai-memory-grpc"}'
-              upsert_resource "routes" "ai-tool-grpc-route" '{"uri":"/koduck.tool.v1.ToolService/*","priority":200,"upstream_id":"ai-tool-grpc"}'
-              upsert_resource "routes" "ai-llm-stream-grpc-route" '{"uri":"/koduck.llm.v1.LlmService/StreamGenerate","priority":210,"upstream_id":"ai-llm-stream-grpc"}'
-              upsert_resource "routes" "ai-llm-grpc-route" '{"uri":"/koduck.llm.v1.LlmService/*","priority":200,"upstream_id":"ai-llm-grpc"}'
+              upsert_resource "routes" "ai-memory-grpc-route" '{"uri":"/koduck.memory.v1.MemoryService/*","priority":200,"plugins":{"limit-count":{"count":600,"time_window":60,"key":"$uri","key_type":"var","rejected_code":429,"rejected_msg":"ai memory grpc quota exceeded"},"limit-req":{"rate":120,"burst":60,"key":"$uri","key_type":"var","rejected_code":429,"rejected_msg":"ai memory grpc burst limited","nodelay":true},"opentelemetry":{"sampler":{"name":"always_on"}},"proxy-rewrite":{"headers":{"set":{"X-Request-Id":"$http_x_request_id","X-Trace-Id":"$opentelemetry_trace_id","traceparent":"$opentelemetry_context_traceparent","X-Session-Id":"$http_x_session_id","X-User-Id":"$http_x_user_id"}}}},"upstream_id":"ai-memory-grpc"}'
+              upsert_resource "routes" "ai-tool-grpc-route" '{"uri":"/koduck.tool.v1.ToolService/*","priority":200,"plugins":{"limit-count":{"count":600,"time_window":60,"key":"$uri","key_type":"var","rejected_code":429,"rejected_msg":"ai tool grpc quota exceeded"},"limit-req":{"rate":120,"burst":60,"key":"$uri","key_type":"var","rejected_code":429,"rejected_msg":"ai tool grpc burst limited","nodelay":true},"opentelemetry":{"sampler":{"name":"always_on"}},"proxy-rewrite":{"headers":{"set":{"X-Request-Id":"$http_x_request_id","X-Trace-Id":"$opentelemetry_trace_id","traceparent":"$opentelemetry_context_traceparent","X-Session-Id":"$http_x_session_id","X-User-Id":"$http_x_user_id"}}}},"upstream_id":"ai-tool-grpc"}'
+              upsert_resource "routes" "ai-llm-stream-grpc-route" '{"uri":"/koduck.llm.v1.LlmService/StreamGenerate","priority":210,"plugins":{"limit-count":{"count":240,"time_window":60,"key":"$uri","key_type":"var","rejected_code":429,"rejected_msg":"ai llm stream grpc quota exceeded"},"limit-req":{"rate":40,"burst":20,"key":"$uri","key_type":"var","rejected_code":429,"rejected_msg":"ai llm stream grpc burst limited","nodelay":true},"opentelemetry":{"sampler":{"name":"always_on"}},"proxy-rewrite":{"headers":{"set":{"X-Request-Id":"$http_x_request_id","X-Trace-Id":"$opentelemetry_trace_id","traceparent":"$opentelemetry_context_traceparent","X-Session-Id":"$http_x_session_id","X-User-Id":"$http_x_user_id"}}}},"upstream_id":"ai-llm-stream-grpc"}'
+              upsert_resource "routes" "ai-llm-grpc-route" '{"uri":"/koduck.llm.v1.LlmService/*","priority":200,"plugins":{"limit-count":{"count":600,"time_window":60,"key":"$uri","key_type":"var","rejected_code":429,"rejected_msg":"ai llm grpc quota exceeded"},"limit-req":{"rate":120,"burst":60,"key":"$uri","key_type":"var","rejected_code":429,"rejected_msg":"ai llm grpc burst limited","nodelay":true},"opentelemetry":{"sampler":{"name":"always_on"}},"proxy-rewrite":{"headers":{"set":{"X-Request-Id":"$http_x_request_id","X-Trace-Id":"$opentelemetry_trace_id","traceparent":"$opentelemetry_context_traceparent","X-Session-Id":"$http_x_session_id","X-User-Id":"$http_x_user_id"}}}},"upstream_id":"ai-llm-grpc"}'
+
+              if [ "${ENABLE_AI_GRPC_TRANSCODE}" = "true" ]; then
+                echo "grpc-transcode migration window enabled; route definitions should be added with explicit proto assets."
+              else
+                echo "grpc-transcode migration window disabled; no transcode routes registered."
+              fi
 
               # ── WebSocket / Frontend 路由 ──
 

--- a/k8s/overlays/dev/apisix.yaml
+++ b/k8s/overlays/dev/apisix.yaml
@@ -202,6 +202,12 @@ data:
     apisix:
       node_listen: 9080
       enable_ipv6: false
+    nginx_config:
+      http:
+        enable_access_log: true
+        access_log: /dev/stdout
+        access_log_format: '{"time":"$time_iso8601","route_id":"$route_id","service_id":"$service_id","upstream_addr":"$upstream_addr","status":"$status","request_id":"$request_id","session_id":"$http_x_session_id","user_id":"$consumer_name","trace_id":"$opentelemetry_trace_id","traceparent":"$opentelemetry_context_traceparent","uri":"$uri","method":"$request_method"}'
+        access_log_format_escape: json
     deployment:
       role: traditional
       role_traditional:
@@ -219,6 +225,9 @@ data:
           - "http://dev-apisix-etcd:2379"
         prefix: "/apisix"
         timeout: 30
+    plugin_attr:
+      opentelemetry:
+        set_ngx_var: true
     plugins:
       - cors
       - jwt-auth
@@ -226,5 +235,7 @@ data:
       - limit-count
       - limit-req
       - openid-connect
+      - opentelemetry
       - prometheus
       - proxy-rewrite
+      - grpc-transcode

--- a/k8s/overlays/prod/apisix-route-init.yaml
+++ b/k8s/overlays/prod/apisix-route-init.yaml
@@ -38,14 +38,22 @@ spec:
               value: "prod-apisix-gateway"
             - name: BACKEND_SERVICE
               value: "backend:8080"
+            - name: AUTH_SERVICE
+              value: "backend:8080"
             - name: FRONTEND_SERVICE
               value: "prod-koduck-frontend:80"
+            - name: AI_SERVICE
+              value: "prod-koduck-ai:8083"
             - name: MEMORY_GRPC_SERVICE
               value: "prod-memory-service:50051"
             - name: TOOL_GRPC_SERVICE
               value: "prod-tool-service:50051"
             - name: LLM_GRPC_SERVICE
               value: "prod-koduck-agent:50054"
+            - name: APISIX_SERVICE_NAME
+              value: "koduck-apisix-prod"
+            - name: ENABLE_AI_GRPC_TRANSCODE
+              value: "false"
           command:
             - /bin/sh
             - -ec
@@ -176,6 +184,9 @@ spec:
                 sleep 2
               done
 
+              echo "Registering opentelemetry plugin metadata"
+              upsert_resource "plugin_metadata" "opentelemetry" "$(printf '{"trace_id_source":"random","set_ngx_var":true,"resource":{"service.name":"%s"},"additional_attributes":["route_id","service_id","upstream_addr","status"],"additional_header_prefix_attributes":["x-request-id","x-session-id","x-user-id"]}' "$APISIX_SERVICE_NAME")"
+
               echo "Registering JWT consumer: koduck_user"
               curl -fsS -X PUT "${ADMIN}/consumers/koduck_user" \
                 -H "$KEY" -H 'Content-Type: application/json' \
@@ -191,6 +202,11 @@ spec:
                 -H "$KEY" -H 'Content-Type: application/json' \
                 -d "$(printf '{"uri":"/api/*","plugins":{"jwt-auth":{}},"upstream":{"type":"roundrobin","nodes":{"%s":1}}}' "$BACKEND_SERVICE")"
 
+              echo "Registering AI route: /api/v1/ai/* -> koduck-ai (openid-connect + governance baseline)"
+              curl -fsS -X PUT "${ADMIN}/routes/api-ai" \
+                -H "$KEY" -H 'Content-Type: application/json' \
+                -d "$(printf '{"uri":"/api/v1/ai/*","priority":10,"plugins":{"openid-connect":{"client_id":"koduck-ai","client_secret":"%s","discovery":"http://%s/.well-known/openid-configuration","scope":"openid","ssl_verify":false,"timeout":10,"bearer_only":true,"use_jwks":true,"token_signing_alg_values_expected":"RS256","set_access_token_header":true,"access_token_in_authorization_header":true,"set_id_token_header":false,"set_userinfo_header":false,"jwk_expires_in":3600},"limit-count":{"count":120,"time_window":60,"key":"$consumer_name $uri","key_type":"var_combination","rejected_code":429,"rejected_msg":"ai gateway quota exceeded"},"limit-req":{"rate":20,"burst":10,"key":"$consumer_name $uri","key_type":"var_combination","rejected_code":429,"rejected_msg":"ai gateway burst limited","nodelay":true},"opentelemetry":{"sampler":{"name":"always_on"}},"proxy-rewrite":{"headers":{"set":{"X-Auth-Provider":"apisix-oidc","X-Request-Id":"$request_id","X-Trace-Id":"$opentelemetry_trace_id","traceparent":"$opentelemetry_context_traceparent","X-User-Id":"$consumer_name","X-Session-Id":"$http_x_session_id"}}}},"upstream":{"type":"roundrobin","nodes":{"%s":1}}}' "$JWT_SECRET" "$AUTH_SERVICE" "$AI_SERVICE")"
+
               echo "Registering gRPC upstreams for memory/tool/llm"
               upsert_resource "upstreams" "ai-memory-grpc" "$(printf '{"name":"ai-memory-grpc","type":"roundrobin","scheme":"grpc","retries":1,"timeout":{"connect":1,"send":5,"read":65},"keepalive_pool":{"size":256,"idle_timeout":60000,"requests":1000},"checks":{"passive":{"type":"tcp","healthy":{"successes":1},"unhealthy":{"tcp_failures":2,"timeouts":2}}},"nodes":{"%s":1}}' "$MEMORY_GRPC_SERVICE")"
               upsert_resource "upstreams" "ai-tool-grpc" "$(printf '{"name":"ai-tool-grpc","type":"roundrobin","scheme":"grpc","retries":1,"timeout":{"connect":1,"send":5,"read":65},"keepalive_pool":{"size":256,"idle_timeout":60000,"requests":1000},"checks":{"passive":{"type":"tcp","healthy":{"successes":1},"unhealthy":{"tcp_failures":2,"timeouts":2}}},"nodes":{"%s":1}}' "$TOOL_GRPC_SERVICE")"
@@ -198,10 +214,16 @@ spec:
               upsert_resource "upstreams" "ai-llm-stream-grpc" "$(printf '{"name":"ai-llm-stream-grpc","type":"roundrobin","scheme":"grpc","retries":1,"timeout":{"connect":1,"send":5,"read":310},"keepalive_pool":{"size":256,"idle_timeout":60000,"requests":1000},"checks":{"passive":{"type":"tcp","healthy":{"successes":1},"unhealthy":{"tcp_failures":2,"timeouts":2}}},"nodes":{"%s":1}}' "$LLM_GRPC_SERVICE")"
 
               echo "Registering gRPC routes for memory/tool/llm"
-              upsert_resource "routes" "ai-memory-grpc-route" '{"uri":"/koduck.memory.v1.MemoryService/*","priority":200,"upstream_id":"ai-memory-grpc"}'
-              upsert_resource "routes" "ai-tool-grpc-route" '{"uri":"/koduck.tool.v1.ToolService/*","priority":200,"upstream_id":"ai-tool-grpc"}'
-              upsert_resource "routes" "ai-llm-stream-grpc-route" '{"uri":"/koduck.llm.v1.LlmService/StreamGenerate","priority":210,"upstream_id":"ai-llm-stream-grpc"}'
-              upsert_resource "routes" "ai-llm-grpc-route" '{"uri":"/koduck.llm.v1.LlmService/*","priority":200,"upstream_id":"ai-llm-grpc"}'
+              upsert_resource "routes" "ai-memory-grpc-route" '{"uri":"/koduck.memory.v1.MemoryService/*","priority":200,"plugins":{"limit-count":{"count":600,"time_window":60,"key":"$uri","key_type":"var","rejected_code":429,"rejected_msg":"ai memory grpc quota exceeded"},"limit-req":{"rate":120,"burst":60,"key":"$uri","key_type":"var","rejected_code":429,"rejected_msg":"ai memory grpc burst limited","nodelay":true},"opentelemetry":{"sampler":{"name":"always_on"}},"proxy-rewrite":{"headers":{"set":{"X-Request-Id":"$http_x_request_id","X-Trace-Id":"$opentelemetry_trace_id","traceparent":"$opentelemetry_context_traceparent","X-Session-Id":"$http_x_session_id","X-User-Id":"$http_x_user_id"}}}},"upstream_id":"ai-memory-grpc"}'
+              upsert_resource "routes" "ai-tool-grpc-route" '{"uri":"/koduck.tool.v1.ToolService/*","priority":200,"plugins":{"limit-count":{"count":600,"time_window":60,"key":"$uri","key_type":"var","rejected_code":429,"rejected_msg":"ai tool grpc quota exceeded"},"limit-req":{"rate":120,"burst":60,"key":"$uri","key_type":"var","rejected_code":429,"rejected_msg":"ai tool grpc burst limited","nodelay":true},"opentelemetry":{"sampler":{"name":"always_on"}},"proxy-rewrite":{"headers":{"set":{"X-Request-Id":"$http_x_request_id","X-Trace-Id":"$opentelemetry_trace_id","traceparent":"$opentelemetry_context_traceparent","X-Session-Id":"$http_x_session_id","X-User-Id":"$http_x_user_id"}}}},"upstream_id":"ai-tool-grpc"}'
+              upsert_resource "routes" "ai-llm-stream-grpc-route" '{"uri":"/koduck.llm.v1.LlmService/StreamGenerate","priority":210,"plugins":{"limit-count":{"count":240,"time_window":60,"key":"$uri","key_type":"var","rejected_code":429,"rejected_msg":"ai llm stream grpc quota exceeded"},"limit-req":{"rate":40,"burst":20,"key":"$uri","key_type":"var","rejected_code":429,"rejected_msg":"ai llm stream grpc burst limited","nodelay":true},"opentelemetry":{"sampler":{"name":"always_on"}},"proxy-rewrite":{"headers":{"set":{"X-Request-Id":"$http_x_request_id","X-Trace-Id":"$opentelemetry_trace_id","traceparent":"$opentelemetry_context_traceparent","X-Session-Id":"$http_x_session_id","X-User-Id":"$http_x_user_id"}}}},"upstream_id":"ai-llm-stream-grpc"}'
+              upsert_resource "routes" "ai-llm-grpc-route" '{"uri":"/koduck.llm.v1.LlmService/*","priority":200,"plugins":{"limit-count":{"count":600,"time_window":60,"key":"$uri","key_type":"var","rejected_code":429,"rejected_msg":"ai llm grpc quota exceeded"},"limit-req":{"rate":120,"burst":60,"key":"$uri","key_type":"var","rejected_code":429,"rejected_msg":"ai llm grpc burst limited","nodelay":true},"opentelemetry":{"sampler":{"name":"always_on"}},"proxy-rewrite":{"headers":{"set":{"X-Request-Id":"$http_x_request_id","X-Trace-Id":"$opentelemetry_trace_id","traceparent":"$opentelemetry_context_traceparent","X-Session-Id":"$http_x_session_id","X-User-Id":"$http_x_user_id"}}}},"upstream_id":"ai-llm-grpc"}'
+
+              if [ "${ENABLE_AI_GRPC_TRANSCODE}" = "true" ]; then
+                echo "grpc-transcode migration window enabled; route definitions should be added with explicit proto assets."
+              else
+                echo "grpc-transcode migration window disabled; no transcode routes registered."
+              fi
 
               echo "Registering WebSocket route: /ws/* -> backend"
               curl -fsS -X PUT "${ADMIN}/routes/ws" \

--- a/k8s/overlays/prod/apisix.yaml
+++ b/k8s/overlays/prod/apisix.yaml
@@ -192,6 +192,12 @@ data:
     apisix:
       node_listen: 9080
       enable_ipv6: false
+    nginx_config:
+      http:
+        enable_access_log: true
+        access_log: /dev/stdout
+        access_log_format: '{"time":"$time_iso8601","route_id":"$route_id","service_id":"$service_id","upstream_addr":"$upstream_addr","status":"$status","request_id":"$request_id","session_id":"$http_x_session_id","user_id":"$consumer_name","trace_id":"$opentelemetry_trace_id","traceparent":"$opentelemetry_context_traceparent","uri":"$uri","method":"$request_method"}'
+        access_log_format_escape: json
     deployment:
       role: traditional
       role_traditional:
@@ -209,6 +215,9 @@ data:
           - "http://prod-apisix-etcd:2379"
         prefix: "/apisix"
         timeout: 30
+    plugin_attr:
+      opentelemetry:
+        set_ngx_var: true
     plugins:
       - cors
       - jwt-auth
@@ -216,5 +225,7 @@ data:
       - limit-count
       - limit-req
       - openid-connect
+      - opentelemetry
       - prometheus
       - proxy-rewrite
+      - grpc-transcode

--- a/koduck-ai/docs/adr/0014-apisix-gateway-plugin-baseline-for-ai-routes.md
+++ b/koduck-ai/docs/adr/0014-apisix-gateway-plugin-baseline-for-ai-routes.md
@@ -1,0 +1,113 @@
+# ADR-0014: 为 koduck-ai 建立 APISIX 网关插件基线
+
+- Status: Accepted
+- Date: 2026-04-11
+- Issue: #746
+
+## Context
+
+根据 `docs/design/koduckai-rust-server/ai-decoupled-architecture.md` 第 16.2 节：
+
+1. `koduck-ai` 的网关入口需要统一接入 `limit-req / limit-count / prometheus / opentelemetry / access-log`。
+2. 网关日志与 trace 需要至少收敛 `request_id / session_id / user_id / trace_id` 这些统一字段。
+3. `grpc-transcode` 仅作为迁移窗口能力存在，默认应可关闭，避免长期保留兼容层。
+
+在 Task 6.2 开始前：
+
+- APISIX 仅在插件清单里启用了 `limit-req / limit-count / prometheus`，但没有在 AI 路由或 southbound gRPC 路由上真正绑定限流与 tracing 基线。
+- APISIX ConfigMap 没有统一 access log 格式，无法稳定输出 `request_id / session_id / user_id / trace_id`。
+- `opentelemetry` 与 `grpc-transcode` 还未纳入网关基础能力清单。
+
+## Decision
+
+本次将 Task 6.2 的范围收敛为“网关基线能力可用且默认安全”，而不是一次性引入完整迁移期兼容路线。
+
+### 1. 在 APISIX ConfigMap 中启用插件基线
+
+在 dev/prod 的 APISIX ConfigMap 中：
+
+- 启用 `opentelemetry`
+- 启用 `grpc-transcode`
+- 保持 `limit-req / limit-count / prometheus / proxy-rewrite` 可用
+- 通过 `nginx_config.http.access_log_*` 把 access log 输出到 stdout，并统一 JSON 字段
+
+`access-log` 这里采用 APISIX/Nginx 原生 access log，而不是额外的 logger sink 插件：
+
+- 运维侧更容易直接从容器 stdout 收集
+- 不会为本次任务额外引入外部日志后端依赖
+
+### 2. 在 route-init 中为 AI 入口与 southbound gRPC 路由绑定治理插件
+
+对 northbound AI HTTP 路由和 southbound gRPC 路由统一挂载：
+
+- `limit-count`
+- `limit-req`
+- `opentelemetry`
+- `proxy-rewrite`
+
+其中：
+
+- northbound AI HTTP 路由按 `$consumer_name + $uri` 做限流分组
+- southbound gRPC 路由按 `$uri` 做限流分组
+- `proxy-rewrite` 负责补齐并透传：
+  - `X-Request-Id`
+  - `X-Trace-Id`
+  - `traceparent`
+  - `X-Session-Id`
+  - `X-User-Id`
+
+这样 APISIX access log、trace span 和上游服务日志可以围绕同一组标识串联。
+
+### 3. 用 plugin metadata 统一 opentelemetry 公共元数据
+
+通过 `plugin_metadata/opentelemetry` 统一设置：
+
+- `trace_id_source=random`
+- `set_ngx_var=true`
+- `service.name`
+- 公共 attribute/header 透传项
+
+这样 route 级只需要保留最小 `sampler` 配置，而统一 trace 变量可直接复用到 access log 和 `proxy-rewrite`。
+
+### 4. `grpc-transcode` 默认关闭，仅保留迁移期开关
+
+本次将 `grpc-transcode` 纳入 APISIX 插件清单，但 route-init 默认不创建 transcode 路由：
+
+- 通过 `ENABLE_AI_GRPC_TRANSCODE=false` 明确默认关闭
+- 迁移窗口真正到来时，再基于 proto asset 和特定 URI 增量开启 transcode 路由
+
+这满足“仅迁移窗口可选开启”的要求，同时避免在当前阶段引入未使用的兼容路由。
+
+## Consequences
+
+### 正向影响
+
+1. **入口限流真正落地**：不再只是插件“可用”，而是 AI 路由和 gRPC 路由已经绑定基线策略。
+2. **trace 与 access log 可对齐**：APISIX 会生成/维护统一 trace 标识，并写入日志与上游请求头。
+3. **迁移开关边界清晰**：`grpc-transcode` 变成显式可选能力，而不是默认常开。
+
+### 代价与风险
+
+1. **session_id / user_id 仍受请求形态限制**：当前 northbound AI 请求的 `session_id` 主要存在于 body 中，网关 access log 只能稳定记录 header 层字段，未提供 header 时会为空。
+2. **trace 目前以网关变量为中心**：当前仓库尚未引入独立 OTEL collector 基础设施，本次先确保 trace 标识可生成、透传和串联。
+3. **prod AI/auth 资源仍依赖现有占位服务**：本次重点是网关 IaC，不扩展 prod overlay 的应用编排范围。
+
+### 兼容性影响
+
+- **向前兼容**：现有 northbound HTTP 路由与 southbound gRPC 路由 URI 不变。
+- **行为变化**：超出网关限流阈值的请求会返回 `429`，并带统一拒绝消息。
+- **迁移控制更严格**：`grpc-transcode` 只有在显式开关打开时才允许进入迁移窗口。
+
+## Alternatives Considered
+
+### 1. 只把插件加入 APISIX `plugins` 列表，不在 route-init 绑定
+
+- **拒绝理由**：这只能说明插件“可加载”，不能满足“网关侧限流生效”和“指标与 trace 可串起全链路”的验收目标。
+
+### 2. 使用 logger 类插件替代 access log
+
+- **拒绝理由**：当前仓库没有配套的外部日志 sink 设施。直接使用 stdout access log 更贴合现有部署方式。
+
+### 3. 立即创建 `grpc-transcode` 兼容路由
+
+- **拒绝理由**：当前仓库尚未准备对应 proto asset 与迁移路径，直接创建只会引入未使用的兼容面。


### PR DESCRIPTION
## Summary
- enable APISIX gateway plugin baseline for AI ingress and southbound gRPC routes
- add access log and opentelemetry baseline config plus optional grpc-transcode switch
- add ADR and mark Task 6.2 complete

## Verification
- kubectl apply --dry-run=client -f k8s/overlays/dev/apisix.yaml
- kubectl apply --dry-run=client -f k8s/overlays/prod/apisix.yaml
- kubectl apply --dry-run=client -f k8s/overlays/dev/apisix-route-init.yaml
- kubectl apply --dry-run=client -f k8s/overlays/prod/apisix-route-init.yaml
- docker build -t koduck-ai:dev ./koduck-ai

Closes #746