### PR TITLE
feat(koduck-ai): add shared llm http foundation

### DIFF
--- a/koduck-ai/docs/adr/0016-shared-reqwest-foundation-for-direct-llm-providers.md
+++ b/koduck-ai/docs/adr/0016-shared-reqwest-foundation-for-direct-llm-providers.md
@@ -1,0 +1,120 @@
+# ADR-0016: 为 direct LLM provider 建立共享 reqwest HTTP 基础设施
+
+- Status: Accepted
+- Date: 2026-04-11
+- Issue: #750
+
+## Context
+
+根据 `koduck-ai/docs/design/ai-decoupled-architecture.md` 第 6.5.5 节和
+`koduck-ai/docs/implementation/koduck-ai-rust-grpc-tasks.md` Task 3.3.2：
+
+1. `koduck-ai` 的 direct 模式需要统一基于 `reqwest` 实现，不引入额外 OpenAI SDK。
+2. 未来 `openai` / `deepseek` / `minimax` 三个 provider adapter 都会走 HTTP + SSE/chunk 流式协议。
+3. 如果每个 provider 各自实现 header、timeout、错误映射和流式 chunk 解析，会重复大量样板代码，也会让 429 / 5xx / timeout / EOF 的语义不一致。
+
+在本次任务开始前，`src/llm/` 只有 trait 抽象和 gRPC adapter 兼容实现，还没有：
+
+- 共享 `reqwest::Client`
+- 统一 header / deadline timeout 组织
+- 共享 SSE chunk 解析器
+- 厂商 HTTP 状态码与错误体到 `AppError` 的标准化映射
+
+## Decision
+
+本次在 `src/llm/` 下新增共享 HTTP 基础设施，而不直接实现具体 provider。
+
+### 1. 引入共享 reqwest client
+
+新增 `src/llm/http.rs`，提供 `LlmHttpClient`：
+
+- 使用 `reqwest::Client::builder()`
+- 显式启用 `rustls`
+- 统一连接复用参数：
+  - `connect_timeout`
+  - `pool_idle_timeout`
+  - `pool_max_idle_per_host`
+  - `tcp_keepalive`
+
+这样后续三个 provider adapter 可以共享同一套连接池与 TLS 基线。
+
+### 2. 统一 JSON 请求构造
+
+新增 `JsonRequestOptions`：
+
+- `url`
+- `request_id`
+- `deadline_ms`
+- `bearer_token`
+- `traceparent`
+- `accept`
+- `extra_headers`
+
+统一由共享基础设施注入：
+
+- `Authorization: Bearer <token>`
+- `Content-Type: application/json`
+- `Accept`
+- `X-Request-Id`
+- `traceparent`
+
+同时把 `deadline_ms` 映射到本地 request timeout，保证后续 provider adapter 严格服从上层预算。
+
+### 3. 统一 SSE chunk 解析
+
+同文件新增 `SseStreamParser`：
+
+- 支持跨 chunk 拼接
+- 支持 `event` / `id` / `data`
+- 支持按空行 flush 完整事件
+- 对提前 EOF 和 malformed chunk 返回统一 `AppError`
+
+这让三个 provider 可以复用同一套流式文本解析器，只在 adapter 内做 provider-specific JSON 到统一 `StreamEvent` 的最后一跳转换。
+
+### 4. 统一 HTTP / stream 错误语义
+
+新增 `src/llm/errors.rs`，提供：
+
+- `map_http_transport_error`
+- `map_http_status_error`
+- `map_stream_eof`
+- `map_malformed_stream_chunk`
+
+归一规则：
+
+- `429` -> `RATE_LIMITED`
+- `503` -> `SERVER_BUSY`
+- `502` -> `UPSTREAM_UNAVAILABLE`
+- `504` / timeout -> `STREAM_TIMEOUT`
+- 其他 `5xx` -> `DEPENDENCY_FAILED`
+- 提前 EOF / malformed chunk -> `STREAM_INTERRUPTED`
+
+同时兼容从 HTTP header / body 读取 `retry_after_ms`，为后续重试预算逻辑保留一致输入。
+
+## Consequences
+
+### 正向影响
+
+1. **direct provider 有统一底座**：后续三个 provider adapter 只需关心各自 URL、body schema 和响应字段差异。
+2. **错误语义一致**：HTTP / stream 异常不会在不同 provider 中漂移成不同的 `AppError`。
+3. **便于复用和测试**：header、timeout、SSE 解析器都可以独立单测。
+
+### 代价与风险
+
+1. **仍未接入真实 provider**：本次只完成基础设施，真正的 `openai` / `deepseek` / `minimax` adapter 留到 Task 3.3.3。
+2. **当前错误映射是通用启发式**：后续若某个 provider 有更细的错误体语义，需要在 adapter 层补充映射，但不应破坏共享基线。
+
+### 兼容性影响
+
+- **对 northbound API 无兼容性变化**：当前线上路径仍然是 adapter gRPC。
+- **对后续 direct provider 是增量增强**：新模块是可并行接入的底座，不影响现有 trait 抽象。
+
+## Alternatives Considered
+
+### 1. 在每个 provider adapter 内各自写 HTTP / SSE / 错误处理
+
+- **拒绝理由**：会在三个 provider 中复制同样的连接池、header、timeout 和错误映射逻辑，长期维护成本高。
+
+### 2. 引入第三方 OpenAI SDK 作为公共底座
+
+- **拒绝理由**：设计已经明确要求统一基于 `reqwest`，并且 `MiniMax` / `DeepSeek` 只是 OpenAI-compatible，直接使用 SDK 会增加不必要耦合。

--- a/koduck-ai/docs/implementation/koduck-ai-rust-grpc-tasks.md
+++ b/koduck-ai/docs/implementation/koduck-ai-rust-grpc-tasks.md
@@ -196,9 +196,9 @@ cd koduck-ai
 3. 实现厂商 HTTP 状态码与错误 body 到统一错误语义的映射辅助
 
 **验收标准:**
-- [ ] 统一 client 支持连接复用与 rustls
-- [ ] 429/5xx/timeout/EOF 等异常路径可被标准化处理
-- [ ] stream 解析工具可被三个 provider 复用
+- [x] 统一 client 支持连接复用与 rustls
+- [x] 429/5xx/timeout/EOF 等异常路径可被标准化处理
+- [x] stream 解析工具可被三个 provider 复用
 
 ### Task 3.3.3: 实现首批三个 Provider Adapter
 **文件:** `src/llm/minimax.rs`, `src/llm/openai.rs`, `src/llm/deepseek.rs`

--- a/koduck-ai/src/llm/errors.rs
+++ b/koduck-ai/src/llm/errors.rs
@@ -1,0 +1,342 @@
+//! HTTP and stream error normalization helpers for provider-native LLM integrations.
+
+use reqwest::{
+    header::HeaderMap,
+    StatusCode,
+};
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::reliability::error::{AppError, ErrorCode, UpstreamService};
+
+pub fn map_http_transport_error(
+    upstream: UpstreamService,
+    request_id: impl Into<String>,
+    err: &reqwest::Error,
+) -> AppError {
+    let request_id = request_id.into();
+
+    let (code, message) = if err.is_timeout() {
+        (
+            ErrorCode::StreamTimeout,
+            "llm provider request timed out before the local deadline".to_string(),
+        )
+    } else if err.is_connect() {
+        (
+            ErrorCode::UpstreamUnavailable,
+            "llm provider connection failed".to_string(),
+        )
+    } else if err.is_body() || err.is_decode() {
+        (
+            ErrorCode::StreamInterrupted,
+            "llm provider stream body could not be read completely".to_string(),
+        )
+    } else {
+        (
+            ErrorCode::UpstreamUnavailable,
+            "llm provider request failed".to_string(),
+        )
+    };
+
+    AppError::new(code, message)
+        .with_request_id(request_id)
+        .with_upstream(upstream)
+        .with_source(HttpTransportSnapshot(err.to_string()))
+}
+
+pub fn map_http_status_error(
+    upstream: UpstreamService,
+    request_id: impl Into<String>,
+    status: StatusCode,
+    headers: &HeaderMap,
+    body: &str,
+) -> AppError {
+    let request_id = request_id.into();
+    let parsed = parse_error_payload(body);
+    let code = classify_error_code(status, parsed.code.as_deref());
+    let message = parsed
+        .message
+        .unwrap_or_else(|| default_message_for_status(status));
+
+    let mut err = AppError::new(code, message)
+        .with_request_id(request_id)
+        .with_upstream(upstream)
+        .with_source(HttpStatusSnapshot {
+            status,
+            body: truncate_for_snapshot(body),
+        });
+
+    if let Some(retry_after_ms) = parsed
+        .retry_after_ms
+        .or_else(|| retry_after_ms_from_headers(headers))
+    {
+        err = err.with_retry_after_ms(retry_after_ms);
+    }
+
+    err
+}
+
+pub fn map_stream_eof(
+    upstream: UpstreamService,
+    request_id: impl Into<String>,
+    context: &'static str,
+) -> AppError {
+    AppError::new(
+        ErrorCode::StreamInterrupted,
+        format!("llm provider stream ended before a complete {context} event was received"),
+    )
+    .with_request_id(request_id)
+    .with_upstream(upstream)
+}
+
+pub fn map_malformed_stream_chunk(
+    upstream: UpstreamService,
+    request_id: impl Into<String>,
+    context: &'static str,
+) -> AppError {
+    AppError::new(
+        ErrorCode::StreamInterrupted,
+        format!("llm provider stream emitted a malformed {context} chunk"),
+    )
+    .with_request_id(request_id)
+    .with_upstream(upstream)
+}
+
+fn classify_error_code(status: StatusCode, body_code: Option<&str>) -> ErrorCode {
+    if is_rate_limit_code(body_code) {
+        return ErrorCode::RateLimited;
+    }
+
+    match status {
+        StatusCode::BAD_REQUEST | StatusCode::UNPROCESSABLE_ENTITY => ErrorCode::InvalidArgument,
+        StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => ErrorCode::AuthFailed,
+        StatusCode::NOT_FOUND => ErrorCode::ResourceNotFound,
+        StatusCode::CONFLICT => ErrorCode::Conflict,
+        StatusCode::REQUEST_TIMEOUT | StatusCode::GATEWAY_TIMEOUT => ErrorCode::StreamTimeout,
+        StatusCode::TOO_MANY_REQUESTS => ErrorCode::RateLimited,
+        StatusCode::SERVICE_UNAVAILABLE => ErrorCode::ServerBusy,
+        StatusCode::BAD_GATEWAY => ErrorCode::UpstreamUnavailable,
+        _ if status.is_server_error() => ErrorCode::DependencyFailed,
+        _ => ErrorCode::DependencyFailed,
+    }
+}
+
+fn is_rate_limit_code(code: Option<&str>) -> bool {
+    code.map(|value| value.to_ascii_lowercase())
+        .map(|value| {
+            value.contains("rate")
+                || value.contains("quota")
+                || value.contains("too_many_requests")
+                || value.contains("resource_exhausted")
+        })
+        .unwrap_or(false)
+}
+
+fn default_message_for_status(status: StatusCode) -> String {
+    match status {
+        StatusCode::TOO_MANY_REQUESTS => "llm provider rate limit exceeded".to_string(),
+        StatusCode::SERVICE_UNAVAILABLE => "llm provider is temporarily busy".to_string(),
+        StatusCode::REQUEST_TIMEOUT | StatusCode::GATEWAY_TIMEOUT => {
+            "llm provider request timed out".to_string()
+        }
+        _ if status.is_server_error() => "llm provider returned a server error".to_string(),
+        _ => "llm provider request failed".to_string(),
+    }
+}
+
+fn retry_after_ms_from_headers(headers: &HeaderMap) -> Option<u64> {
+    headers
+        .get("retry-after-ms")
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .or_else(|| {
+            headers
+                .get("retry-after")
+                .and_then(|value| value.to_str().ok())
+                .and_then(|value| value.trim().parse::<u64>().ok())
+                .map(|seconds| seconds.saturating_mul(1000))
+        })
+}
+
+#[derive(Debug, Default)]
+struct ParsedErrorPayload {
+    message: Option<String>,
+    code: Option<String>,
+    retry_after_ms: Option<u64>,
+}
+
+fn parse_error_payload(body: &str) -> ParsedErrorPayload {
+    if body.trim().is_empty() {
+        return ParsedErrorPayload::default();
+    }
+
+    if let Ok(envelope) = serde_json::from_str::<OpenAiErrorEnvelope>(body) {
+        if let Some(error) = envelope.error {
+            return ParsedErrorPayload {
+                message: error.message.filter(|value| !value.trim().is_empty()),
+                code: error.code.and_then(json_value_to_string),
+                retry_after_ms: error.retry_after_ms,
+            };
+        }
+    }
+
+    if let Ok(envelope) = serde_json::from_str::<FlatErrorEnvelope>(body) {
+        return ParsedErrorPayload {
+            message: envelope
+                .message
+                .or(envelope.error_description)
+                .filter(|value| !value.trim().is_empty()),
+            code: envelope.code.and_then(json_value_to_string),
+            retry_after_ms: envelope.retry_after_ms,
+        };
+    }
+
+    ParsedErrorPayload {
+        message: Some(truncate_message(body)),
+        code: None,
+        retry_after_ms: None,
+    }
+}
+
+fn json_value_to_string(value: Value) -> Option<String> {
+    match value {
+        Value::Null => None,
+        Value::String(text) => Some(text),
+        other => Some(other.to_string()),
+    }
+}
+
+fn truncate_message(body: &str) -> String {
+    truncate_for_snapshot(body)
+}
+
+fn truncate_for_snapshot(body: &str) -> String {
+    const MAX_LEN: usize = 256;
+
+    if body.len() <= MAX_LEN {
+        body.to_string()
+    } else {
+        format!("{}...", &body[..MAX_LEN])
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAiErrorEnvelope {
+    error: Option<OpenAiErrorBody>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAiErrorBody {
+    message: Option<String>,
+    code: Option<Value>,
+    #[serde(default)]
+    retry_after_ms: Option<u64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct FlatErrorEnvelope {
+    message: Option<String>,
+    error_description: Option<String>,
+    code: Option<Value>,
+    #[serde(default)]
+    retry_after_ms: Option<u64>,
+}
+
+#[derive(Debug)]
+struct HttpTransportSnapshot(String);
+
+impl std::fmt::Display for HttpTransportSnapshot {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl std::error::Error for HttpTransportSnapshot {}
+
+#[derive(Debug)]
+struct HttpStatusSnapshot {
+    status: StatusCode,
+    body: String,
+}
+
+impl std::fmt::Display for HttpStatusSnapshot {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "status={} body={}", self.status, self.body)
+    }
+}
+
+impl std::error::Error for HttpStatusSnapshot {}
+
+#[cfg(test)]
+mod tests {
+    use reqwest::{
+        header::{HeaderMap, HeaderValue},
+        StatusCode,
+    };
+
+    use super::{
+        map_http_status_error, map_malformed_stream_chunk, map_stream_eof, retry_after_ms_from_headers,
+    };
+    use crate::reliability::error::{ErrorCode, UpstreamService};
+
+    #[test]
+    fn maps_429_with_retry_after_header() {
+        let mut headers = HeaderMap::new();
+        headers.insert("retry-after", HeaderValue::from_static("3"));
+
+        let err = map_http_status_error(
+            UpstreamService::Llm,
+            "req-1",
+            StatusCode::TOO_MANY_REQUESTS,
+            &headers,
+            r#"{"error":{"message":"rate limit","code":"rate_limit_exceeded"}}"#,
+        );
+
+        assert_eq!(err.code, ErrorCode::RateLimited);
+        assert_eq!(err.retry_after_ms, Some(3000));
+    }
+
+    #[test]
+    fn maps_503_to_server_busy() {
+        let err = map_http_status_error(
+            UpstreamService::Llm,
+            "req-2",
+            StatusCode::SERVICE_UNAVAILABLE,
+            &HeaderMap::new(),
+            r#"{"message":"temporarily unavailable"}"#,
+        );
+
+        assert_eq!(err.code, ErrorCode::ServerBusy);
+        assert_eq!(err.request_id.as_deref(), Some("req-2"));
+    }
+
+    #[test]
+    fn maps_gateway_timeout_to_stream_timeout() {
+        let err = map_http_status_error(
+            UpstreamService::Llm,
+            "req-3",
+            StatusCode::GATEWAY_TIMEOUT,
+            &HeaderMap::new(),
+            "",
+        );
+
+        assert_eq!(err.code, ErrorCode::StreamTimeout);
+    }
+
+    #[test]
+    fn parses_retry_after_ms_override_header() {
+        let mut headers = HeaderMap::new();
+        headers.insert("retry-after-ms", HeaderValue::from_static("1500"));
+
+        assert_eq!(retry_after_ms_from_headers(&headers), Some(1500));
+    }
+
+    #[test]
+    fn maps_stream_level_interruptions() {
+        let eof = map_stream_eof(UpstreamService::Llm, "req-4", "delta");
+        let malformed = map_malformed_stream_chunk(UpstreamService::Llm, "req-5", "sse");
+
+        assert_eq!(eof.code, ErrorCode::StreamInterrupted);
+        assert_eq!(malformed.code, ErrorCode::StreamInterrupted);
+    }
+}

--- a/koduck-ai/src/llm/http.rs
+++ b/koduck-ai/src/llm/http.rs
@@ -1,0 +1,350 @@
+//! Shared reqwest client, header injection, and SSE chunk parsing utilities for direct LLM providers.
+
+use std::time::Duration;
+
+use reqwest::{
+    header::{
+        HeaderMap, HeaderName, HeaderValue, ACCEPT, AUTHORIZATION, CONTENT_TYPE,
+    },
+    Client, Method, Request, Response,
+};
+use serde::Serialize;
+
+use crate::reliability::error::{AppError, ErrorCode, UpstreamService};
+
+use super::{
+    errors::{map_http_transport_error, map_malformed_stream_chunk, map_stream_eof},
+    types::RequestContext,
+};
+
+const X_REQUEST_ID: HeaderName = HeaderName::from_static("x-request-id");
+const TRACEPARENT: HeaderName = HeaderName::from_static("traceparent");
+
+#[derive(Clone)]
+pub struct LlmHttpClient {
+    inner: Client,
+}
+
+#[derive(Clone)]
+pub struct JsonRequestOptions {
+    pub url: String,
+    pub request_id: String,
+    pub deadline_ms: u64,
+    pub bearer_token: Option<String>,
+    pub traceparent: Option<String>,
+    pub accept: &'static str,
+    pub extra_headers: HeaderMap,
+}
+
+impl JsonRequestOptions {
+    pub fn json(url: impl Into<String>, meta: &RequestContext, bearer_token: Option<String>) -> Self {
+        Self {
+            url: url.into(),
+            request_id: meta.request_id.clone(),
+            deadline_ms: meta.deadline_ms,
+            bearer_token,
+            traceparent: (!meta.trace_id.trim().is_empty()).then(|| meta.trace_id.clone()),
+            accept: "application/json",
+            extra_headers: HeaderMap::new(),
+        }
+    }
+
+    pub fn event_stream(mut self) -> Self {
+        self.accept = "text/event-stream";
+        self
+    }
+
+    pub fn with_extra_header(mut self, name: HeaderName, value: HeaderValue) -> Self {
+        self.extra_headers.insert(name, value);
+        self
+    }
+}
+
+impl LlmHttpClient {
+    pub fn new() -> Result<Self, AppError> {
+        let inner = Client::builder()
+            .use_rustls_tls()
+            .connect_timeout(Duration::from_secs(3))
+            .pool_idle_timeout(Duration::from_secs(90))
+            .pool_max_idle_per_host(16)
+            .tcp_keepalive(Duration::from_secs(30))
+            .build()
+            .map_err(|err| {
+                AppError::new(
+                    ErrorCode::InternalError,
+                    "failed to build llm reqwest client",
+                )
+                .with_source(err)
+            })?;
+
+        Ok(Self { inner })
+    }
+
+    pub fn build_json_request<T: Serialize>(
+        &self,
+        method: Method,
+        options: &JsonRequestOptions,
+        body: &T,
+    ) -> Result<Request, AppError> {
+        let timeout = Duration::from_millis(options.deadline_ms.max(1));
+        let mut builder = self
+            .inner
+            .request(method, &options.url)
+            .timeout(timeout)
+            .header(CONTENT_TYPE, HeaderValue::from_static("application/json"))
+            .header(ACCEPT, HeaderValue::from_static(options.accept))
+            .header(X_REQUEST_ID, header_value(&options.request_id)?);
+
+        if let Some(traceparent) = options
+            .traceparent
+            .as_deref()
+            .filter(|value| !value.trim().is_empty())
+        {
+            builder = builder.header(TRACEPARENT, header_value(traceparent)?);
+        }
+
+        if let Some(token) = options
+            .bearer_token
+            .as_deref()
+            .filter(|value| !value.trim().is_empty())
+        {
+            builder = builder.header(AUTHORIZATION, header_value(&format!("Bearer {token}"))?);
+        }
+
+        for (name, value) in &options.extra_headers {
+            builder = builder.header(name, value);
+        }
+
+        builder.json(body).build().map_err(|err| {
+            AppError::new(ErrorCode::InvalidArgument, "failed to build llm http request")
+                .with_request_id(options.request_id.clone())
+                .with_upstream(UpstreamService::Llm)
+                .with_source(err)
+        })
+    }
+
+    pub async fn execute(
+        &self,
+        upstream: UpstreamService,
+        request_id: &str,
+        request: Request,
+    ) -> Result<Response, AppError> {
+        self.inner
+            .execute(request)
+            .await
+            .map_err(|err| map_http_transport_error(upstream, request_id.to_string(), &err))
+    }
+
+    pub async fn post_json<T: Serialize>(
+        &self,
+        upstream: UpstreamService,
+        options: &JsonRequestOptions,
+        body: &T,
+    ) -> Result<Response, AppError> {
+        let request = self.build_json_request(Method::POST, options, body)?;
+        self.execute(upstream, &options.request_id, request).await
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SseEvent {
+    pub event: Option<String>,
+    pub data: String,
+    pub id: Option<String>,
+}
+
+#[derive(Debug, Default)]
+pub struct SseStreamParser {
+    pending: Vec<u8>,
+    current_event: Option<String>,
+    current_id: Option<String>,
+    current_data: Vec<String>,
+}
+
+impl SseStreamParser {
+    pub fn push(
+        &mut self,
+        request_id: &str,
+        chunk: &[u8],
+    ) -> Result<Vec<SseEvent>, AppError> {
+        self.pending.extend_from_slice(chunk);
+        let mut events = Vec::new();
+
+        while let Some(line_end) = self.pending.iter().position(|byte| *byte == b'\n') {
+            let line_bytes = self.pending.drain(..=line_end).collect::<Vec<_>>();
+            let line = normalize_line(&line_bytes);
+
+            if line.is_empty() {
+                if let Some(event) = self.finish_event() {
+                    events.push(event);
+                }
+                continue;
+            }
+
+            if line.starts_with(':') {
+                continue;
+            }
+
+            let (field, value) = line
+                .split_once(':')
+                .map(|(field, value)| (field, value.trim_start()))
+                .unwrap_or((line.as_str(), ""));
+
+            match field {
+                "event" => self.current_event = Some(value.to_string()),
+                "id" => self.current_id = Some(value.to_string()),
+                "data" => self.current_data.push(value.to_string()),
+                "retry" => {}
+                _ => {
+                    return Err(map_malformed_stream_chunk(
+                        UpstreamService::Llm,
+                        request_id.to_string(),
+                        "sse",
+                    ))
+                }
+            }
+        }
+
+        Ok(events)
+    }
+
+    pub fn finish(&mut self, request_id: &str) -> Result<Vec<SseEvent>, AppError> {
+        if !self.pending.is_empty() {
+            return Err(map_stream_eof(
+                UpstreamService::Llm,
+                request_id.to_string(),
+                "sse",
+            ));
+        }
+
+        Ok(self.finish_event().into_iter().collect())
+    }
+
+    fn finish_event(&mut self) -> Option<SseEvent> {
+        if self.current_event.is_none() && self.current_id.is_none() && self.current_data.is_empty()
+        {
+            return None;
+        }
+
+        Some(SseEvent {
+            event: self.current_event.take(),
+            id: self.current_id.take(),
+            data: self.current_data.drain(..).collect::<Vec<_>>().join("\n"),
+        })
+    }
+}
+
+fn normalize_line(line_bytes: &[u8]) -> String {
+    let mut line = String::from_utf8_lossy(line_bytes).into_owned();
+    while line.ends_with('\n') || line.ends_with('\r') {
+        line.pop();
+    }
+    line
+}
+
+fn header_value(value: &str) -> Result<HeaderValue, AppError> {
+    HeaderValue::from_str(value).map_err(|err| {
+        AppError::new(ErrorCode::InvalidArgument, "invalid llm header value").with_source(err)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use reqwest::{
+        header::{HeaderValue, ACCEPT, AUTHORIZATION},
+        Method,
+    };
+    use serde_json::json;
+
+    use super::{JsonRequestOptions, LlmHttpClient, SseEvent, SseStreamParser};
+    use crate::llm::types::RequestContext;
+
+    fn sample_meta() -> RequestContext {
+        RequestContext {
+            request_id: "req-1".to_string(),
+            session_id: "sess-1".to_string(),
+            user_id: "user-1".to_string(),
+            trace_id: "00-abc-xyz-01".to_string(),
+            deadline_ms: 1_500,
+        }
+    }
+
+    #[test]
+    fn builds_json_request_with_common_headers_and_timeout() {
+        let client = LlmHttpClient::new().unwrap();
+        let options = JsonRequestOptions::json(
+            "https://example.com/v1/chat/completions",
+            &sample_meta(),
+            Some("secret-token".to_string()),
+        )
+        .with_extra_header(
+            reqwest::header::HeaderName::from_static("x-provider"),
+            HeaderValue::from_static("openai"),
+        );
+
+        let request = client
+            .build_json_request(Method::POST, &options, &json!({"model": "gpt"}))
+            .unwrap();
+
+        assert_eq!(request.timeout(), Some(Duration::from_millis(1_500)));
+        assert_eq!(
+            request.headers().get(ACCEPT),
+            Some(&HeaderValue::from_static("application/json"))
+        );
+        assert_eq!(
+            request.headers().get(AUTHORIZATION),
+            Some(&HeaderValue::from_static("Bearer secret-token"))
+        );
+        assert_eq!(
+            request.headers().get("x-request-id"),
+            Some(&HeaderValue::from_static("req-1"))
+        );
+        assert_eq!(
+            request.headers().get("traceparent"),
+            Some(&HeaderValue::from_static("00-abc-xyz-01"))
+        );
+        assert_eq!(
+            request.headers().get("x-provider"),
+            Some(&HeaderValue::from_static("openai"))
+        );
+    }
+
+    #[test]
+    fn sse_parser_reassembles_events_across_chunks() {
+        let mut parser = SseStreamParser::default();
+        let first = parser
+            .push("req-2", b"id: evt-1\nevent: message\ndata: hel")
+            .unwrap();
+        assert!(first.is_empty());
+
+        let second = parser
+            .push("req-2", b"lo\ndata: world\n\n")
+            .unwrap();
+
+        assert_eq!(
+            second,
+            vec![SseEvent {
+                event: Some("message".to_string()),
+                id: Some("evt-1".to_string()),
+                data: "hello\nworld".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn sse_parser_requires_complete_frame_before_finish() {
+        let mut parser = SseStreamParser::default();
+        parser.push("req-3", b"data: partial").unwrap();
+
+        let err = parser.finish("req-3").unwrap_err();
+        assert_eq!(err.code.to_string(), "STREAM_INTERRUPTED");
+    }
+
+    #[test]
+    fn event_stream_accept_header_can_be_switched() {
+        let options = JsonRequestOptions::json("https://example.com/stream", &sample_meta(), None)
+            .event_stream();
+
+        assert_eq!(options.accept, "text/event-stream");
+    }
+}

--- a/koduck-ai/src/llm/mod.rs
+++ b/koduck-ai/src/llm/mod.rs
@@ -1,10 +1,13 @@
 //! LLM provider adapter and routing.
 
 pub mod compat;
+pub mod errors;
+pub mod http;
 pub mod provider;
 pub mod types;
 
 pub use compat::AdapterLlmProvider;
+pub use http::{JsonRequestOptions, LlmHttpClient, SseEvent, SseStreamParser};
 pub use provider::{LlmProvider, ProviderEventStream};
 pub use types::{
     ChatMessage, CountTokensRequest, CountTokensResponse, GenerateRequest, GenerateResponse,


### PR DESCRIPTION
## Summary
- add shared reqwest client and JSON request builder for direct llm providers
- add reusable HTTP/stream error normalization and SSE chunk parsing helpers
- add ADR 0016 and mark task 3.3.2 complete

Closes #750