### PR TITLE
feat(koduck-ai): add llm provider abstraction

### DIFF
--- a/koduck-ai/docs/adr/0015-unified-llm-provider-trait-with-adapter-compat.md
+++ b/koduck-ai/docs/adr/0015-unified-llm-provider-trait-with-adapter-compat.md
@@ -1,0 +1,109 @@
+# ADR-0015: 为 koduck-ai 引入统一 LLM Provider Trait，并保留 adapter 兼容实现
+
+- Status: Accepted
+- Date: 2026-04-11
+- Issue: #748
+
+## Context
+
+根据 `koduck-ai/docs/design/ai-decoupled-architecture.md` 第 6.5 节和
+`koduck-ai/docs/implementation/koduck-ai-rust-grpc-tasks.md` Task 3.3.1：
+
+1. `koduck-ai` 需要把上层编排与具体 LLM 厂商协议解耦。
+2. 上层 orchestrator 只能依赖统一抽象，不能直接感知 gRPC contract 或厂商 HTTP/JSON 细节。
+3. 迁移期仍需保留现有 `llm.proto` / `LlmServiceClient` 兼容路径，为后续 `direct | adapter`
+   模式切换打基础。
+
+在本次任务开始前，现状存在两个问题：
+
+- `src/api/mod.rs` 直接构造 `LlmServiceClient`、`GenerateRequest`、`StreamGenerateEvent`，
+  上层已经耦合到具体 gRPC 契约。
+- chat 与 stream 的主链路拿到的是下游 proto 类型，而不是统一的 LLM 领域对象。
+
+## Decision
+
+本次先引入一层最小统一抽象，让现有 gRPC adapter 路径成为 `LlmProvider` 的一个实现，
+再在后续任务中继续接入 provider-native HTTP。
+
+### 1. 定义统一 trait 与领域类型
+
+新增：
+
+- `src/llm/provider.rs`
+- `src/llm/types.rs`
+
+核心抽象：
+
+- `LlmProvider`
+  - `generate`
+  - `stream_generate`
+  - `list_models`
+  - `count_tokens`
+- 统一领域类型：
+  - `RequestContext`
+  - `GenerateRequest`
+  - `GenerateResponse`
+  - `CountTokensRequest/Response`
+  - `ModelInfo`
+  - `StreamEvent`
+  - `TokenUsage`
+
+这些类型只表达编排层关心的稳定语义，不暴露 provider-specific JSON 字段。
+
+### 2. 用兼容实现包住现有 gRPC adapter
+
+新增 `src/llm/compat.rs`，提供 `AdapterLlmProvider`：
+
+- 输入统一领域类型
+- 内部转换为现有 `llm.proto` 请求
+- 输出统一领域类型
+- 把流式 gRPC 事件映射为统一 `StreamEvent`
+
+这样现有链路仍然通过 gRPC adapter 工作，但上层已经不再直接依赖 `LlmServiceClient`。
+
+### 3. 在 AppState 中注入 trait object
+
+`AppState` 新增：
+
+- `llm_provider: Arc<dyn LlmProvider>`
+
+当前默认注入 `AdapterLlmProvider`。后续 direct provider router 落地时，只需要替换注入实现，
+不需要再修改 chat/stream 主链路。
+
+### 4. 将 API 主链路切到统一抽象
+
+`src/api/mod.rs` 中：
+
+- chat 非流式路径改为调用 `state.llm_provider.generate`
+- stream 路径改为调用 `state.llm_provider.stream_generate`
+- 上层只处理统一 `GenerateResponse` 与 `StreamEvent`
+
+这保证了 orchestrator/API 层不再接触 provider-specific gRPC 类型。
+
+## Consequences
+
+### 正向影响
+
+1. **上层完成解耦**：编排层已经不依赖具体 gRPC proto 类型。
+2. **为 direct 模式铺路**：后续接入 OpenAI/MiniMax/DeepSeek 的 HTTP adapter 时，不必再改上层接口。
+3. **兼容路径保留**：当前功能行为仍然沿用现有 LLM adapter gRPC 链路，风险较低。
+
+### 代价与风险
+
+1. **当前仍只有 adapter 实现**：`direct` 模式的真实 provider-native HTTP 适配留到后续任务完成。
+2. **领域类型与 proto 暂时接近**：这是为了平滑迁移，后续 provider-native HTTP 落地后再继续校准语义边界。
+
+### 兼容性影响
+
+- **向后兼容**：现有 northbound chat/stream 行为不变。
+- **内部接口变化**：`src/api/mod.rs` 不再直接使用 `LlmServiceClient`，统一改为 trait object。
+
+## Alternatives Considered
+
+### 1. 继续直接在 API 层使用 `LlmServiceClient`
+
+- **拒绝理由**：会让后续 direct provider-native HTTP 接入时再次重写主链路，重复成本高。
+
+### 2. 直接在本任务引入完整 provider-native HTTP router
+
+- **拒绝理由**：这会把 Task 3.3.2-3.3.5 一起做掉，超出 Task 3.3.1 的边界。

--- a/koduck-ai/docs/design/ai-decoupled-architecture.md
+++ b/koduck-ai/docs/design/ai-decoupled-architecture.md
@@ -268,44 +268,221 @@ V2 的核心结论如下：
 - 新实现通过 `capabilities + contract` 兼容性检查。
 - 统一错误与指标字段不变，灰度和回滚路径可用。
 
-### 6.5 LLM Contract（provider-agnostic）
+### 6.5 LLM Provider Adapter（Rust, provider-native HTTP）
 
-`koduck-ai` 对模型调用采用统一 LLM 契约，屏蔽厂商差异。对内以 gRPC 契约表达；对外由适配层转换为各厂商原生 HTTP API。
+`koduck-ai` 对模型调用采用统一的 Rust Provider Adapter 抽象，屏蔽厂商差异，
+并默认通过 provider-native HTTP 直接访问外部 LLM Provider。
 
-推荐最小 RPC 集合：
+目标态：
 
-- `rpc Generate(GenerateRequest) returns (GenerateResponse)`
-- `rpc StreamGenerate(GenerateRequest) returns (stream StreamGenerateEvent)`
-- `rpc CountTokens(CountTokensRequest) returns (CountTokensResponse)`
-- `rpc ListModels(ListModelsRequest) returns (ListModelsResponse)`（可选）
+- `koduck-ai -> provider-native HTTP -> {MiniMax / OpenAI / DeepSeek}`
 
-`GenerateRequest` 关键字段建议：
+迁移期可选：
 
+- `koduck-ai -> LLM Adapter(gRPC) -> provider-native HTTP -> LLM Provider`
+
+结论：
+
+- `memory/tool` 是长期 southbound gRPC 契约。
+- `llm.proto` 仅作为迁移期兼容契约保留，不是目标态主调用面。
+- `koduck-ai` 默认不依赖第三方 OpenAI SDK；统一使用 Rust HTTP 客户端实现 provider adapter。
+
+#### 6.5.1 目录与模块建议
+
+推荐在 `koduck-ai/src/llm/` 下按以下结构组织：
+
+```text
+src/llm/
+  mod.rs
+  provider.rs       # Provider trait 与统一抽象
+  router.rs         # provider 选择、mode 切换、模型路由
+  types.rs          # 统一请求/响应/usage/event 类型
+  http.rs           # reqwest client、公共 header、SSE/stream 解析工具
+  errors.rs         # provider HTTP/body 到统一错误语义的映射辅助
+  openai.rs         # OpenAI provider-native HTTP 适配
+  deepseek.rs       # DeepSeek provider-native HTTP 适配
+  minimax.rs        # MiniMax provider-native HTTP 适配
+  compat.rs         # 迁移期 LLM Adapter gRPC bridge（可选）
+```
+
+原则：
+
+- Provider 差异收敛在 `src/llm/` 内，不向 orchestrator 泄漏厂商细节。
+- 公共重试、header、stream 解析逻辑优先复用，不在各 provider 文件重复实现。
+- 兼容模式与目标态直连模式使用同一套上层抽象。
+
+#### 6.5.2 统一 Provider Trait
+
+推荐最小抽象：
+
+```rust
+#[async_trait]
+pub trait LlmProvider: Send + Sync {
+    async fn generate(&self, req: GenerateRequest) -> Result<GenerateResponse, AppError>;
+    async fn stream_generate(
+        &self,
+        req: GenerateRequest,
+    ) -> Result<ProviderEventStream, AppError>;
+    async fn list_models(&self) -> Result<Vec<ModelInfo>, AppError>;
+    async fn count_tokens(&self, req: CountTokensRequest) -> Result<CountTokensResponse, AppError>;
+}
+```
+
+说明：
+
+- `generate` / `stream_generate` 为主链路必需能力。
+- `list_models` 建议实现，用于能力展示、启动探活和运营排查。
+- `count_tokens` 优先使用厂商原生能力；若厂商未提供，允许返回 `UNIMPLEMENTED` 或采用本地估算。
+- 上层 orchestrator 只依赖 trait，不直接依赖 `reqwest`、HTTP 路径或厂商 JSON 结构。
+
+#### 6.5.3 统一请求与响应语义
+
+`GenerateRequest` 建议字段：
+
+- `provider`
 - `model`
-- `messages[]`（role/content）
-- `temperature`、`top_p`、`max_tokens`
+- `messages[]`（`role/content/name/metadata`）
+- `temperature`
+- `top_p`
+- `max_tokens`
 - `tools[]`（可选）
 - `response_format`（可选）
-- `request_id`、`trace_id`、`deadline_ms`
+- `request_id`
+- `session_id`
+- `trace_id`
+- `deadline_ms`
 
-`StreamGenerateEvent` 关键字段建议：
+`GenerateResponse` 建议字段：
+
+- `message`
+- `finish_reason`
+- `usage`
+- `provider`
+- `model`
+
+`ProviderEventStream` 建议事件：
 
 - `event_id`
 - `sequence_num`
 - `delta`
-- `finish_reason`（结束事件）
-- `usage`（结束事件可选）
+- `finish_reason`
+- `usage`
+- `provider`
+- `model`
+
+要求：
+
+- sequence 由 `koduck-ai` 保证单调递增，不依赖厂商原始分片序号。
+- usage 在结束事件中至少出现一次；中间增量事件可不携带 usage。
+- 上层 SSE 层不感知 provider 原始分片结构，只消费统一事件。
+
+#### 6.5.4 Router 与 Mode 切换
+
+推荐同时支持两种运行模式：
+
+- `direct`：目标态，直接访问 provider-native HTTP
+- `adapter`：迁移期兼容模式，调用 `llm.proto` / `LlmServiceClient`
+
+`router.rs` 负责：
+
+- 按 `request.provider` 或 `default_provider` 选择具体 provider
+- 按 `llm.mode` 决定走 `direct` 还是 `adapter`
+- 处理模型别名、默认模型和 provider fallback
+
+约束：
+
+- `direct` 是默认值。
+- `adapter` 仅作为迁移、回滚和灰度开关，不得继续扩展为目标态主路径。
+- provider fallback 必须显式配置，不允许在错误时静默切换到其他厂商。
+
+#### 6.5.5 HTTP 客户端与协议实现
+
+统一采用 `reqwest` 实现，不依赖第三方 OpenAI SDK。
+
+原因：
+
+- `MiniMax` / `DeepSeek` 提供 OpenAI-compatible HTTP 接口，可直接复用统一请求构造逻辑。
+- `OpenAI` 官方接口同样可由 `reqwest` 覆盖，无需额外 SDK 依赖。
+- 便于统一超时、trace header、重试预算、错误体解析和流式事件处理。
+
+公共 HTTP 基线建议：
+
+- 统一 `reqwest::Client` 复用连接池
+- TLS 使用 `rustls`
+- 统一 Header：
+  - `Authorization: Bearer <api_key>`
+  - `Content-Type: application/json`
+  - `X-Request-Id`（如厂商允许）
+  - `traceparent`（如厂商允许）
+- 统一本地 timeout budget，严格服从 `deadline_ms`
+
+stream 建议：
+
+- 优先按 SSE / chunked 文本流解析
+- provider adapter 负责把原始 chunk 转换成统一 `delta` 事件
+- 对 malformed chunk、提前 EOF、无 finish 事件等异常场景做保护性收敛
+
+#### 6.5.6 Provider 差异处理
+
+首批支持 provider：
+
+- `minimax`
+- `openai`
+- `deepseek`
+
+差异收敛原则：
+
+- 公共字段优先按 OpenAI-compatible schema 组织
+- 厂商特有字段（如 MiniMax extra body）只在各自 adapter 内处理
+- 工具调用、响应格式、reasoning 字段等高级能力按 provider capability 显式声明，不做隐式假设
+
+模型配置建议：
+
+- `minimax.default_model`
+- `openai.default_model`
+- `deepseek.default_model`
+- `base_url` / `api_key` 按 provider 独立配置
+
+#### 6.5.7 错误映射与重试约束
 
 错误语义约束：
 
 - 适配层必须把厂商错误归一到本设计定义的标准错误码集合。
 - 对 `429` 优先传递 `retry_after_ms`。
 - 超时必须区分“上游超时”与“本地预算耗尽”。
+- 厂商原始错误 body 只进入内部日志，不直接透传给北向 API。
 
-说明：
+重试约束：
 
-- “统一使用 gRPC”适用于内部服务契约与平台内部适配层接口。
-- 外部 LLM 厂商接口仍以其原生 HTTP 协议为准，由适配层负责转换。
+- 是否重试由 `koduck-ai` 的 retry budget 决定，而不是由 provider adapter 自行决定。
+- 仅 `429`、网络瞬断、显式可重试 `5xx` 进入重试白名单。
+- stream 已开始输出后，禁止在 provider adapter 层自动重试同一次生成请求。
+
+#### 6.5.8 能力协商与 `llm.proto` 定位
+
+目标态下，provider-native HTTP 不参与内部 `GetCapabilities` gRPC 协商。
+
+建议：
+
+- `memory/tool` 继续使用 `GetCapabilities`
+- `llm` 在 `direct` 模式下改为本地静态 capability + 启动探活
+- `llm.proto` 仅在 `adapter` 模式下参与 capability 协商
+
+启动探活建议：
+
+- 校验 provider 配置完整性（`api_key/base_url/default_model`）
+- 可选执行 `ListModels` 或轻量 health probe
+- 失败时按配置决定 fail-fast 或降级禁用该 provider
+
+#### 6.5.9 验收标准
+
+满足以下条件即视为 Rust provider adapter 落地完成：
+
+- `koduck-ai` 在不依赖 OpenAI SDK 的情况下可直接调用 `MiniMax/OpenAI/DeepSeek`
+- `generate` 与 `stream_generate` 均可输出统一语义结果
+- provider 切换不影响 orchestrator 代码
+- `direct/adapter` 模式可配置切换，且回滚路径可用
+- 429、5xx、timeout、malformed stream 均可映射到统一错误码
 
 ---
 

--- a/koduck-ai/docs/implementation/koduck-ai-rust-grpc-tasks.md
+++ b/koduck-ai/docs/implementation/koduck-ai-rust-grpc-tasks.md
@@ -174,6 +174,73 @@ cd koduck-ai
 - [ ] 429 能携带 `retry_after_ms`
 - [ ] provider 切换不影响上层编排代码
 
+### Task 3.3.1: 定义 Rust LLM Provider 抽象
+**文件:** `src/llm/provider.rs`, `src/llm/types.rs`
+
+**详细要求:**
+1. 定义统一 `LlmProvider` trait：`generate/stream_generate/list_models/count_tokens`
+2. 定义统一请求/响应/usage/stream event 类型
+3. 约束上层 orchestrator 仅依赖 trait，不感知厂商 HTTP/JSON 差异
+
+**验收标准:**
+- [x] trait 与类型定义能覆盖 chat/stream 主链路
+- [x] 不暴露 provider-specific JSON 结构到 orchestrator
+- [x] 支持 `direct` 与 `adapter` 共用同一套上层抽象
+
+### Task 3.3.2: 构建通用 HTTP 基础设施
+**文件:** `src/llm/http.rs`, `src/llm/errors.rs`
+
+**详细要求:**
+1. 使用 `reqwest` 构建统一 HTTP client，不依赖 OpenAI SDK
+2. 实现公共 header、deadline timeout、body 序列化、stream chunk 解析
+3. 实现厂商 HTTP 状态码与错误 body 到统一错误语义的映射辅助
+
+**验收标准:**
+- [ ] 统一 client 支持连接复用与 rustls
+- [ ] 429/5xx/timeout/EOF 等异常路径可被标准化处理
+- [ ] stream 解析工具可被三个 provider 复用
+
+### Task 3.3.3: 实现首批三个 Provider Adapter
+**文件:** `src/llm/minimax.rs`, `src/llm/openai.rs`, `src/llm/deepseek.rs`
+
+**详细要求:**
+1. 实现 `minimax` provider-native HTTP 适配
+2. 实现 `openai` provider-native HTTP 适配
+3. 实现 `deepseek` provider-native HTTP 适配
+4. 在各自 adapter 内收敛 provider-specific 字段和行为差异
+
+**验收标准:**
+- [ ] 三个 provider 均可完成非流式生成
+- [ ] 三个 provider 均可完成流式增量输出
+- [ ] 厂商差异不泄漏到公共 trait 和 orchestrator
+
+### Task 3.3.4: 实现 Router 与模式切换
+**文件:** `src/llm/router.rs`, `src/config/mod.rs`
+
+**详细要求:**
+1. 引入 `llm.mode = direct | adapter` 配置
+2. 实现按 provider/model/default_provider 选择 adapter 的路由逻辑
+3. `direct` 作为默认模式，`adapter` 仅作迁移兼容与回滚开关
+4. 增加按 provider 独立配置：`api_key/base_url/default_model`
+
+**验收标准:**
+- [ ] `direct` 模式默认可用
+- [ ] `adapter` 模式可回退到现有 `llm.proto` 链路
+- [ ] provider fallback 不会静默发生
+
+### Task 3.3.5: 接入主链路并完成能力探活
+**文件:** `src/api/mod.rs`, `src/llm/router.rs`, `src/clients/capability.rs`
+
+**详细要求:**
+1. 将 chat/stream 主链路改为调用 Rust provider adapter
+2. `memory/tool` 保持 `GetCapabilities` 协商；`llm` 在 `direct` 模式下改为本地静态 capability + 启动探活
+3. `llm.proto` capability 协商仅在 `adapter` 模式启用
+
+**验收标准:**
+- [ ] chat/stream 不再默认依赖 `LlmServiceClient`
+- [ ] `direct` 模式下启动期可校验 provider 配置与可用性
+- [ ] `adapter` 模式下现有兼容链路仍可工作
+
 ---
 
 ## Phase 4: SSE 可靠性与取消语义
@@ -276,12 +343,14 @@ cd koduck-ai
 **交付物:** APISIX route/upstream 配置（IaC）
 
 **详细要求:**
-1. 建立 ai->memory/tool/llm 的 gRPC upstream
-2. 按附录 C 配置 connect/send/read timeout
-3. 配置 keepalive、轻重试、熔断阈值
+1. 建立 ai->memory/tool 的 gRPC upstream
+2. 若启用兼容模式，再建立 ai->llm 的可选 gRPC upstream
+3. 按附录 C 配置 connect/send/read timeout
+4. 配置 keepalive、轻重试、熔断阈值
 
 **验收标准:**
-- [x] gRPC 请求全部经过 APISIX
+- [x] memory/tool 的 gRPC 请求全部经过 APISIX
+- [x] `llm` 的 gRPC 路由仅在兼容模式下保留
 - [x] 超时与重试符合基线值
 - [x] 路由变更可回滚
 

--- a/koduck-ai/src/api/mod.rs
+++ b/koduck-ai/src/api/mod.rs
@@ -20,15 +20,14 @@ use uuid::Uuid;
 use crate::{
     app::AppState,
     auth::AuthContext,
-    clients::proto::{
-        ChatMessage as LlmChatMessage, GenerateRequest as LlmGenerateRequest, LlmServiceClient,
-        RequestMeta, StreamGenerateEvent as LlmStreamGenerateEvent,
+    llm::{
+        ChatMessage as ProviderChatMessage, GenerateRequest as ProviderGenerateRequest,
+        RequestContext, StreamEvent as ProviderStreamEvent,
     },
     orchestrator::cancel::{run_abortable_with_cleanup, AbortReason, RequestGenerationGuard},
     reliability::{
         degrade::{DegradeDecision, DegradeRoute},
         error::{AppError, ErrorCode, UpstreamService},
-        error_mapper::{map_contract_error_detail, map_grpc_status, map_transport_error},
         retry_budget::RetryDirective,
     },
     stream::sse::{PendingStreamEvent, ResumeCursor, StreamEventData},
@@ -109,11 +108,12 @@ pub async fn chat(
     }
 
     let session_id = resolve_session_id(request.session_id.clone());
+    let trace_id = extract_trace_id(&headers);
 
     info!(
         request_id = %request_id,
         session_id = %session_id,
-        trace_id = %extract_trace_id(&headers),
+        trace_id = %trace_id,
         "chat request received"
     );
 
@@ -127,7 +127,16 @@ pub async fn chat(
             "stub_enabled",
         )
     } else {
-        match call_llm_generate(&state, &request, &request_id, &session_id, &auth_ctx).await {
+        match call_llm_generate(
+            &state,
+            &request,
+            &request_id,
+            &session_id,
+            &auth_ctx,
+            &trace_id,
+        )
+        .await
+        {
             Ok(ok) => ok,
             Err(err) => {
                 if let Some(decision) = state
@@ -257,8 +266,15 @@ pub async fn chat_stream(
             );
         } else {
             let upstream =
-                match call_llm_stream(&state, &request.chat, &request_id, &session_id, &auth_ctx)
-                    .await
+                match call_llm_stream(
+                    &state,
+                    &request.chat,
+                    &request_id,
+                    &session_id,
+                    &auth_ctx,
+                    &trace_id,
+                )
+                .await
                 {
                     Ok(stream) => stream,
                     Err(err) => {
@@ -324,12 +340,7 @@ pub async fn chat_stream(
                                     break;
                                 }
                             }
-                            Err(err) => {
-                                let mapped_error = map_grpc_status(
-                                    UpstreamService::Llm,
-                                    stream_session.request_id().to_string(),
-                                    &err,
-                                );
+                            Err(mapped_error) => {
                                 info!(
                                     request_id = %stream_session.request_id(),
                                     session_id = %stream_session.session_id(),
@@ -587,12 +598,14 @@ async fn call_llm_generate(
     request_id: &str,
     session_id: &str,
     auth_ctx: &AuthContext,
+    trace_id: &str,
 ) -> Result<ChatResponse, AppError> {
     let policy = Arc::clone(&state.retry_budget_policy);
     let session = policy.begin_session();
     let mut attempt_index = 0;
     let body = loop {
-        let deadline_ms = match policy.next_attempt_deadline_ms(&session, state.config.llm.timeout_ms) {
+        let deadline_ms =
+            match policy.next_attempt_deadline_ms(&session, state.config.llm.timeout_ms) {
             Some(deadline_ms) => deadline_ms,
             None => {
                 return Err(
@@ -603,7 +616,16 @@ async fn call_llm_generate(
                 )
             }
         };
-        match llm_generate_once(state, request, request_id, session_id, auth_ctx, deadline_ms).await {
+        let llm_request = build_provider_generate_request(
+            state,
+            request,
+            request_id,
+            session_id,
+            auth_ctx,
+            trace_id,
+            deadline_ms,
+        );
+        match state.llm_provider.generate(llm_request).await {
             Ok(body) => break body,
             Err(err) => match policy.should_retry(&session, attempt_index, err) {
                 RetryDirective::RetryAfter { delay, err } => {
@@ -620,22 +642,18 @@ async fn call_llm_generate(
 
     let answer = body
         .message
-        .as_ref()
-        .map(|m| m.content.clone())
-        .unwrap_or_default();
+        .content
+        .clone();
     let usage = body.usage.as_ref();
     Ok(ChatResponse {
         request_id: request_id.to_string(),
         session_id: session_id.to_string(),
         answer,
-        model: request
-            .model
-            .clone()
-            .unwrap_or_else(|| state.config.llm.default_provider.clone()),
+        model: body.model,
         usage: TokenUsage {
-            prompt_tokens: usage.map(|u| u.prompt_tokens as u32).unwrap_or(0),
-            completion_tokens: usage.map(|u| u.completion_tokens as u32).unwrap_or(0),
-            total_tokens: usage.map(|u| u.total_tokens as u32).unwrap_or(0),
+            prompt_tokens: usage.map(|u| u.prompt_tokens).unwrap_or(0),
+            completion_tokens: usage.map(|u| u.completion_tokens).unwrap_or(0),
+            total_tokens: usage.map(|u| u.total_tokens).unwrap_or(0),
         },
         degraded: false,
     })
@@ -647,13 +665,15 @@ async fn call_llm_stream(
     request_id: &str,
     session_id: &str,
     auth_ctx: &AuthContext,
-) -> Result<tonic::Streaming<LlmStreamGenerateEvent>, AppError> {
+    trace_id: &str,
+) -> Result<crate::llm::ProviderEventStream, AppError> {
     let policy = Arc::clone(&state.retry_budget_policy);
     let session = policy.begin_session();
     let mut attempt_index = 0;
 
     loop {
-        let deadline_ms = match policy.next_attempt_deadline_ms(&session, state.config.llm.timeout_ms) {
+        let deadline_ms =
+            match policy.next_attempt_deadline_ms(&session, state.config.llm.timeout_ms) {
             Some(deadline_ms) => deadline_ms,
             None => {
                 return Err(
@@ -664,7 +684,16 @@ async fn call_llm_stream(
                 )
             }
         };
-        match llm_stream_once(state, request, request_id, session_id, auth_ctx, deadline_ms).await {
+        let llm_request = build_provider_generate_request(
+            state,
+            request,
+            request_id,
+            session_id,
+            auth_ctx,
+            trace_id,
+            deadline_ms,
+        );
+        match state.llm_provider.stream_generate(llm_request).await {
             Ok(stream) => return Ok(stream),
             Err(err) => match policy.should_retry(&session, attempt_index, err) {
                 RetryDirective::RetryAfter { delay, err } => {
@@ -680,182 +709,52 @@ async fn call_llm_stream(
     }
 }
 
-async fn llm_generate_once(
+fn build_provider_generate_request(
     state: &Arc<AppState>,
     request: &ChatRequest,
     request_id: &str,
     session_id: &str,
     auth_ctx: &AuthContext,
+    trace_id: &str,
     deadline_ms: u64,
-) -> Result<crate::clients::proto::GenerateResponse, AppError> {
-    let target = grpc_target_with_scheme(&state.config.llm.adapter_grpc_target);
-    let stream = tokio::time::timeout(Duration::from_millis(deadline_ms), async {
-        let channel = tonic::transport::Channel::from_shared(target.clone())
-            .map_err(|e| {
-                map_transport_error(
-                    UpstreamService::Llm,
-                    request_id.to_string(),
-                    "invalid llm grpc target",
-                    e,
-                )
-            })?
-            .connect()
-            .await
-            .map_err(|e| {
-                map_transport_error(
-                    UpstreamService::Llm,
-                    request_id.to_string(),
-                    "failed to connect llm adapter",
-                    e,
-                )
-            })?;
-        let mut client = LlmServiceClient::new(channel);
-        let req = tonic::Request::new(LlmGenerateRequest {
-            meta: Some(RequestMeta {
-                request_id: request_id.to_string(),
-                session_id: session_id.to_string(),
-                user_id: auth_ctx.user_id.clone(),
-                tenant_id: String::new(),
-                trace_id: String::new(),
-                idempotency_key: String::new(),
-                deadline_ms: deadline_ms as i64,
-                api_version: "v1".to_string(),
-            }),
-            model: request
-                .model
-                .clone()
-                .unwrap_or_else(|| state.config.llm.default_provider.clone()),
-            messages: vec![LlmChatMessage {
-                role: "user".to_string(),
-                content: request.message.clone(),
-                name: String::new(),
-                metadata: std::collections::HashMap::new(),
-            }],
-            temperature: request.temperature.unwrap_or(0.2),
-            top_p: 1.0,
-            max_tokens: request.max_tokens.unwrap_or(2048) as i32,
-            tools: vec![],
-            response_format: String::new(),
-            provider: state.config.llm.default_provider.clone(),
-        });
-        client
-            .generate(req)
-            .await
-            .map_err(|e| map_grpc_status(UpstreamService::Llm, request_id.to_string(), &e))
-            .map(|resp| resp.into_inner())
-    })
-    .await
-    .map_err(|_| {
-        AppError::new(ErrorCode::UpstreamUnavailable, "llm request exceeded local timeout budget")
-            .with_request_id(request_id.to_string())
-            .with_upstream(UpstreamService::Llm)
-    })??;
-
-    if !stream.ok {
-        return Err(map_contract_error_detail(
-            UpstreamService::Llm,
-            request_id.to_string(),
-            stream.error.as_ref(),
-            ErrorCode::DependencyFailed,
-            "llm adapter returned not ok",
-        ));
+) -> ProviderGenerateRequest {
+    ProviderGenerateRequest {
+        meta: RequestContext {
+            request_id: request_id.to_string(),
+            session_id: session_id.to_string(),
+            user_id: auth_ctx.user_id.clone(),
+            trace_id: trace_id.to_string(),
+            deadline_ms,
+        },
+        provider: state.config.llm.default_provider.clone(),
+        model: request
+            .model
+            .clone()
+            .unwrap_or_else(|| state.config.llm.default_provider.clone()),
+        messages: vec![ProviderChatMessage {
+            role: "user".to_string(),
+            content: request.message.clone(),
+            name: String::new(),
+            metadata: HashMap::new(),
+        }],
+        temperature: request.temperature.unwrap_or(0.2),
+        top_p: 1.0,
+        max_tokens: request.max_tokens.unwrap_or(2048),
+        tools: vec![],
+        response_format: String::new(),
     }
-
-    Ok(stream)
-}
-
-async fn llm_stream_once(
-    state: &Arc<AppState>,
-    request: &ChatRequest,
-    request_id: &str,
-    session_id: &str,
-    auth_ctx: &AuthContext,
-    deadline_ms: u64,
-) -> Result<tonic::Streaming<LlmStreamGenerateEvent>, AppError> {
-    let target = grpc_target_with_scheme(&state.config.llm.adapter_grpc_target);
-    tokio::time::timeout(Duration::from_millis(deadline_ms), async {
-        let channel = tonic::transport::Channel::from_shared(target.clone())
-            .map_err(|e| {
-                map_transport_error(
-                    UpstreamService::Llm,
-                    request_id.to_string(),
-                    "invalid llm grpc target",
-                    e,
-                )
-            })?
-            .connect()
-            .await
-            .map_err(|e| {
-                map_transport_error(
-                    UpstreamService::Llm,
-                    request_id.to_string(),
-                    "failed to connect llm adapter",
-                    e,
-                )
-            })?;
-        let mut client = LlmServiceClient::new(channel);
-        let req = tonic::Request::new(LlmGenerateRequest {
-            meta: Some(RequestMeta {
-                request_id: request_id.to_string(),
-                session_id: session_id.to_string(),
-                user_id: auth_ctx.user_id.clone(),
-                tenant_id: String::new(),
-                trace_id: String::new(),
-                idempotency_key: String::new(),
-                deadline_ms: deadline_ms as i64,
-                api_version: "v1".to_string(),
-            }),
-            model: request
-                .model
-                .clone()
-                .unwrap_or_else(|| state.config.llm.default_provider.clone()),
-            messages: vec![LlmChatMessage {
-                role: "user".to_string(),
-                content: request.message.clone(),
-                name: String::new(),
-                metadata: std::collections::HashMap::new(),
-            }],
-            temperature: request.temperature.unwrap_or(0.2),
-            top_p: 1.0,
-            max_tokens: request.max_tokens.unwrap_or(2048) as i32,
-            tools: vec![],
-            response_format: String::new(),
-            provider: state.config.llm.default_provider.clone(),
-        });
-        client
-            .stream_generate(req)
-            .await
-            .map_err(|e| map_grpc_status(UpstreamService::Llm, request_id.to_string(), &e))
-            .map(|resp| resp.into_inner())
-    })
-    .await
-    .map_err(|_| {
-        AppError::new(
-            ErrorCode::UpstreamUnavailable,
-            "llm stream setup exceeded local timeout budget",
-        )
-        .with_request_id(request_id.to_string())
-        .with_upstream(UpstreamService::Llm)
-    })?
 }
 
 fn build_stream_event(
-    ev: &LlmStreamGenerateEvent,
+    ev: &ProviderStreamEvent,
     request_id: &str,
     session_id: &str,
 ) -> PendingStreamEvent {
-    if ev.error.is_some() {
-        let mapped_error = map_contract_error_detail(
-            UpstreamService::Llm,
-            request_id.to_string(),
-            ev.error.as_ref(),
-            ErrorCode::DependencyFailed,
-            "llm stream returned error event",
-        );
-        return build_stream_error_event(&mapped_error, request_id, session_id);
-    }
-
-    let event_type = if ev.finish_reason.is_empty() { "delta" } else { "done" };
+    let event_type = if ev.finish_reason.is_empty() {
+        "delta"
+    } else {
+        "done"
+    };
     let payload = if event_type == "done" {
         json!({ "finish_reason": &ev.finish_reason })
     } else {
@@ -866,7 +765,7 @@ fn build_stream_event(
         event_type: event_type.to_string(),
         payload,
         event_id: Some(ev.event_id.clone()),
-        sequence_num: Some(ev.sequence_num as u32),
+        sequence_num: Some(ev.sequence_num),
         request_id: request_id.to_string(),
         session_id: session_id.to_string(),
     }
@@ -1017,14 +916,6 @@ fn spawn_stub_stream(
             );
         }
     });
-}
-
-fn grpc_target_with_scheme(raw: &str) -> String {
-    if raw.starts_with("http://") || raw.starts_with("https://") {
-        raw.to_string()
-    } else {
-        format!("http://{raw}")
-    }
 }
 
 fn api_error_response(err: AppError, request_id: String) -> Response {

--- a/koduck-ai/src/app/mod.rs
+++ b/koduck-ai/src/app/mod.rs
@@ -12,6 +12,7 @@ use tower_http::trace::TraceLayer;
 
 use crate::api;
 use crate::config::Config;
+use crate::llm::{AdapterLlmProvider, LlmProvider};
 use crate::reliability::degrade::DegradePolicy;
 use crate::reliability::retry_budget::RetryBudgetPolicy;
 use crate::stream::sse::StreamRegistry;
@@ -25,6 +26,7 @@ pub struct AppState {
     pub lifecycle: Arc<lifecycle::LifecycleManager>,
     pub degrade_policy: Arc<DegradePolicy>,
     pub retry_budget_policy: Arc<RetryBudgetPolicy>,
+    pub llm_provider: Arc<dyn LlmProvider>,
 }
 
 /// Health check response
@@ -49,6 +51,9 @@ pub fn build_state(config: Config) -> Arc<AppState> {
 
     Arc::new(AppState {
         degrade_policy: Arc::new(DegradePolicy::new(config.reliability.degrade.clone())),
+        llm_provider: Arc::new(AdapterLlmProvider::new(
+            config.llm.adapter_grpc_target.clone(),
+        )),
         retry_budget_policy: Arc::new(RetryBudgetPolicy::new(config.reliability.retry.clone())),
         config,
         stream_registry: Arc::new(StreamRegistry::default()),

--- a/koduck-ai/src/llm/compat.rs
+++ b/koduck-ai/src/llm/compat.rs
@@ -1,0 +1,298 @@
+//! Compatibility provider that adapts the existing gRPC LLM adapter to the unified trait.
+
+use async_trait::async_trait;
+use futures::StreamExt;
+use tonic::transport::Channel;
+
+use crate::{
+    clients::proto::{
+        ChatMessage as ProtoChatMessage, CountTokensRequest as ProtoCountTokensRequest,
+        GenerateRequest as ProtoGenerateRequest, LlmServiceClient, ListModelsRequest as ProtoListModelsRequest,
+        ModelInfo as ProtoModelInfo, RequestMeta, StreamGenerateEvent as ProtoStreamGenerateEvent,
+        TokenUsage as ProtoTokenUsage, ToolDefinition as ProtoToolDefinition,
+    },
+    reliability::{
+        error::{AppError, ErrorCode, UpstreamService},
+        error_mapper::{map_contract_error_detail, map_grpc_status, map_transport_error},
+    },
+};
+
+use super::{
+    provider::{LlmProvider, ProviderEventStream},
+    types::{
+        ChatMessage, CountTokensRequest, CountTokensResponse, GenerateRequest, GenerateResponse,
+        ListModelsRequest, ModelInfo, StreamEvent, TokenUsage, ToolDefinition,
+    },
+};
+
+#[derive(Debug, Clone)]
+pub struct AdapterLlmProvider {
+    adapter_grpc_target: String,
+}
+
+impl AdapterLlmProvider {
+    pub fn new(adapter_grpc_target: impl Into<String>) -> Self {
+        Self {
+            adapter_grpc_target: adapter_grpc_target.into(),
+        }
+    }
+
+    async fn connect(&self, request_id: &str) -> Result<LlmServiceClient<Channel>, AppError> {
+        let target = grpc_target_with_scheme(&self.adapter_grpc_target);
+        let channel = Channel::from_shared(target.clone())
+            .map_err(|e| {
+                map_transport_error(
+                    UpstreamService::Llm,
+                    request_id.to_string(),
+                    "invalid llm grpc target",
+                    e,
+                )
+            })?
+            .connect()
+            .await
+            .map_err(|e| {
+                map_transport_error(
+                    UpstreamService::Llm,
+                    request_id.to_string(),
+                    "failed to connect llm adapter",
+                    e,
+                )
+            })?;
+
+        Ok(LlmServiceClient::new(channel))
+    }
+}
+
+#[async_trait]
+impl LlmProvider for AdapterLlmProvider {
+    async fn generate(&self, req: GenerateRequest) -> Result<GenerateResponse, AppError> {
+        let request_id = req.meta.request_id.clone();
+        let provider = req.provider.clone();
+        let model = req.model.clone();
+        let mut client = self.connect(&request_id).await?;
+        let response = client
+            .generate(tonic::Request::new(proto_generate_request(req)))
+            .await
+            .map_err(|e| map_grpc_status(UpstreamService::Llm, request_id.clone(), &e))?
+            .into_inner();
+
+        if !response.ok {
+            return Err(map_contract_error_detail(
+                UpstreamService::Llm,
+                request_id,
+                response.error.as_ref(),
+                ErrorCode::DependencyFailed,
+                "llm adapter returned not ok",
+            ));
+        }
+
+        Ok(GenerateResponse {
+            provider,
+            model,
+            message: proto_chat_message_to_unified(response.message.unwrap_or_default()),
+            finish_reason: response.finish_reason,
+            usage: response.usage.map(proto_usage_to_unified),
+        })
+    }
+
+    async fn stream_generate(&self, req: GenerateRequest) -> Result<ProviderEventStream, AppError> {
+        let request_id = req.meta.request_id.clone();
+        let provider = req.provider.clone();
+        let model = req.model.clone();
+        let mut client = self.connect(&request_id).await?;
+        let stream = client
+            .stream_generate(tonic::Request::new(proto_generate_request(req)))
+            .await
+            .map_err(|e| map_grpc_status(UpstreamService::Llm, request_id.clone(), &e))?
+            .into_inner()
+            .map(move |item| match item {
+                Ok(event) => proto_stream_event_to_unified(event, &request_id, &provider, &model),
+                Err(status) => Err(map_grpc_status(
+                    UpstreamService::Llm,
+                    request_id.clone(),
+                    &status,
+                )),
+            });
+
+        Ok(Box::pin(stream))
+    }
+
+    async fn list_models(&self, req: ListModelsRequest) -> Result<Vec<ModelInfo>, AppError> {
+        let request_id = req.meta.request_id.clone();
+        let mut client = self.connect(&request_id).await?;
+        let response = client
+            .list_models(tonic::Request::new(ProtoListModelsRequest {
+                meta: Some(proto_request_meta(&req.meta)),
+                provider: req.provider.clone(),
+            }))
+            .await
+            .map_err(|e| map_grpc_status(UpstreamService::Llm, request_id.clone(), &e))?
+            .into_inner();
+
+        if !response.ok {
+            return Err(map_contract_error_detail(
+                UpstreamService::Llm,
+                request_id,
+                response.error.as_ref(),
+                ErrorCode::DependencyFailed,
+                "llm adapter list_models returned not ok",
+            ));
+        }
+
+        Ok(response.models.into_iter().map(proto_model_to_unified).collect())
+    }
+
+    async fn count_tokens(
+        &self,
+        req: CountTokensRequest,
+    ) -> Result<CountTokensResponse, AppError> {
+        let request_id = req.meta.request_id.clone();
+        let mut client = self.connect(&request_id).await?;
+        let response = client
+            .count_tokens(tonic::Request::new(ProtoCountTokensRequest {
+                meta: Some(proto_request_meta(&req.meta)),
+                model: req.model.clone(),
+                messages: req
+                    .messages
+                    .into_iter()
+                    .map(unified_chat_message_to_proto)
+                    .collect(),
+            }))
+            .await
+            .map_err(|e| map_grpc_status(UpstreamService::Llm, request_id.clone(), &e))?
+            .into_inner();
+
+        if !response.ok {
+            return Err(map_contract_error_detail(
+                UpstreamService::Llm,
+                request_id,
+                response.error.as_ref(),
+                ErrorCode::DependencyFailed,
+                "llm adapter count_tokens returned not ok",
+            ));
+        }
+
+        Ok(CountTokensResponse {
+            provider: req.provider,
+            model: req.model,
+            total_tokens: response.total_tokens.max(0) as u32,
+        })
+    }
+}
+
+fn proto_generate_request(req: GenerateRequest) -> ProtoGenerateRequest {
+    ProtoGenerateRequest {
+        meta: Some(proto_request_meta(&req.meta)),
+        model: req.model,
+        messages: req
+            .messages
+            .into_iter()
+            .map(unified_chat_message_to_proto)
+            .collect(),
+        temperature: req.temperature,
+        top_p: req.top_p,
+        max_tokens: req.max_tokens as i32,
+        tools: req
+            .tools
+            .into_iter()
+            .map(unified_tool_to_proto)
+            .collect(),
+        response_format: req.response_format,
+        provider: req.provider,
+    }
+}
+
+fn proto_request_meta(meta: &super::types::RequestContext) -> RequestMeta {
+    RequestMeta {
+        request_id: meta.request_id.clone(),
+        session_id: meta.session_id.clone(),
+        user_id: meta.user_id.clone(),
+        tenant_id: String::new(),
+        trace_id: meta.trace_id.clone(),
+        idempotency_key: String::new(),
+        deadline_ms: meta.deadline_ms as i64,
+        api_version: "v1".to_string(),
+    }
+}
+
+fn unified_chat_message_to_proto(message: ChatMessage) -> ProtoChatMessage {
+    ProtoChatMessage {
+        role: message.role,
+        content: message.content,
+        name: message.name,
+        metadata: message.metadata,
+    }
+}
+
+fn proto_chat_message_to_unified(message: ProtoChatMessage) -> ChatMessage {
+    ChatMessage {
+        role: message.role,
+        content: message.content,
+        name: message.name,
+        metadata: message.metadata,
+    }
+}
+
+fn unified_tool_to_proto(tool: ToolDefinition) -> ProtoToolDefinition {
+    ProtoToolDefinition {
+        name: tool.name,
+        description: tool.description,
+        input_schema: tool.input_schema,
+    }
+}
+
+fn proto_usage_to_unified(usage: ProtoTokenUsage) -> TokenUsage {
+    TokenUsage {
+        prompt_tokens: usage.prompt_tokens.max(0) as u32,
+        completion_tokens: usage.completion_tokens.max(0) as u32,
+        total_tokens: usage.total_tokens.max(0) as u32,
+    }
+}
+
+fn proto_model_to_unified(model: ProtoModelInfo) -> ModelInfo {
+    ModelInfo {
+        id: model.id,
+        provider: model.provider,
+        display_name: model.display_name,
+        max_context_tokens: model.max_context_tokens.max(0) as u32,
+        max_output_tokens: model.max_output_tokens.max(0) as u32,
+        supports_streaming: model.supports_streaming,
+        supports_tools: model.supports_tools,
+        supported_features: model.supported_features,
+    }
+}
+
+fn proto_stream_event_to_unified(
+    event: ProtoStreamGenerateEvent,
+    request_id: &str,
+    provider: &str,
+    model: &str,
+) -> Result<StreamEvent, AppError> {
+    if event.error.is_some() {
+        return Err(map_contract_error_detail(
+            UpstreamService::Llm,
+            request_id.to_string(),
+            event.error.as_ref(),
+            ErrorCode::DependencyFailed,
+            "llm stream returned error event",
+        ));
+    }
+
+    Ok(StreamEvent {
+        provider: provider.to_string(),
+        model: model.to_string(),
+        event_id: event.event_id,
+        sequence_num: event.sequence_num.max(0) as u32,
+        delta: event.delta,
+        finish_reason: event.finish_reason,
+        usage: event.usage.map(proto_usage_to_unified),
+    })
+}
+
+fn grpc_target_with_scheme(raw: &str) -> String {
+    if raw.starts_with("http://") || raw.starts_with("https://") {
+        raw.to_string()
+    } else {
+        format!("http://{raw}")
+    }
+}

--- a/koduck-ai/src/llm/mod.rs
+++ b/koduck-ai/src/llm/mod.rs
@@ -1,1 +1,12 @@
-//! LLM provider adapter and routing
+//! LLM provider adapter and routing.
+
+pub mod compat;
+pub mod provider;
+pub mod types;
+
+pub use compat::AdapterLlmProvider;
+pub use provider::{LlmProvider, ProviderEventStream};
+pub use types::{
+    ChatMessage, CountTokensRequest, CountTokensResponse, GenerateRequest, GenerateResponse,
+    ListModelsRequest, ModelInfo, RequestContext, StreamEvent, TokenUsage, ToolDefinition,
+};

--- a/koduck-ai/src/llm/provider.rs
+++ b/koduck-ai/src/llm/provider.rs
@@ -1,0 +1,141 @@
+//! Provider abstraction shared by direct and adapter-backed LLM integrations.
+
+use std::pin::Pin;
+
+use async_trait::async_trait;
+use futures::Stream;
+
+use crate::reliability::error::AppError;
+
+use super::types::{
+    CountTokensRequest, CountTokensResponse, GenerateRequest, GenerateResponse, ListModelsRequest,
+    ModelInfo, StreamEvent,
+};
+
+pub type ProviderEventStream =
+    Pin<Box<dyn Stream<Item = Result<StreamEvent, AppError>> + Send + 'static>>;
+
+#[async_trait]
+pub trait LlmProvider: Send + Sync {
+    async fn generate(&self, req: GenerateRequest) -> Result<GenerateResponse, AppError>;
+
+    async fn stream_generate(&self, req: GenerateRequest) -> Result<ProviderEventStream, AppError>;
+
+    async fn list_models(&self, req: ListModelsRequest) -> Result<Vec<ModelInfo>, AppError>;
+
+    async fn count_tokens(
+        &self,
+        req: CountTokensRequest,
+    ) -> Result<CountTokensResponse, AppError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::HashMap, sync::Arc};
+
+    use async_trait::async_trait;
+    use futures::stream;
+
+    use crate::reliability::error::AppError;
+
+    use super::{
+        CountTokensRequest, CountTokensResponse, GenerateRequest, GenerateResponse, LlmProvider,
+        ListModelsRequest, ModelInfo, ProviderEventStream, StreamEvent,
+    };
+    use crate::llm::types::{ChatMessage, RequestContext, TokenUsage};
+
+    struct MockProvider;
+
+    #[async_trait]
+    impl LlmProvider for MockProvider {
+        async fn generate(&self, req: GenerateRequest) -> Result<GenerateResponse, AppError> {
+            Ok(GenerateResponse {
+                provider: req.provider,
+                model: req.model,
+                message: req.messages.into_iter().next().unwrap(),
+                finish_reason: "stop".to_string(),
+                usage: Some(TokenUsage {
+                    prompt_tokens: 1,
+                    completion_tokens: 1,
+                    total_tokens: 2,
+                }),
+            })
+        }
+
+        async fn stream_generate(
+            &self,
+            req: GenerateRequest,
+        ) -> Result<ProviderEventStream, AppError> {
+            Ok(Box::pin(stream::iter(vec![Ok(StreamEvent {
+                provider: req.provider,
+                model: req.model,
+                event_id: "evt-1".to_string(),
+                sequence_num: 1,
+                delta: "hello".to_string(),
+                finish_reason: String::new(),
+                usage: None,
+            })])))
+        }
+
+        async fn list_models(&self, req: ListModelsRequest) -> Result<Vec<ModelInfo>, AppError> {
+            Ok(vec![ModelInfo {
+                id: "mock-model".to_string(),
+                provider: req.provider,
+                display_name: "Mock Model".to_string(),
+                max_context_tokens: 1024,
+                max_output_tokens: 512,
+                supports_streaming: true,
+                supports_tools: false,
+                supported_features: vec!["chat".to_string(), "stream".to_string()],
+            }])
+        }
+
+        async fn count_tokens(
+            &self,
+            req: CountTokensRequest,
+        ) -> Result<CountTokensResponse, AppError> {
+            Ok(CountTokensResponse {
+                provider: req.provider,
+                model: req.model,
+                total_tokens: req.messages.len() as u32,
+            })
+        }
+    }
+
+    fn sample_request() -> GenerateRequest {
+        GenerateRequest {
+            meta: RequestContext {
+                request_id: "req-1".to_string(),
+                session_id: "sess-1".to_string(),
+                user_id: "user-1".to_string(),
+                trace_id: "trace-1".to_string(),
+                deadline_ms: 1000,
+            },
+            provider: "adapter".to_string(),
+            model: "test-model".to_string(),
+            messages: vec![ChatMessage {
+                role: "user".to_string(),
+                content: "hi".to_string(),
+                name: String::new(),
+                metadata: HashMap::new(),
+            }],
+            temperature: 0.2,
+            top_p: 1.0,
+            max_tokens: 128,
+            tools: vec![],
+            response_format: String::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn trait_object_covers_generate_and_stream_paths() {
+        let provider: Arc<dyn LlmProvider> = Arc::new(MockProvider);
+        let response = provider.generate(sample_request()).await.unwrap();
+        assert_eq!(response.message.content, "hi");
+
+        let mut stream = provider.stream_generate(sample_request()).await.unwrap();
+        let event = futures::StreamExt::next(&mut stream).await.unwrap().unwrap();
+        assert_eq!(event.sequence_num, 1);
+        assert_eq!(event.delta, "hello");
+    }
+}

--- a/koduck-ai/src/llm/types.rs
+++ b/koduck-ai/src/llm/types.rs
@@ -1,0 +1,102 @@
+//! Unified LLM provider request/response types used by orchestrators.
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RequestContext {
+    pub request_id: String,
+    pub session_id: String,
+    pub user_id: String,
+    pub trace_id: String,
+    pub deadline_ms: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ChatMessage {
+    pub role: String,
+    pub content: String,
+    pub name: String,
+    pub metadata: HashMap<String, String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ToolDefinition {
+    pub name: String,
+    pub description: String,
+    pub input_schema: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TokenUsage {
+    pub prompt_tokens: u32,
+    pub completion_tokens: u32,
+    pub total_tokens: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct GenerateRequest {
+    pub meta: RequestContext,
+    pub provider: String,
+    pub model: String,
+    pub messages: Vec<ChatMessage>,
+    pub temperature: f32,
+    pub top_p: f32,
+    pub max_tokens: u32,
+    pub tools: Vec<ToolDefinition>,
+    pub response_format: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct GenerateResponse {
+    pub provider: String,
+    pub model: String,
+    pub message: ChatMessage,
+    pub finish_reason: String,
+    pub usage: Option<TokenUsage>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct StreamEvent {
+    pub provider: String,
+    pub model: String,
+    pub event_id: String,
+    pub sequence_num: u32,
+    pub delta: String,
+    pub finish_reason: String,
+    pub usage: Option<TokenUsage>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ModelInfo {
+    pub id: String,
+    pub provider: String,
+    pub display_name: String,
+    pub max_context_tokens: u32,
+    pub max_output_tokens: u32,
+    pub supports_streaming: bool,
+    pub supports_tools: bool,
+    pub supported_features: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ListModelsRequest {
+    pub meta: RequestContext,
+    pub provider: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CountTokensRequest {
+    pub meta: RequestContext,
+    pub provider: String,
+    pub model: String,
+    pub messages: Vec<ChatMessage>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CountTokensResponse {
+    pub provider: String,
+    pub model: String,
+    pub total_tokens: u32,
+}


### PR DESCRIPTION
## Summary
- add a unified llm provider abstraction and adapter compatibility layer
- refactor chat and stream paths to depend on the provider trait
- add ADR 0015 and mark task 3.3.1 complete

Closes #748