### PR TITLE
feat(koduck-ai): add llm router and mode switch

### DIFF
--- a/koduck-ai/Cargo.lock
+++ b/koduck-ai/Cargo.lock
@@ -1841,6 +1841,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-core",
+ "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
@@ -1860,12 +1861,14 @@ dependencies = [
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-rustls 0.26.4",
+ "tokio-util",
  "tower 0.5.3",
  "tower-http 0.6.8",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots",
 ]
@@ -2951,6 +2954,19 @@ dependencies = [
  "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/koduck-ai/docs/adr/0018-llm-router-mode-switch-and-explicit-provider-selection.md
+++ b/koduck-ai/docs/adr/0018-llm-router-mode-switch-and-explicit-provider-selection.md
@@ -1,0 +1,126 @@
+# ADR-0018: 为 koduck-ai 引入 LLM Router、模式切换与显式 Provider 选择
+
+- Status: Accepted
+- Date: 2026-04-11
+- Issue: #754
+
+## Context
+
+根据 `koduck-ai/docs/design/ai-decoupled-architecture.md` 第 6.5 节和
+`koduck-ai/docs/implementation/koduck-ai-rust-grpc-tasks.md` Task 3.3.4：
+
+1. `koduck-ai` 需要支持 `llm.mode = direct | adapter` 的模式切换。
+2. `direct` 需要成为默认模式，`adapter` 仅保留为迁移兼容与回滚开关。
+3. 路由选择必须同时支持 `provider`、`model` 前缀和 `default_provider`。
+4. 多 provider 配置必须独立管理 `enabled/api_key/base_url/default_model`，并且不能发生静默 fallback。
+
+在本次任务开始前，仓库已经具备：
+
+- 统一的 `LlmProvider` trait
+- `AdapterLlmProvider` 兼容实现
+- `openai` / `deepseek` / `minimax` direct provider adapter
+
+但还缺少一层统一 router 来在 direct 与 adapter 之间切换，也缺少独立的 provider 配置结构。
+
+## Decision
+
+本次引入 `LlmRouter`，作为 `AppState.llm_provider` 的统一入口，在启动期完成模式装配，在请求期完成 provider 路由解析。
+
+### 1. 引入 `llm.mode` 与分 provider 配置
+
+在 `src/config/mod.rs` 中：
+
+- 新增 `LlmMode`
+  - `direct`
+  - `adapter`
+- 将原先扁平的 LLM 配置改为：
+  - `llm.openai`
+  - `llm.deepseek`
+  - `llm.minimax`
+
+每个 provider 独立配置：
+
+- `enabled`
+- `api_key`
+- `base_url`
+- `default_model`
+
+默认值选择：
+
+- `direct` 为默认模式
+- `openai` 默认启用
+- `deepseek` / `minimax` 默认关闭，避免未显式配置时影响默认直连路径
+
+### 2. 引入 `LlmRouter` 统一处理 direct | adapter 路由
+
+新增 `src/llm/router.rs`，并在 `src/app/mod.rs` 中替换原先固定注入的 `AdapterLlmProvider`。
+
+`LlmRouter` 负责：
+
+- 根据 `llm.mode` 选择 direct 或 adapter 路径
+- 根据显式 `provider`、`model` 前缀或 `default_provider` 解析目标 provider
+- 将解析后的统一请求下发给对应 provider 实现
+
+请求路由优先级为：
+
+1. `request.provider`
+2. `request.model` 中的 provider 前缀，如 `openai:gpt-4.1-mini`
+3. `request.model` 中的 provider path 前缀，如 `deepseek/deepseek-chat`
+4. `llm.default_provider`
+
+### 3. direct 模式只允许显式启用、显式报错
+
+在 `direct` 模式下：
+
+- 仅对 `enabled=true` 的 provider 视为可路由目标
+- 如果请求指向未启用 provider，立即返回错误
+- 如果 provider 被启用但缺失运行时凭证，也立即返回错误
+
+这样保证：
+
+- 不会从 `deepseek` 静默跳到 `openai`
+- 不会从 direct 静默回落到 adapter
+- 错误由调用方显式感知，可用于后续降级或回滚策略
+
+### 4. adapter 模式保留现有 `llm.proto` 兼容链路
+
+在 `adapter` 模式下，router 统一转发到 `AdapterLlmProvider`：
+
+- provider 解析规则仍然保留
+- 但真正下游链路仍是现有 `llm.proto` / gRPC adapter
+
+这保证迁移期间可以通过单个开关切回旧链路。
+
+## Consequences
+
+### 正向影响
+
+1. **direct 成为默认模式**：后续主链路可以在不再感知 gRPC adapter 的前提下继续推进。
+2. **回滚路径简单清晰**：把 `llm.mode` 切到 `adapter` 即可恢复旧 southbound 链路。
+3. **provider 选择行为可预测**：所有 fallback 都变成显式错误，不会产生隐藏流量漂移。
+4. **多 provider 配置边界清晰**：各 provider 的 base_url、default_model、api_key 可独立演进。
+
+### 代价与风险
+
+1. **配置项增多**：部署侧需要理解 `mode` 与各 provider 独立配置。
+2. **未启用或未配 key 的 provider 会快速失败**：这会更早暴露配置问题，但不会再由系统偷偷兜底。
+
+### 兼容性影响
+
+- **对 northbound API 无破坏性变化**：`/chat`、`/chat/stream` 输入输出契约不变。
+- **对 southbound 链路引入显式开关**：默认从固定 adapter 注入切换为 router 注入。
+- **对运维配置有增量要求**：需要按 provider 设置独立配置项；旧 `adapter_grpc_target` 仍保留用于兼容模式。
+
+## Alternatives Considered
+
+### 1. 继续固定注入 `AdapterLlmProvider`
+
+- **拒绝理由**：无法满足 direct 为默认模式的设计目标，也无法形成显式回滚开关。
+
+### 2. 允许 direct 模式自动回落到 default provider 或 adapter
+
+- **拒绝理由**：会导致请求真实流向不可预测，不利于灰度、回滚和问题定位。
+
+### 3. 将所有 provider 默认一起启用
+
+- **拒绝理由**：在凭证尚未完整配置时会放大默认配置复杂度，不利于“默认可用”的目标。

--- a/koduck-ai/docs/implementation/koduck-ai-rust-grpc-tasks.md
+++ b/koduck-ai/docs/implementation/koduck-ai-rust-grpc-tasks.md
@@ -224,9 +224,9 @@ cd koduck-ai
 4. 增加按 provider 独立配置：`api_key/base_url/default_model`
 
 **验收标准:**
-- [ ] `direct` 模式默认可用
-- [ ] `adapter` 模式可回退到现有 `llm.proto` 链路
-- [ ] provider fallback 不会静默发生
+- [x] `direct` 模式默认可用
+- [x] `adapter` 模式可回退到现有 `llm.proto` 链路
+- [x] provider fallback 不会静默发生
 
 ### Task 3.3.5: 接入主链路并完成能力探活
 **文件:** `src/api/mod.rs`, `src/llm/router.rs`, `src/clients/capability.rs`

--- a/koduck-ai/src/api/mod.rs
+++ b/koduck-ai/src/api/mod.rs
@@ -710,7 +710,7 @@ async fn call_llm_stream(
 }
 
 fn build_provider_generate_request(
-    state: &Arc<AppState>,
+    _state: &Arc<AppState>,
     request: &ChatRequest,
     request_id: &str,
     session_id: &str,
@@ -726,11 +726,8 @@ fn build_provider_generate_request(
             trace_id: trace_id.to_string(),
             deadline_ms,
         },
-        provider: state.config.llm.default_provider.clone(),
-        model: request
-            .model
-            .clone()
-            .unwrap_or_else(|| state.config.llm.default_provider.clone()),
+        provider: String::new(),
+        model: request.model.clone().unwrap_or_default(),
         messages: vec![ProviderChatMessage {
             role: "user".to_string(),
             content: request.message.clone(),

--- a/koduck-ai/src/app/mod.rs
+++ b/koduck-ai/src/app/mod.rs
@@ -12,7 +12,7 @@ use tower_http::trace::TraceLayer;
 
 use crate::api;
 use crate::config::Config;
-use crate::llm::{AdapterLlmProvider, LlmProvider};
+use crate::llm::{build_provider_router, LlmProvider};
 use crate::reliability::degrade::DegradePolicy;
 use crate::reliability::retry_budget::RetryBudgetPolicy;
 use crate::stream::sse::StreamRegistry;
@@ -51,9 +51,8 @@ pub fn build_state(config: Config) -> Arc<AppState> {
 
     Arc::new(AppState {
         degrade_policy: Arc::new(DegradePolicy::new(config.reliability.degrade.clone())),
-        llm_provider: Arc::new(AdapterLlmProvider::new(
-            config.llm.adapter_grpc_target.clone(),
-        )),
+        llm_provider: build_provider_router(&config)
+            .expect("failed to build llm provider router from config"),
         retry_budget_policy: Arc::new(RetryBudgetPolicy::new(config.reliability.retry.clone())),
         config,
         stream_registry: Arc::new(StreamRegistry::default()),

--- a/koduck-ai/src/config/mod.rs
+++ b/koduck-ai/src/config/mod.rs
@@ -6,6 +6,7 @@
 use config::{Config as ConfigBuilder, ConfigError, Environment, File};
 use secrecy::{ExposeSecret, SecretString};
 use serde::Deserialize;
+use strum::{Display, EnumString};
 use std::fmt;
 
 /// Custom validation error for configuration
@@ -64,18 +65,31 @@ pub struct ToolConfig {
 /// LLM adapter configuration
 #[derive(Debug, Deserialize, Clone)]
 pub struct LlmConfig {
+    pub mode: LlmMode,
     pub adapter_grpc_target: String,
     pub default_provider: String,
     pub timeout_ms: u64,
     /// Enable local stub response when downstream LLM adapter is not ready.
     pub stub_enabled: bool,
-    /// API keys per provider — wrapped in SecretString to prevent log leakage.
-    #[serde(default)]
-    pub openai_api_key: Option<SecretString>,
-    #[serde(default)]
-    pub deepseek_api_key: Option<SecretString>,
-    #[serde(default)]
-    pub anthropic_api_key: Option<SecretString>,
+    pub openai: LlmProviderConfig,
+    pub deepseek: LlmProviderConfig,
+    pub minimax: LlmProviderConfig,
+}
+
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, Display, EnumString)]
+#[serde(rename_all = "lowercase")]
+#[strum(serialize_all = "lowercase")]
+pub enum LlmMode {
+    Direct,
+    Adapter,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct LlmProviderConfig {
+    pub enabled: bool,
+    pub api_key: Option<SecretString>,
+    pub base_url: String,
+    pub default_model: String,
 }
 
 /// Stream / SSE transport configuration
@@ -189,7 +203,69 @@ impl LlmConfig {
                 message: "llm.adapter_grpc_target cannot be empty".to_string(),
             });
         }
+        self.provider_config("openai").unwrap().validate("llm.openai")?;
+        self.provider_config("deepseek").unwrap().validate("llm.deepseek")?;
+        self.provider_config("minimax").unwrap().validate("llm.minimax")?;
+
+        match self.mode {
+            LlmMode::Direct => {
+                let default_provider = self.default_provider.trim();
+                let default_config = self.provider_config(default_provider).ok_or_else(|| {
+                    ValidationError {
+                        message: format!(
+                            "llm.default_provider '{}' is not supported; expected one of openai, deepseek, minimax",
+                            default_provider
+                        ),
+                    }
+                })?;
+                if !default_config.enabled {
+                    return Err(ValidationError {
+                        message: format!(
+                            "llm.default_provider '{}' must reference an enabled provider in direct mode",
+                            default_provider
+                        ),
+                    });
+                }
+            }
+            LlmMode::Adapter => {}
+        }
         Ok(())
+    }
+
+    pub fn provider_config(&self, provider: &str) -> Option<&LlmProviderConfig> {
+        match provider.trim().to_ascii_lowercase().as_str() {
+            "openai" => Some(&self.openai),
+            "deepseek" => Some(&self.deepseek),
+            "minimax" => Some(&self.minimax),
+            _ => None,
+        }
+    }
+}
+
+impl LlmProviderConfig {
+    pub fn validate(&self, field_name: &str) -> Result<(), ValidationError> {
+        if self.default_model.trim().is_empty() {
+            return Err(ValidationError {
+                message: format!("{field_name}.default_model cannot be empty"),
+            });
+        }
+        if self.base_url.trim().is_empty() {
+            return Err(ValidationError {
+                message: format!("{field_name}.base_url cannot be empty"),
+            });
+        }
+        Ok(())
+    }
+}
+
+impl Default for LlmProviderConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            api_key: None,
+            base_url: String::new(),
+            default_model: String::new(),
+        }
     }
 }
 
@@ -329,13 +405,29 @@ impl Default for ToolConfig {
 impl Default for LlmConfig {
     fn default() -> Self {
         Self {
+            mode: LlmMode::Direct,
             adapter_grpc_target: "http://localhost:50054".to_string(),
             default_provider: "openai".to_string(),
             timeout_ms: 30_000,
             stub_enabled: false,
-            openai_api_key: None,
-            deepseek_api_key: None,
-            anthropic_api_key: None,
+            openai: LlmProviderConfig {
+                enabled: true,
+                api_key: None,
+                base_url: "https://api.openai.com/v1".to_string(),
+                default_model: "gpt-4.1-mini".to_string(),
+            },
+            deepseek: LlmProviderConfig {
+                enabled: false,
+                api_key: None,
+                base_url: "https://api.deepseek.com/v1".to_string(),
+                default_model: "deepseek-chat".to_string(),
+            },
+            minimax: LlmProviderConfig {
+                enabled: false,
+                api_key: None,
+                base_url: "https://api.minimax.chat/v1".to_string(),
+                default_model: "MiniMax-M1".to_string(),
+            },
         }
     }
 }
@@ -442,10 +534,20 @@ impl Config {
             // Defaults — ToolConfig
             .set_default("tools.grpc_target", "http://localhost:50053")?
             // Defaults — LlmConfig
+            .set_default("llm.mode", "direct")?
             .set_default("llm.adapter_grpc_target", "http://localhost:50054")?
             .set_default("llm.default_provider", "openai")?
             .set_default("llm.timeout_ms", 30_000)?
             .set_default("llm.stub_enabled", false)?
+            .set_default("llm.openai.enabled", true)?
+            .set_default("llm.openai.base_url", "https://api.openai.com/v1")?
+            .set_default("llm.openai.default_model", "gpt-4.1-mini")?
+            .set_default("llm.deepseek.enabled", false)?
+            .set_default("llm.deepseek.base_url", "https://api.deepseek.com/v1")?
+            .set_default("llm.deepseek.default_model", "deepseek-chat")?
+            .set_default("llm.minimax.enabled", false)?
+            .set_default("llm.minimax.base_url", "https://api.minimax.chat/v1")?
+            .set_default("llm.minimax.default_model", "MiniMax-M1")?
             // Defaults — StreamConfig
             .set_default("stream.max_duration_ms", 300_000)?
             .set_default("stream.queue_capacity", 64)?
@@ -507,15 +609,15 @@ impl Config {
     /// Expose a provider API key for use in LLM client initialization.
     /// Returns `None` if the key is not configured.
     pub fn openai_api_key(&self) -> Option<&str> {
-        self.llm.openai_api_key.as_ref().map(|k| k.expose_secret().as_str())
+        self.llm.openai.api_key.as_ref().map(|k| k.expose_secret().as_str())
     }
 
     pub fn deepseek_api_key(&self) -> Option<&str> {
-        self.llm.deepseek_api_key.as_ref().map(|k| k.expose_secret().as_str())
+        self.llm.deepseek.api_key.as_ref().map(|k| k.expose_secret().as_str())
     }
 
-    pub fn anthropic_api_key(&self) -> Option<&str> {
-        self.llm.anthropic_api_key.as_ref().map(|k| k.expose_secret().as_str())
+    pub fn minimax_api_key(&self) -> Option<&str> {
+        self.llm.minimax.api_key.as_ref().map(|k| k.expose_secret().as_str())
     }
 }
 
@@ -527,10 +629,11 @@ impl fmt::Display for Config {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "Config {{ server: {:?}, memory: {:?}, tools: {:?}, llm: LlmConfig {{ adapter_grpc_target: {:?}, default_provider: {:?}, timeout_ms: {}, stub_enabled: {}, api_keys: ***, ... }}, stream: {:?}, auth: {:?}, capabilities: {:?}, reliability: {:?} }}",
+            "Config {{ server: {:?}, memory: {:?}, tools: {:?}, llm: LlmConfig {{ mode: {:?}, adapter_grpc_target: {:?}, default_provider: {:?}, timeout_ms: {}, stub_enabled: {}, providers: ***, ... }}, stream: {:?}, auth: {:?}, capabilities: {:?}, reliability: {:?} }}",
             self.server,
             self.memory,
             self.tools,
+            self.llm.mode,
             self.llm.adapter_grpc_target,
             self.llm.default_provider,
             self.llm.timeout_ms,
@@ -701,8 +804,18 @@ mod tests {
             memory: MemoryConfig::default(),
             tools: ToolConfig::default(),
             llm: LlmConfig {
-                openai_api_key: Some(SecretString::from("sk-super-secret-key".to_string())),
-                deepseek_api_key: Some(SecretString::from("sk-another-secret".to_string())),
+                openai: LlmProviderConfig {
+                    api_key: Some(SecretString::from("sk-super-secret-key".to_string())),
+                    enabled: true,
+                    base_url: "https://api.openai.com/v1".to_string(),
+                    default_model: "gpt-4.1-mini".to_string(),
+                },
+                deepseek: LlmProviderConfig {
+                    api_key: Some(SecretString::from("sk-another-secret".to_string())),
+                    enabled: true,
+                    base_url: "https://api.deepseek.com/v1".to_string(),
+                    default_model: "deepseek-chat".to_string(),
+                },
                 ..LlmConfig::default()
             },
             stream: StreamConfig::default(),
@@ -723,9 +836,24 @@ mod tests {
             memory: MemoryConfig::default(),
             tools: ToolConfig::default(),
             llm: LlmConfig {
-                openai_api_key: Some(SecretString::from("sk-test".to_string())),
-                deepseek_api_key: None,
-                anthropic_api_key: Some(SecretString::from("sk-anthropic".to_string())),
+                openai: LlmProviderConfig {
+                    api_key: Some(SecretString::from("sk-test".to_string())),
+                    enabled: true,
+                    base_url: "https://api.openai.com/v1".to_string(),
+                    default_model: "gpt-4.1-mini".to_string(),
+                },
+                deepseek: LlmProviderConfig {
+                    api_key: None,
+                    enabled: true,
+                    base_url: "https://api.deepseek.com/v1".to_string(),
+                    default_model: "deepseek-chat".to_string(),
+                },
+                minimax: LlmProviderConfig {
+                    api_key: Some(SecretString::from("sk-minimax".to_string())),
+                    enabled: true,
+                    base_url: "https://api.minimax.chat/v1".to_string(),
+                    default_model: "MiniMax-M1".to_string(),
+                },
                 ..LlmConfig::default()
             },
             stream: StreamConfig::default(),
@@ -735,7 +863,7 @@ mod tests {
         };
         assert_eq!(config.openai_api_key(), Some("sk-test"));
         assert_eq!(config.deepseek_api_key(), None);
-        assert_eq!(config.anthropic_api_key(), Some("sk-anthropic"));
+        assert_eq!(config.minimax_api_key(), Some("sk-minimax"));
     }
 
     #[test]

--- a/koduck-ai/src/llm/http.rs
+++ b/koduck-ai/src/llm/http.rs
@@ -265,6 +265,8 @@ fn header_value(value: &str) -> Result<HeaderValue, AppError> {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use reqwest::{
         header::{HeaderValue, ACCEPT, AUTHORIZATION},
         Method,

--- a/koduck-ai/src/llm/mod.rs
+++ b/koduck-ai/src/llm/mod.rs
@@ -7,6 +7,7 @@ pub mod http;
 pub mod minimax;
 pub mod openai;
 pub mod provider;
+pub mod router;
 pub mod types;
 
 pub use compat::AdapterLlmProvider;
@@ -15,6 +16,7 @@ pub use http::{JsonRequestOptions, LlmHttpClient, SseEvent, SseStreamParser};
 pub use minimax::MiniMaxProvider;
 pub use openai::OpenAiProvider;
 pub use provider::{LlmProvider, ProviderEventStream};
+pub use router::{build_provider_router, LlmRouter};
 pub use types::{
     ChatMessage, CountTokensRequest, CountTokensResponse, GenerateRequest, GenerateResponse,
     ListModelsRequest, ModelInfo, RequestContext, StreamEvent, TokenUsage, ToolDefinition,

--- a/koduck-ai/src/llm/router.rs
+++ b/koduck-ai/src/llm/router.rs
@@ -1,0 +1,310 @@
+//! Provider selection and mode switch for direct vs adapter-backed LLM traffic.
+
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
+
+use async_trait::async_trait;
+
+use crate::{
+    config::{Config, LlmMode},
+    reliability::error::{AppError, ErrorCode},
+};
+
+use super::{
+    compat::AdapterLlmProvider,
+    deepseek::DeepSeekProvider,
+    minimax::MiniMaxProvider,
+    openai::OpenAiProvider,
+    provider::{LlmProvider, ProviderEventStream},
+    types::{
+        CountTokensRequest, CountTokensResponse, GenerateRequest, GenerateResponse, ListModelsRequest,
+        ModelInfo,
+    },
+};
+
+pub fn build_provider_router(config: &Config) -> Result<Arc<dyn LlmProvider>, AppError> {
+    Ok(Arc::new(LlmRouter::from_config(config)?))
+}
+
+pub struct LlmRouter {
+    mode: LlmMode,
+    default_provider: String,
+    enabled_providers: HashSet<String>,
+    direct_providers: HashMap<String, Arc<dyn LlmProvider>>,
+    adapter_provider: Arc<dyn LlmProvider>,
+}
+
+impl LlmRouter {
+    pub fn from_config(config: &Config) -> Result<Self, AppError> {
+        let adapter_provider: Arc<dyn LlmProvider> =
+            Arc::new(AdapterLlmProvider::new(config.llm.adapter_grpc_target.clone()));
+        let mut direct_providers: HashMap<String, Arc<dyn LlmProvider>> = HashMap::new();
+        let mut enabled_providers: HashSet<String> = HashSet::new();
+
+        if config.llm.openai.enabled {
+            enabled_providers.insert("openai".to_string());
+            if let Some(api_key) = config.openai_api_key().filter(|key| !key.trim().is_empty()) {
+                direct_providers.insert(
+                    "openai".to_string(),
+                    Arc::new(OpenAiProvider::new(
+                        api_key.to_string(),
+                        Some(config.llm.openai.base_url.clone()),
+                        config.llm.openai.default_model.clone(),
+                    )?),
+                );
+            }
+        }
+
+        if config.llm.deepseek.enabled {
+            enabled_providers.insert("deepseek".to_string());
+            if let Some(api_key) = config.deepseek_api_key().filter(|key| !key.trim().is_empty()) {
+                direct_providers.insert(
+                    "deepseek".to_string(),
+                    Arc::new(DeepSeekProvider::new(
+                        api_key.to_string(),
+                        Some(config.llm.deepseek.base_url.clone()),
+                        config.llm.deepseek.default_model.clone(),
+                    )?),
+                );
+            }
+        }
+
+        if config.llm.minimax.enabled {
+            enabled_providers.insert("minimax".to_string());
+            if let Some(api_key) = config.minimax_api_key().filter(|key| !key.trim().is_empty()) {
+                direct_providers.insert(
+                    "minimax".to_string(),
+                    Arc::new(MiniMaxProvider::new(
+                        api_key.to_string(),
+                        Some(config.llm.minimax.base_url.clone()),
+                        config.llm.minimax.default_model.clone(),
+                    )?),
+                );
+            }
+        }
+
+        Ok(Self {
+            mode: config.llm.mode,
+            default_provider: config.llm.default_provider.clone(),
+            enabled_providers,
+            direct_providers,
+            adapter_provider,
+        })
+    }
+
+    fn resolve_route(&self, provider: &str, model: &str) -> Result<ResolvedRoute, AppError> {
+        let (parsed_provider, parsed_model) = parse_provider_model(provider, model);
+        let provider = parsed_provider.unwrap_or_else(|| self.default_provider.clone());
+        let model = parsed_model.unwrap_or_else(|| model.to_string());
+
+        match self.mode {
+            LlmMode::Adapter => Ok(ResolvedRoute {
+                provider,
+                model,
+                target: Arc::clone(&self.adapter_provider),
+            }),
+            LlmMode::Direct => {
+                if !self.enabled_providers.contains(&provider) {
+                    return Err(AppError::new(
+                        ErrorCode::InvalidArgument,
+                        format!(
+                            "llm provider '{}' is not enabled for direct mode; no implicit fallback will be applied",
+                            provider
+                        ),
+                    ));
+                }
+                let target = self.direct_providers.get(&provider).ok_or_else(|| {
+                    AppError::new(
+                        ErrorCode::InvalidArgument,
+                        format!(
+                            "llm provider '{}' is enabled for direct mode but missing runtime credentials; no implicit fallback will be applied",
+                            provider
+                        ),
+                    )
+                })?;
+                Ok(ResolvedRoute {
+                    provider,
+                    model,
+                    target: Arc::clone(target),
+                })
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl LlmProvider for LlmRouter {
+    async fn generate(&self, mut req: GenerateRequest) -> Result<GenerateResponse, AppError> {
+        let route = self.resolve_route(&req.provider, &req.model)?;
+        req.provider = route.provider;
+        req.model = route.model;
+        route.target.generate(req).await
+    }
+
+    async fn stream_generate(&self, mut req: GenerateRequest) -> Result<ProviderEventStream, AppError> {
+        let route = self.resolve_route(&req.provider, &req.model)?;
+        req.provider = route.provider;
+        req.model = route.model;
+        route.target.stream_generate(req).await
+    }
+
+    async fn list_models(&self, mut req: ListModelsRequest) -> Result<Vec<ModelInfo>, AppError> {
+        let route = self.resolve_route(&req.provider, "")?;
+        req.provider = route.provider;
+        route.target.list_models(req).await
+    }
+
+    async fn count_tokens(
+        &self,
+        mut req: CountTokensRequest,
+    ) -> Result<CountTokensResponse, AppError> {
+        let route = self.resolve_route(&req.provider, &req.model)?;
+        req.provider = route.provider;
+        req.model = route.model;
+        route.target.count_tokens(req).await
+    }
+}
+
+struct ResolvedRoute {
+    provider: String,
+    model: String,
+    target: Arc<dyn LlmProvider>,
+}
+
+fn parse_provider_model(provider: &str, model: &str) -> (Option<String>, Option<String>) {
+    if !provider.trim().is_empty() {
+        return (Some(provider.trim().to_ascii_lowercase()), normalized_model(model));
+    }
+
+    let model = model.trim();
+    if let Some((provider, rest)) = model.split_once(':') {
+        return (
+            Some(provider.trim().to_ascii_lowercase()),
+            normalized_model(rest),
+        );
+    }
+    if let Some((provider, rest)) = model.split_once('/') {
+        if matches!(
+            provider.trim().to_ascii_lowercase().as_str(),
+            "openai" | "deepseek" | "minimax"
+        ) {
+            return (
+                Some(provider.trim().to_ascii_lowercase()),
+                normalized_model(rest),
+            );
+        }
+    }
+
+    (None, normalized_model(model))
+}
+
+fn normalized_model(model: &str) -> Option<String> {
+    let model = model.trim();
+    (!model.is_empty()).then(|| model.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::{HashMap, HashSet},
+        sync::Arc,
+    };
+
+    use crate::config::{
+        AuthConfig, CapabilitiesConfig, MemoryConfig, ReliabilityConfig, ServerConfig, StreamConfig,
+        ToolConfig,
+    };
+    use secrecy::SecretString;
+
+    use crate::config::{Config, LlmConfig, LlmProviderConfig, LlmMode};
+
+    use super::{parse_provider_model, AdapterLlmProvider, LlmRouter};
+
+    #[test]
+    fn parses_model_prefix_variants() {
+        assert_eq!(
+            parse_provider_model("", "openai:gpt-4.1-mini"),
+            (Some("openai".to_string()), Some("gpt-4.1-mini".to_string()))
+        );
+        assert_eq!(
+            parse_provider_model("", "deepseek/deepseek-chat"),
+            (Some("deepseek".to_string()), Some("deepseek-chat".to_string()))
+        );
+        assert_eq!(
+            parse_provider_model("minimax", "MiniMax-M1"),
+            (Some("minimax".to_string()), Some("MiniMax-M1".to_string()))
+        );
+    }
+
+    #[test]
+    fn config_validation_rejects_unknown_default_provider_in_direct_mode() {
+        let config = Config {
+            server: ServerConfig::default(),
+            memory: MemoryConfig::default(),
+            tools: ToolConfig::default(),
+            llm: LlmConfig {
+                mode: LlmMode::Direct,
+                default_provider: "unknown".to_string(),
+                openai: LlmProviderConfig {
+                    api_key: Some(SecretString::from("sk-test".to_string())),
+                    enabled: true,
+                    base_url: "https://api.openai.com/v1".to_string(),
+                    default_model: "gpt-4.1-mini".to_string(),
+                },
+                deepseek: LlmProviderConfig {
+                    api_key: None,
+                    enabled: false,
+                    base_url: "https://api.deepseek.com/v1".to_string(),
+                    default_model: "deepseek-chat".to_string(),
+                },
+                minimax: LlmProviderConfig {
+                    api_key: None,
+                    enabled: false,
+                    base_url: "https://api.minimax.chat/v1".to_string(),
+                    default_model: "MiniMax-M1".to_string(),
+                },
+                ..LlmConfig::default()
+            },
+            stream: StreamConfig::default(),
+            auth: AuthConfig::default(),
+            capabilities: CapabilitiesConfig::default(),
+            reliability: ReliabilityConfig::default(),
+        };
+
+        let result = config.validate();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn direct_mode_rejects_unenabled_provider_without_fallback() {
+        let router = LlmRouter {
+            mode: LlmMode::Direct,
+            default_provider: "openai".to_string(),
+            enabled_providers: ["openai".to_string()].into_iter().collect(),
+            direct_providers: HashMap::new(),
+            adapter_provider: Arc::new(AdapterLlmProvider::new("http://localhost:50054")),
+        };
+
+        match router.resolve_route("deepseek", "deepseek-chat") {
+            Ok(_) => panic!("expected provider route resolution to fail"),
+            Err(err) => assert!(err.message.contains("no implicit fallback")),
+        }
+    }
+
+    #[test]
+    fn adapter_mode_routes_to_existing_compat_provider() {
+        let router = LlmRouter {
+            mode: LlmMode::Adapter,
+            default_provider: "openai".to_string(),
+            enabled_providers: HashSet::new(),
+            direct_providers: HashMap::new(),
+            adapter_provider: Arc::new(AdapterLlmProvider::new("http://localhost:50054")),
+        };
+
+        let route = router.resolve_route("", "").unwrap();
+        assert_eq!(route.provider, "openai");
+        assert!(route.model.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary
- add llm router to switch between direct and adapter modes
- split provider config into per-provider enabled/api_key/base_url/default_model blocks
- add ADR 0018 and mark Task 3.3.4 as complete

## Verification
- docker build -t koduck-ai:dev ./koduck-ai
- docker run --rm -v /tmp/koduck-ai-task-3-3-4/koduck-ai:/app -w /app koduck-ai-builder cargo test llm::router --lib (fails in builder image due upstream crate environment issue: num_integer not found)

Closes #754