### PR TITLE
feat(koduck-ai): add direct llm provider adapters

### DIFF
--- a/koduck-ai/Cargo.toml
+++ b/koduck-ai/Cargo.toml
@@ -64,7 +64,7 @@ once_cell = "1.19"
 async-trait = "0.1"
 futures = "0.3"
 tokio-stream = { version = "0.1", features = ["sync"] }
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
 jsonwebtoken = "9.3"
 
 [build-dependencies]

--- a/koduck-ai/docs/adr/0017-openai-compatible-direct-provider-adapters.md
+++ b/koduck-ai/docs/adr/0017-openai-compatible-direct-provider-adapters.md
@@ -1,0 +1,114 @@
+# ADR-0017: 为 koduck-ai 落地首批 OpenAI-compatible direct provider adapters
+
+- Status: Accepted
+- Date: 2026-04-11
+- Issue: #752
+
+## Context
+
+根据 `koduck-ai/docs/design/ai-decoupled-architecture.md` 第 6.5 节和
+`koduck-ai/docs/implementation/koduck-ai-rust-grpc-tasks.md` Task 3.3.3：
+
+1. `koduck-ai` 需要默认走 provider-native HTTP 直连外部 LLM Provider。
+2. 首批支持 provider 为 `openai`、`deepseek`、`minimax`。
+3. 上层 orchestrator 只能依赖统一 `LlmProvider` trait，不允许泄漏厂商-specific HTTP 路径、body 或 stream chunk 结构。
+
+在本次任务开始前，仓库已经有：
+
+- `LlmProvider` 统一抽象
+- 兼容旧 `llm.proto` 的 `AdapterLlmProvider`
+- 共享 `reqwest`/SSE/HTTP 错误基础设施
+
+但还没有真正的 direct provider adapter，因此 `direct` 模式仍然缺少可以承接实际请求的实现。
+
+## Decision
+
+本次为 `openai`、`deepseek`、`minimax` 新增首批 direct provider adapter，并把公共 OpenAI-compatible 协议处理沉到一个共享实现中。
+
+### 1. 增加三个 provider 文件
+
+新增：
+
+- `src/llm/openai.rs`
+- `src/llm/deepseek.rs`
+- `src/llm/minimax.rs`
+
+其中：
+
+- `OpenAiProvider` 直接实现 OpenAI 官方接口适配
+- `DeepSeekProvider` 与 `MiniMaxProvider` 作为 wrapper，复用同一套 OpenAI-compatible HTTP 协议处理
+
+### 2. 在 adapter 内收敛厂商差异
+
+共享层负责：
+
+- `chat.completions` 请求构造
+- `stream=true` 的 SSE 增量解析
+- `models` 查询
+- 本地 token 估算
+- OpenAI-compatible 的响应体解析与标准化
+
+各 provider 仅暴露：
+
+- `provider` 标识
+- 默认 `base_url`
+- 默认 `model`
+- provider-specific 构造入口
+
+这样可以把厂商差异留在 `src/llm/` 内，而不扩散到 orchestrator 或 API 层。
+
+### 3. 使用本地 token 估算作为当前 count_tokens 实现
+
+考虑到并非所有 provider 都稳定提供独立 token count endpoint，本次 `count_tokens` 先采用本地估算：
+
+- 按 message 字符长度粗略折算
+- 保持统一返回结构
+
+这符合设计里“若厂商未提供，允许本地估算”的约束，也避免了在 Task 3.3.3 阶段引入额外 southbound 契约复杂度。
+
+### 4. 流式输出统一映射为 `StreamEvent`
+
+stream adapter 统一把 OpenAI-compatible SSE chunk 映射到：
+
+- `event_id`
+- `sequence_num`
+- `delta`
+- `finish_reason`
+- `usage`
+- `provider`
+- `model`
+
+并在 adapter 内处理：
+
+- `[DONE]`
+- 仅含 `finish_reason` 的尾事件
+- 仅含 `usage` 的尾事件
+- malformed chunk / 提前 EOF 的错误收敛
+
+## Consequences
+
+### 正向影响
+
+1. **首批 direct provider 已可落地**：`openai` / `deepseek` / `minimax` 都具备非流式和流式生成能力。
+2. **厂商差异被限制在 adapter 层**：上层继续只依赖 `LlmProvider`。
+3. **后续 router 接入更直接**：Task 3.3.4 只需要做配置和 provider 选择，不必再补 provider 具体协议代码。
+
+### 代价与风险
+
+1. **MiniMax 仍按 OpenAI-compatible 路径建模**：如果后续发现 MiniMax 某些高级能力需要额外字段，应继续在 `minimax.rs` 内收敛，不上浮到公共 trait。
+2. **count_tokens 当前是估算值**：精度不如厂商原生能力，但足以支撑现阶段能力探活与主链路衔接。
+
+### 兼容性影响
+
+- **对 northbound API 无破坏性变化**：本次只新增 direct provider adapter，不改现有主链路默认模式。
+- **对后续 direct 模式是前置能力补全**：为 Task 3.3.4 / 3.3.5 提供可切换的真实 provider 实现。
+
+## Alternatives Considered
+
+### 1. 分别在三个 provider 文件里复制完整 HTTP / stream 逻辑
+
+- **拒绝理由**：会造成请求构造、SSE 解析、错误处理和 usage 映射的大量重复，后续维护成本高。
+
+### 2. 继续只保留 `AdapterLlmProvider`
+
+- **拒绝理由**：这与设计的目标态相违背，也无法支撑后续 `direct` 作为默认模式的要求。

--- a/koduck-ai/docs/implementation/koduck-ai-rust-grpc-tasks.md
+++ b/koduck-ai/docs/implementation/koduck-ai-rust-grpc-tasks.md
@@ -210,9 +210,9 @@ cd koduck-ai
 4. 在各自 adapter 内收敛 provider-specific 字段和行为差异
 
 **验收标准:**
-- [ ] 三个 provider 均可完成非流式生成
-- [ ] 三个 provider 均可完成流式增量输出
-- [ ] 厂商差异不泄漏到公共 trait 和 orchestrator
+- [x] 三个 provider 均可完成非流式生成
+- [x] 三个 provider 均可完成流式增量输出
+- [x] 厂商差异不泄漏到公共 trait 和 orchestrator
 
 ### Task 3.3.4: 实现 Router 与模式切换
 **文件:** `src/llm/router.rs`, `src/config/mod.rs`

--- a/koduck-ai/src/llm/deepseek.rs
+++ b/koduck-ai/src/llm/deepseek.rs
@@ -1,0 +1,65 @@
+//! DeepSeek direct LLM provider adapter.
+
+use async_trait::async_trait;
+
+use crate::reliability::error::AppError;
+
+use super::{
+    openai::{OpenAiCompatibleProvider, ProviderProfile},
+    provider::{LlmProvider, ProviderEventStream},
+    types::{
+        CountTokensRequest, CountTokensResponse, GenerateRequest, GenerateResponse,
+        ListModelsRequest, ModelInfo,
+    },
+};
+
+const DEEPSEEK_PROFILE: ProviderProfile = ProviderProfile {
+    provider: "deepseek",
+    default_base_url: "https://api.deepseek.com/v1",
+    models_path: "/models",
+    chat_completions_path: "/chat/completions",
+};
+
+#[derive(Clone)]
+pub struct DeepSeekProvider {
+    inner: OpenAiCompatibleProvider,
+}
+
+impl DeepSeekProvider {
+    pub fn new(
+        api_key: impl Into<String>,
+        base_url: Option<String>,
+        default_model: impl Into<String>,
+    ) -> Result<Self, AppError> {
+        Ok(Self {
+            inner: OpenAiCompatibleProvider::new(
+                DEEPSEEK_PROFILE,
+                api_key.into(),
+                base_url,
+                default_model.into(),
+            )?,
+        })
+    }
+}
+
+#[async_trait]
+impl LlmProvider for DeepSeekProvider {
+    async fn generate(&self, req: GenerateRequest) -> Result<GenerateResponse, AppError> {
+        self.inner.generate_inner(req).await
+    }
+
+    async fn stream_generate(&self, req: GenerateRequest) -> Result<ProviderEventStream, AppError> {
+        self.inner.stream_generate_inner(req).await
+    }
+
+    async fn list_models(&self, req: ListModelsRequest) -> Result<Vec<ModelInfo>, AppError> {
+        self.inner.list_models_inner(req).await
+    }
+
+    async fn count_tokens(
+        &self,
+        req: CountTokensRequest,
+    ) -> Result<CountTokensResponse, AppError> {
+        self.inner.count_tokens_inner(req).await
+    }
+}

--- a/koduck-ai/src/llm/http.rs
+++ b/koduck-ai/src/llm/http.rs
@@ -80,11 +80,11 @@ impl LlmHttpClient {
         Ok(Self { inner })
     }
 
-    pub fn build_json_request<T: Serialize>(
+    pub fn build_request<T: Serialize>(
         &self,
         method: Method,
         options: &JsonRequestOptions,
-        body: &T,
+        body: Option<&T>,
     ) -> Result<Request, AppError> {
         let timeout = Duration::from_millis(options.deadline_ms.max(1));
         let mut builder = self
@@ -115,12 +115,27 @@ impl LlmHttpClient {
             builder = builder.header(name, value);
         }
 
-        builder.json(body).build().map_err(|err| {
+        let builder = if let Some(body) = body {
+            builder.json(body)
+        } else {
+            builder
+        };
+
+        builder.build().map_err(|err| {
             AppError::new(ErrorCode::InvalidArgument, "failed to build llm http request")
                 .with_request_id(options.request_id.clone())
                 .with_upstream(UpstreamService::Llm)
                 .with_source(err)
         })
+    }
+
+    pub fn build_json_request<T: Serialize>(
+        &self,
+        method: Method,
+        options: &JsonRequestOptions,
+        body: &T,
+    ) -> Result<Request, AppError> {
+        self.build_request(method, options, Some(body))
     }
 
     pub async fn execute(

--- a/koduck-ai/src/llm/minimax.rs
+++ b/koduck-ai/src/llm/minimax.rs
@@ -1,0 +1,65 @@
+//! MiniMax direct LLM provider adapter.
+
+use async_trait::async_trait;
+
+use crate::reliability::error::AppError;
+
+use super::{
+    openai::{OpenAiCompatibleProvider, ProviderProfile},
+    provider::{LlmProvider, ProviderEventStream},
+    types::{
+        CountTokensRequest, CountTokensResponse, GenerateRequest, GenerateResponse,
+        ListModelsRequest, ModelInfo,
+    },
+};
+
+const MINIMAX_PROFILE: ProviderProfile = ProviderProfile {
+    provider: "minimax",
+    default_base_url: "https://api.minimax.chat/v1",
+    models_path: "/models",
+    chat_completions_path: "/chat/completions",
+};
+
+#[derive(Clone)]
+pub struct MiniMaxProvider {
+    inner: OpenAiCompatibleProvider,
+}
+
+impl MiniMaxProvider {
+    pub fn new(
+        api_key: impl Into<String>,
+        base_url: Option<String>,
+        default_model: impl Into<String>,
+    ) -> Result<Self, AppError> {
+        Ok(Self {
+            inner: OpenAiCompatibleProvider::new(
+                MINIMAX_PROFILE,
+                api_key.into(),
+                base_url,
+                default_model.into(),
+            )?,
+        })
+    }
+}
+
+#[async_trait]
+impl LlmProvider for MiniMaxProvider {
+    async fn generate(&self, req: GenerateRequest) -> Result<GenerateResponse, AppError> {
+        self.inner.generate_inner(req).await
+    }
+
+    async fn stream_generate(&self, req: GenerateRequest) -> Result<ProviderEventStream, AppError> {
+        self.inner.stream_generate_inner(req).await
+    }
+
+    async fn list_models(&self, req: ListModelsRequest) -> Result<Vec<ModelInfo>, AppError> {
+        self.inner.list_models_inner(req).await
+    }
+
+    async fn count_tokens(
+        &self,
+        req: CountTokensRequest,
+    ) -> Result<CountTokensResponse, AppError> {
+        self.inner.count_tokens_inner(req).await
+    }
+}

--- a/koduck-ai/src/llm/mod.rs
+++ b/koduck-ai/src/llm/mod.rs
@@ -1,13 +1,19 @@
 //! LLM provider adapter and routing.
 
 pub mod compat;
+pub mod deepseek;
 pub mod errors;
 pub mod http;
+pub mod minimax;
+pub mod openai;
 pub mod provider;
 pub mod types;
 
 pub use compat::AdapterLlmProvider;
+pub use deepseek::DeepSeekProvider;
 pub use http::{JsonRequestOptions, LlmHttpClient, SseEvent, SseStreamParser};
+pub use minimax::MiniMaxProvider;
+pub use openai::OpenAiProvider;
 pub use provider::{LlmProvider, ProviderEventStream};
 pub use types::{
     ChatMessage, CountTokensRequest, CountTokensResponse, GenerateRequest, GenerateResponse,

--- a/koduck-ai/src/llm/openai.rs
+++ b/koduck-ai/src/llm/openai.rs
@@ -1,0 +1,807 @@
+//! OpenAI-compatible direct LLM provider adapters.
+
+use std::{
+    collections::VecDeque,
+    pin::Pin,
+};
+
+use async_trait::async_trait;
+use futures::{Stream, StreamExt};
+use hyper::body::Bytes;
+use reqwest::Method;
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+use crate::reliability::error::{AppError, ErrorCode, UpstreamService};
+
+use super::{
+    errors::{map_http_status_error, map_http_transport_error, map_malformed_stream_chunk, map_stream_eof},
+    http::{JsonRequestOptions, LlmHttpClient, SseEvent, SseStreamParser},
+    provider::{LlmProvider, ProviderEventStream},
+    types::{
+        ChatMessage, CountTokensRequest, CountTokensResponse, GenerateRequest, GenerateResponse,
+        ListModelsRequest, ModelInfo, StreamEvent, TokenUsage, ToolDefinition,
+    },
+};
+
+const OPENAI_PROFILE: ProviderProfile = ProviderProfile {
+    provider: "openai",
+    default_base_url: "https://api.openai.com/v1",
+    models_path: "/models",
+    chat_completions_path: "/chat/completions",
+};
+
+#[derive(Clone)]
+pub struct OpenAiProvider {
+    inner: OpenAiCompatibleProvider,
+}
+
+impl OpenAiProvider {
+    pub fn new(
+        api_key: impl Into<String>,
+        base_url: Option<String>,
+        default_model: impl Into<String>,
+    ) -> Result<Self, AppError> {
+        Ok(Self {
+            inner: OpenAiCompatibleProvider::new(
+                OPENAI_PROFILE,
+                api_key.into(),
+                base_url,
+                default_model.into(),
+            )?,
+        })
+    }
+}
+
+#[async_trait]
+impl LlmProvider for OpenAiProvider {
+    async fn generate(&self, req: GenerateRequest) -> Result<GenerateResponse, AppError> {
+        self.inner.generate_inner(req).await
+    }
+
+    async fn stream_generate(&self, req: GenerateRequest) -> Result<ProviderEventStream, AppError> {
+        self.inner.stream_generate_inner(req).await
+    }
+
+    async fn list_models(&self, req: ListModelsRequest) -> Result<Vec<ModelInfo>, AppError> {
+        self.inner.list_models_inner(req).await
+    }
+
+    async fn count_tokens(
+        &self,
+        req: CountTokensRequest,
+    ) -> Result<CountTokensResponse, AppError> {
+        self.inner.count_tokens_inner(req).await
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct ProviderProfile {
+    pub provider: &'static str,
+    pub default_base_url: &'static str,
+    pub models_path: &'static str,
+    pub chat_completions_path: &'static str,
+}
+
+#[derive(Clone)]
+pub(crate) struct OpenAiCompatibleProvider {
+    profile: ProviderProfile,
+    http: LlmHttpClient,
+    api_key: String,
+    base_url: String,
+    default_model: String,
+}
+
+impl OpenAiCompatibleProvider {
+    pub(crate) fn new(
+        profile: ProviderProfile,
+        api_key: String,
+        base_url: Option<String>,
+        default_model: String,
+    ) -> Result<Self, AppError> {
+        if api_key.trim().is_empty() {
+            return Err(AppError::new(
+                ErrorCode::InvalidArgument,
+                format!("{} api_key cannot be empty", profile.provider),
+            ));
+        }
+        if default_model.trim().is_empty() {
+            return Err(AppError::new(
+                ErrorCode::InvalidArgument,
+                format!("{} default_model cannot be empty", profile.provider),
+            ));
+        }
+
+        Ok(Self {
+            profile,
+            http: LlmHttpClient::new()?,
+            api_key,
+            base_url: sanitize_base_url(base_url.as_deref(), profile.default_base_url),
+            default_model,
+        })
+    }
+
+    pub(crate) async fn generate_inner(
+        &self,
+        req: GenerateRequest,
+    ) -> Result<GenerateResponse, AppError> {
+        let model = self.resolve_model(&req.model);
+        let body = build_chat_completions_request(&req, &model, false);
+        let options =
+            JsonRequestOptions::json(self.chat_completions_url(), &req.meta, Some(self.api_key.clone()));
+        let response = self
+            .http
+            .post_json(UpstreamService::Llm, &options, &body)
+            .await?;
+
+        let status = response.status();
+        let headers = response.headers().clone();
+        let text = response
+            .text()
+            .await
+            .map_err(|err| map_http_transport_error(UpstreamService::Llm, req.meta.request_id.clone(), &err))?;
+
+        if !status.is_success() {
+            return Err(map_http_status_error(
+                UpstreamService::Llm,
+                req.meta.request_id,
+                status,
+                &headers,
+                &text,
+            ));
+        }
+
+        let payload: OpenAiGenerateResponse = serde_json::from_str(&text).map_err(|err| {
+            AppError::new(
+                ErrorCode::DependencyFailed,
+                "llm provider returned an invalid generate response body",
+            )
+            .with_request_id(req.meta.request_id.clone())
+            .with_upstream(UpstreamService::Llm)
+            .with_source(err)
+        })?;
+
+        parse_generate_response(self.profile.provider, &model, payload, &req.meta.request_id)
+    }
+
+    pub(crate) async fn stream_generate_inner(
+        &self,
+        req: GenerateRequest,
+    ) -> Result<ProviderEventStream, AppError> {
+        let model = self.resolve_model(&req.model);
+        let body = build_chat_completions_request(&req, &model, true);
+        let options = JsonRequestOptions::json(
+            self.chat_completions_url(),
+            &req.meta,
+            Some(self.api_key.clone()),
+        )
+        .event_stream();
+        let response = self
+            .http
+            .post_json(UpstreamService::Llm, &options, &body)
+            .await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let headers = response.headers().clone();
+            let text = response
+                .text()
+                .await
+                .map_err(|err| map_http_transport_error(UpstreamService::Llm, req.meta.request_id.clone(), &err))?;
+            return Err(map_http_status_error(
+                UpstreamService::Llm,
+                req.meta.request_id,
+                status,
+                &headers,
+                &text,
+            ));
+        }
+
+        let state = StreamState {
+            provider: self.profile.provider.to_string(),
+            model,
+            request_id: req.meta.request_id,
+            inner: Box::pin(response.bytes_stream()),
+            parser: SseStreamParser::default(),
+            pending: VecDeque::new(),
+            sequence_num: 0,
+            saw_terminal_event: false,
+        };
+
+        let stream = futures::stream::try_unfold(state, |mut state| async move {
+            loop {
+                if let Some(event) = state.pending.pop_front() {
+                    return Ok(Some((event, state)));
+                }
+
+                match state.inner.next().await {
+                    Some(Ok(chunk)) => {
+                        let events = state.parser.push(&state.request_id, &chunk)?;
+                        for event in events {
+                            state.ingest_sse_event(event)?;
+                        }
+                    }
+                    Some(Err(err)) => {
+                        return Err(map_http_transport_error(
+                            UpstreamService::Llm,
+                            state.request_id.clone(),
+                            &err,
+                        ))
+                    }
+                    None => {
+                        let final_events = state.parser.finish(&state.request_id)?;
+                        for event in final_events {
+                            state.ingest_sse_event(event)?;
+                        }
+
+                        if let Some(event) = state.pending.pop_front() {
+                            return Ok(Some((event, state)));
+                        }
+
+                        if state.saw_terminal_event {
+                            return Ok(None);
+                        }
+
+                        return Err(map_stream_eof(
+                            UpstreamService::Llm,
+                            state.request_id,
+                            "stream completion",
+                        ));
+                    }
+                }
+            }
+        });
+
+        Ok(Box::pin(stream))
+    }
+
+    pub(crate) async fn list_models_inner(
+        &self,
+        req: ListModelsRequest,
+    ) -> Result<Vec<ModelInfo>, AppError> {
+        let options = JsonRequestOptions::json(
+            self.models_url(),
+            &req.meta,
+            Some(self.api_key.clone()),
+        );
+        let request = self
+            .http
+            .build_request::<Value>(Method::GET, &options, None)?;
+        let response = self
+            .http
+            .execute(UpstreamService::Llm, &req.meta.request_id, request)
+            .await?;
+
+        let status = response.status();
+        let headers = response.headers().clone();
+        let text = response
+            .text()
+            .await
+            .map_err(|err| map_http_transport_error(UpstreamService::Llm, req.meta.request_id.clone(), &err))?;
+
+        if !status.is_success() {
+            return Err(map_http_status_error(
+                UpstreamService::Llm,
+                req.meta.request_id,
+                status,
+                &headers,
+                &text,
+            ));
+        }
+
+        let payload: OpenAiModelsResponse = serde_json::from_str(&text).map_err(|err| {
+            AppError::new(
+                ErrorCode::DependencyFailed,
+                "llm provider returned an invalid models response body",
+            )
+            .with_request_id(req.meta.request_id.clone())
+            .with_upstream(UpstreamService::Llm)
+            .with_source(err)
+        })?;
+
+        Ok(payload
+            .data
+            .into_iter()
+            .map(|model| ModelInfo {
+                id: model.id.clone(),
+                provider: self.profile.provider.to_string(),
+                display_name: model.id,
+                max_context_tokens: 0,
+                max_output_tokens: 0,
+                supports_streaming: true,
+                supports_tools: true,
+                supported_features: vec![
+                    "chat".to_string(),
+                    "stream".to_string(),
+                    "count_tokens".to_string(),
+                ],
+            })
+            .collect())
+    }
+
+    pub(crate) async fn count_tokens_inner(
+        &self,
+        req: CountTokensRequest,
+    ) -> Result<CountTokensResponse, AppError> {
+        Ok(CountTokensResponse {
+            provider: self.profile.provider.to_string(),
+            model: self.resolve_model(&req.model),
+            total_tokens: estimate_tokens(&req.messages),
+        })
+    }
+
+    fn resolve_model(&self, requested: &str) -> String {
+        if requested.trim().is_empty() {
+            self.default_model.clone()
+        } else {
+            requested.to_string()
+        }
+    }
+
+    fn models_url(&self) -> String {
+        format!("{}{}", self.base_url, self.profile.models_path)
+    }
+
+    fn chat_completions_url(&self) -> String {
+        format!("{}{}", self.base_url, self.profile.chat_completions_path)
+    }
+}
+
+#[async_trait]
+impl LlmProvider for OpenAiCompatibleProvider {
+    async fn generate(&self, req: GenerateRequest) -> Result<GenerateResponse, AppError> {
+        self.generate_inner(req).await
+    }
+
+    async fn stream_generate(&self, req: GenerateRequest) -> Result<ProviderEventStream, AppError> {
+        self.stream_generate_inner(req).await
+    }
+
+    async fn list_models(&self, req: ListModelsRequest) -> Result<Vec<ModelInfo>, AppError> {
+        self.list_models_inner(req).await
+    }
+
+    async fn count_tokens(
+        &self,
+        req: CountTokensRequest,
+    ) -> Result<CountTokensResponse, AppError> {
+        self.count_tokens_inner(req).await
+    }
+}
+
+struct StreamState {
+    provider: String,
+    model: String,
+    request_id: String,
+    inner: Pin<Box<dyn Stream<Item = Result<Bytes, reqwest::Error>> + Send>>,
+    parser: SseStreamParser,
+    pending: VecDeque<StreamEvent>,
+    sequence_num: u32,
+    saw_terminal_event: bool,
+}
+
+impl StreamState {
+    fn ingest_sse_event(&mut self, event: SseEvent) -> Result<(), AppError> {
+        if event.data.trim() == "[DONE]" {
+            self.saw_terminal_event = true;
+            return Ok(());
+        }
+
+        let chunk: OpenAiStreamChunk = serde_json::from_str(&event.data).map_err(|_| {
+            map_malformed_stream_chunk(
+                UpstreamService::Llm,
+                self.request_id.clone(),
+                "json",
+            )
+        })?;
+
+        if let Some(unified) = parse_stream_chunk(
+            &self.provider,
+            &self.model,
+            event.id,
+            &mut self.sequence_num,
+            &mut self.saw_terminal_event,
+            chunk,
+        )? {
+            self.pending.push_back(unified);
+        }
+
+        Ok(())
+    }
+}
+
+fn build_chat_completions_request(
+    req: &GenerateRequest,
+    model: &str,
+    stream: bool,
+) -> Value {
+    let mut payload = json!({
+        "model": model,
+        "messages": req.messages.iter().map(message_to_wire).collect::<Vec<_>>(),
+        "temperature": req.temperature,
+        "top_p": req.top_p,
+        "max_tokens": req.max_tokens,
+        "stream": stream,
+    });
+
+    if !req.tools.is_empty() {
+        payload["tools"] = Value::Array(req.tools.iter().map(tool_to_wire).collect());
+    }
+
+    if !req.response_format.trim().is_empty() {
+        payload["response_format"] = response_format_to_wire(&req.response_format);
+    }
+
+    if stream {
+        payload["stream_options"] = json!({ "include_usage": true });
+    }
+
+    payload
+}
+
+fn message_to_wire(message: &ChatMessage) -> Value {
+    let mut value = json!({
+        "role": message.role,
+        "content": message.content,
+    });
+
+    if !message.name.trim().is_empty() {
+        value["name"] = Value::String(message.name.clone());
+    }
+
+    if !message.metadata.is_empty() {
+        value["metadata"] = serde_json::to_value(&message.metadata).unwrap_or(Value::Null);
+    }
+
+    value
+}
+
+fn tool_to_wire(tool: &ToolDefinition) -> Value {
+    json!({
+        "type": "function",
+        "function": {
+            "name": tool.name,
+            "description": tool.description,
+            "parameters": parse_json_or_string(&tool.input_schema),
+        }
+    })
+}
+
+fn response_format_to_wire(raw: &str) -> Value {
+    serde_json::from_str::<Value>(raw).unwrap_or_else(|_| json!({ "type": raw }))
+}
+
+fn parse_generate_response(
+    provider: &str,
+    model: &str,
+    payload: OpenAiGenerateResponse,
+    request_id: &str,
+) -> Result<GenerateResponse, AppError> {
+    let choice = payload.choices.into_iter().next().ok_or_else(|| {
+        AppError::new(
+            ErrorCode::DependencyFailed,
+            "llm provider returned an empty choices array",
+        )
+        .with_request_id(request_id.to_string())
+        .with_upstream(UpstreamService::Llm)
+    })?;
+
+    Ok(GenerateResponse {
+        provider: provider.to_string(),
+        model: payload.model.unwrap_or_else(|| model.to_string()),
+        message: ChatMessage {
+            role: choice.message.role.unwrap_or_else(|| "assistant".to_string()),
+            content: value_to_text(&choice.message.content),
+            name: String::new(),
+            metadata: Default::default(),
+        },
+        finish_reason: choice.finish_reason.unwrap_or_default(),
+        usage: payload.usage.map(usage_to_unified),
+    })
+}
+
+fn parse_stream_chunk(
+    provider: &str,
+    fallback_model: &str,
+    event_id: Option<String>,
+    sequence_num: &mut u32,
+    saw_terminal_event: &mut bool,
+    payload: OpenAiStreamChunk,
+) -> Result<Option<StreamEvent>, AppError> {
+    let choice = payload.choices.into_iter().next();
+    let delta = choice
+        .as_ref()
+        .and_then(|choice| choice.delta.as_ref())
+        .map(delta_to_text)
+        .unwrap_or_default();
+    let finish_reason = choice
+        .as_ref()
+        .and_then(|choice| choice.finish_reason.clone())
+        .unwrap_or_default();
+    let usage = payload.usage.map(usage_to_unified);
+
+    if !finish_reason.is_empty() {
+        *saw_terminal_event = true;
+    }
+
+    if delta.is_empty() && finish_reason.is_empty() && usage.is_none() {
+        return Ok(None);
+    }
+
+    *sequence_num += 1;
+
+    Ok(Some(StreamEvent {
+        provider: provider.to_string(),
+        model: payload.model.unwrap_or_else(|| fallback_model.to_string()),
+        event_id: event_id
+            .or(payload.id)
+            .unwrap_or_else(|| format!("evt-{}", *sequence_num)),
+        sequence_num: *sequence_num,
+        delta,
+        finish_reason,
+        usage,
+    }))
+}
+
+fn delta_to_text(delta: &OpenAiChoiceDelta) -> String {
+    delta.content.as_ref().map(value_to_text).unwrap_or_default()
+}
+
+fn usage_to_unified(usage: OpenAiUsage) -> TokenUsage {
+    TokenUsage {
+        prompt_tokens: usage.prompt_tokens.max(0) as u32,
+        completion_tokens: usage.completion_tokens.max(0) as u32,
+        total_tokens: usage.total_tokens.max(0) as u32,
+    }
+}
+
+fn value_to_text(value: &Value) -> String {
+    match value {
+        Value::Null => String::new(),
+        Value::String(text) => text.clone(),
+        Value::Array(items) => items
+            .iter()
+            .filter_map(|item| match item {
+                Value::String(text) => Some(text.clone()),
+                Value::Object(object) => object
+                    .get("text")
+                    .and_then(|value| value.as_str())
+                    .map(|value| value.to_string()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join(""),
+        other => other.to_string(),
+    }
+}
+
+fn parse_json_or_string(raw: &str) -> Value {
+    serde_json::from_str::<Value>(raw).unwrap_or_else(|_| Value::String(raw.to_string()))
+}
+
+fn sanitize_base_url(base_url: Option<&str>, fallback: &str) -> String {
+    let raw = base_url
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(fallback);
+    raw.trim_end_matches('/').to_string()
+}
+
+fn estimate_tokens(messages: &[ChatMessage]) -> u32 {
+    messages
+        .iter()
+        .map(|message| {
+            let text_len = message.content.chars().count() as u32;
+            let name_bonus = (!message.name.is_empty()) as u32;
+            (text_len / 4).max(1) + name_bonus + 4
+        })
+        .sum::<u32>()
+        .max(1)
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAiGenerateResponse {
+    model: Option<String>,
+    choices: Vec<OpenAiGenerateChoice>,
+    usage: Option<OpenAiUsage>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAiGenerateChoice {
+    message: OpenAiResponseMessage,
+    finish_reason: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAiResponseMessage {
+    role: Option<String>,
+    #[serde(default)]
+    content: Value,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAiUsage {
+    prompt_tokens: i64,
+    completion_tokens: i64,
+    total_tokens: i64,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAiStreamChunk {
+    id: Option<String>,
+    model: Option<String>,
+    #[serde(default)]
+    choices: Vec<OpenAiStreamChoice>,
+    usage: Option<OpenAiUsage>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAiStreamChoice {
+    delta: Option<OpenAiChoiceDelta>,
+    finish_reason: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAiChoiceDelta {
+    content: Option<Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAiModelsResponse {
+    data: Vec<OpenAiModelEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAiModelEntry {
+    id: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use serde_json::json;
+
+    use super::{
+        build_chat_completions_request, parse_generate_response, parse_stream_chunk,
+        OpenAiGenerateResponse, OpenAiGenerateChoice, OpenAiResponseMessage, OpenAiStreamChunk,
+        OpenAiStreamChoice, OpenAiChoiceDelta, OpenAiUsage,
+    };
+    use crate::llm::types::{ChatMessage, GenerateRequest, RequestContext, ToolDefinition};
+
+    fn sample_request() -> GenerateRequest {
+        GenerateRequest {
+            meta: RequestContext {
+                request_id: "req-1".to_string(),
+                session_id: "sess-1".to_string(),
+                user_id: "user-1".to_string(),
+                trace_id: "trace-1".to_string(),
+                deadline_ms: 1500,
+            },
+            provider: "openai".to_string(),
+            model: "gpt-4.1-mini".to_string(),
+            messages: vec![ChatMessage {
+                role: "user".to_string(),
+                content: "hello".to_string(),
+                name: String::new(),
+                metadata: HashMap::new(),
+            }],
+            temperature: 0.2,
+            top_p: 0.9,
+            max_tokens: 256,
+            tools: vec![ToolDefinition {
+                name: "search".to_string(),
+                description: "Search docs".to_string(),
+                input_schema: r#"{"type":"object"}"#.to_string(),
+            }],
+            response_format: "json_object".to_string(),
+        }
+    }
+
+    #[test]
+    fn builds_openai_wire_request() {
+        let body = build_chat_completions_request(&sample_request(), "gpt-4.1-mini", true);
+
+        assert_eq!(body["model"], "gpt-4.1-mini");
+        assert_eq!(body["stream"], true);
+        assert_eq!(body["messages"][0]["content"], "hello");
+        assert_eq!(body["tools"][0]["function"]["name"], "search");
+        assert_eq!(body["response_format"]["type"], "json_object");
+        assert_eq!(body["stream_options"]["include_usage"], true);
+    }
+
+    #[test]
+    fn parses_non_stream_response_into_unified_shape() {
+        let payload = OpenAiGenerateResponse {
+            model: Some("gpt-4.1-mini".to_string()),
+            choices: vec![OpenAiGenerateChoice {
+                message: OpenAiResponseMessage {
+                    role: Some("assistant".to_string()),
+                    content: json!("world"),
+                },
+                finish_reason: Some("stop".to_string()),
+            }],
+            usage: Some(OpenAiUsage {
+                prompt_tokens: 10,
+                completion_tokens: 5,
+                total_tokens: 15,
+            }),
+        };
+
+        let response =
+            parse_generate_response("openai", "fallback-model", payload, "req-1").unwrap();
+
+        assert_eq!(response.provider, "openai");
+        assert_eq!(response.model, "gpt-4.1-mini");
+        assert_eq!(response.message.content, "world");
+        assert_eq!(response.finish_reason, "stop");
+        assert_eq!(response.usage.unwrap().total_tokens, 15);
+    }
+
+    #[test]
+    fn parses_stream_chunks_into_unified_events() {
+        let mut sequence_num = 0;
+        let mut saw_terminal_event = false;
+        let payload = OpenAiStreamChunk {
+            id: Some("chunk-1".to_string()),
+            model: Some("gpt-4.1-mini".to_string()),
+            choices: vec![OpenAiStreamChoice {
+                delta: Some(OpenAiChoiceDelta {
+                    content: Some(json!("hello")),
+                }),
+                finish_reason: None,
+            }],
+            usage: None,
+        };
+
+        let event = parse_stream_chunk(
+            "openai",
+            "fallback-model",
+            Some("evt-1".to_string()),
+            &mut sequence_num,
+            &mut saw_terminal_event,
+            payload,
+        )
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(event.sequence_num, 1);
+        assert_eq!(event.delta, "hello");
+        assert!(!saw_terminal_event);
+    }
+
+    #[test]
+    fn parses_terminal_stream_chunk_with_usage() {
+        let mut sequence_num = 0;
+        let mut saw_terminal_event = false;
+        let payload = OpenAiStreamChunk {
+            id: Some("chunk-2".to_string()),
+            model: None,
+            choices: vec![OpenAiStreamChoice {
+                delta: Some(OpenAiChoiceDelta { content: None }),
+                finish_reason: Some("stop".to_string()),
+            }],
+            usage: Some(OpenAiUsage {
+                prompt_tokens: 7,
+                completion_tokens: 9,
+                total_tokens: 16,
+            }),
+        };
+
+        let event = parse_stream_chunk(
+            "openai",
+            "fallback-model",
+            None,
+            &mut sequence_num,
+            &mut saw_terminal_event,
+            payload,
+        )
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(event.model, "fallback-model");
+        assert_eq!(event.finish_reason, "stop");
+        assert_eq!(event.usage.unwrap().total_tokens, 16);
+        assert!(saw_terminal_event);
+    }
+}


### PR DESCRIPTION
## Summary
- add direct provider adapters for openai, deepseek, and minimax
- reuse shared reqwest, SSE, and error normalization infrastructure
- add ADR 0017 and mark task 3.3.3 complete

Closes #752