### PR TITLE
feat(koduck-ai): add mode-aware capability probing

### DIFF
--- a/koduck-ai/docs/adr/0019-mode-aware-capability-negotiation-and-startup-probing.md
+++ b/koduck-ai/docs/adr/0019-mode-aware-capability-negotiation-and-startup-probing.md
@@ -1,0 +1,109 @@
+# ADR-0019: 为 koduck-ai 引入 mode-aware capability 协商与启动探活
+
+- Status: Accepted
+- Date: 2026-04-11
+- Issue: #757
+
+## Context
+
+根据 `koduck-ai/docs/design/ai-decoupled-architecture.md` 第 6.5.8 节和
+`koduck-ai/docs/implementation/koduck-ai-rust-grpc-tasks.md` Task 3.3.5：
+
+1. `chat/stream` 主链路需要正式以 Rust provider adapter 为默认调用入口。
+2. `memory/tool` 继续沿用 `GetCapabilities` 协商与 TTL 刷新。
+3. `llm` 在 `direct` 模式下不再依赖内部 `llm.proto` 的 `GetCapabilities`，而要改为本地静态 capability + 启动探活。
+4. `llm.proto` 的 capability 协商只应在 `adapter` 模式下保留，用于迁移期兼容和回滚。
+
+在本次任务开始前，仓库已经具备：
+
+- `chat/stream` 主链路基于 `state.llm_provider` 调用统一 trait
+- `LlmRouter` 可在 `direct | adapter` 模式之间切换
+- `CapabilityCache` 已支持 `memory/tool/llm` 的 gRPC capability 协商
+
+但 capability 初始化仍是单一路径：
+
+- 无论 `llm.mode` 为何，都会尝试对 `llm` 使用 gRPC `GetCapabilities`
+- 启动期没有对 direct provider 做显式配置校验与可用性探活
+
+这会让 direct 模式的目标态和 capability 体系不一致。
+
+## Decision
+
+本次把 capability 初始化改为 mode-aware，并将 direct provider 的配置校验和轻量探活纳入服务启动流程。
+
+### 1. 启动时引入 mode-aware capability negotiation
+
+在 `src/clients/capability.rs` 中新增 mode-aware 初始化与刷新逻辑：
+
+- `memory/tool` 始终通过 gRPC `GetCapabilities`
+- `llm`:
+  - `adapter` 模式继续调用 `llm.proto` 的 `GetCapabilities`
+  - `direct` 模式改为本地构建 `Capability`，并通过 `list_models` 做启动探活
+
+### 2. direct 模式下使用本地静态 capability
+
+对 direct 模式，本地 capability 由 `koduck-ai` 自己生成，包含：
+
+- `service = "llm"`
+- `contract_versions`
+- `mode`
+- `default_provider`
+- `available_providers`
+- 每个 provider 的配置默认模型、base_url 与探活得到的模型数量
+
+这样可以保持 northbound / runtime 的 capability 语义一致，而不再虚构一个额外的内部 gRPC LLM service。
+
+### 3. 启动探活基于 `list_models`
+
+direct 模式启动时，对所有 `enabled` 的 provider 逐个执行 `list_models`：
+
+- 若 provider 被启用但缺少运行时凭证，router 会显式返回错误
+- 若 provider HTTP 探活失败，启动直接失败
+- 若成功，则把探活结果汇总到 capability 中
+
+这满足“启动期可校验 provider 配置与可用性”的要求。
+
+### 4. 把 capability 初始化接入服务启动流程
+
+在 `src/app/mod.rs` 和 `src/main.rs` 中：
+
+- `AppState` 新增 `CapabilityCache`
+- 服务开始监听前先执行 `initialize_runtime`
+- 初始化成功后再启动 HTTP / metrics server
+- capability 后台 TTL 刷新也改为 mode-aware
+
+这样 direct 模式配置错误会在启动时 fail-fast，而不是拖到第一条请求才暴露。
+
+## Consequences
+
+### 正向影响
+
+1. **主链路与 capability 体系对齐**：direct 模式下不再依赖 `llm.proto` 做 capability 协商。
+2. **启动失败更早、更明确**：缺失 key、provider 不可达、探活失败都会在启动期暴露。
+3. **adapter 回滚路径仍然保留**：切回 `adapter` 模式后，继续走旧的 gRPC capability 协商链路。
+4. **后台刷新保持一致策略**：启动和运行期对 LLM capability 的处理方式一致，不会出现模式漂移。
+
+### 代价与风险
+
+1. **启动阶段增加外部依赖探活**：direct 模式启动时需要额外访问外部 provider。
+2. **provider 探活依赖 `list_models` 可用**：若某 provider 后续需要改成更轻量探测方式，应继续在 capability 模块内收敛。
+
+### 兼容性影响
+
+- **对 northbound API 无破坏性变化**：`/api/v1/ai/chat` 与 `/api/v1/ai/chat/stream` 契约不变。
+- **对 direct 模式行为更严格**：配置和可用性问题会在启动期 fail-fast。
+- **对 adapter 模式完全兼容**：现有 `llm.proto` 协商链路继续保留。
+
+## Alternatives Considered
+
+### 1. 继续让 direct 模式伪装成 gRPC `GetCapabilities`
+
+- **拒绝理由**：这会让目标架构与运行时现实脱节，也无法真正校验 direct provider 的可用性。
+
+### 2. direct 模式仅做本地 capability，不做启动探活
+
+- **拒绝理由**：只能校验静态配置，不能在启动时发现 provider 实际不可达的问题。
+
+### 3. 仅对 default provider 探活
+
+- **拒绝理由**：会留下“已启用但不可用”的 provider 到运行期才失败，不符合任务对启动校验的要求。

--- a/koduck-ai/docs/implementation/koduck-ai-rust-grpc-tasks.md
+++ b/koduck-ai/docs/implementation/koduck-ai-rust-grpc-tasks.md
@@ -237,9 +237,9 @@ cd koduck-ai
 3. `llm.proto` capability 协商仅在 `adapter` 模式启用
 
 **验收标准:**
-- [ ] chat/stream 不再默认依赖 `LlmServiceClient`
-- [ ] `direct` 模式下启动期可校验 provider 配置与可用性
-- [ ] `adapter` 模式下现有兼容链路仍可工作
+- [x] chat/stream 不再默认依赖 `LlmServiceClient`
+- [x] `direct` 模式下启动期可校验 provider 配置与可用性
+- [x] `adapter` 模式下现有兼容链路仍可工作
 
 ---
 

--- a/koduck-ai/src/app/mod.rs
+++ b/koduck-ai/src/app/mod.rs
@@ -9,9 +9,12 @@ use axum::{
 };
 use tower_http::request_id::{MakeRequestUuid, PropagateRequestIdLayer, SetRequestIdLayer};
 use tower_http::trace::TraceLayer;
+use tokio::sync::broadcast;
 
 use crate::api;
+use crate::clients::capability::CapabilityCache;
 use crate::config::Config;
+use crate::reliability::error::AppError;
 use crate::llm::{build_provider_router, LlmProvider};
 use crate::reliability::degrade::DegradePolicy;
 use crate::reliability::retry_budget::RetryBudgetPolicy;
@@ -27,6 +30,7 @@ pub struct AppState {
     pub degrade_policy: Arc<DegradePolicy>,
     pub retry_budget_policy: Arc<RetryBudgetPolicy>,
     pub llm_provider: Arc<dyn LlmProvider>,
+    pub capability_cache: Arc<CapabilityCache>,
 }
 
 /// Health check response
@@ -54,10 +58,40 @@ pub fn build_state(config: Config) -> Arc<AppState> {
         llm_provider: build_provider_router(&config)
             .expect("failed to build llm provider router from config"),
         retry_budget_policy: Arc::new(RetryBudgetPolicy::new(config.reliability.retry.clone())),
+        capability_cache: Arc::new(CapabilityCache::new(config.capabilities.clone())),
         config,
         stream_registry: Arc::new(StreamRegistry::default()),
         lifecycle,
     })
+}
+
+pub async fn initialize_runtime(
+    state: &Arc<AppState>,
+    shutdown_rx: broadcast::Receiver<()>,
+) -> Result<(), AppError> {
+    state
+        .capability_cache
+        .initial_negotiation_mode_aware(
+            &state.config.memory.grpc_target,
+            &state.config.tools.grpc_target,
+            &state.config.llm.adapter_grpc_target,
+            state.config.llm.mode,
+            &state.config.llm,
+            Arc::clone(&state.llm_provider),
+        )
+        .await?;
+
+    state.capability_cache.spawn_refresh_task_mode_aware(
+        state.config.memory.grpc_target.clone(),
+        state.config.tools.grpc_target.clone(),
+        state.config.llm.adapter_grpc_target.clone(),
+        state.config.llm.mode,
+        state.config.llm.clone(),
+        Arc::clone(&state.llm_provider),
+        shutdown_rx,
+    );
+
+    Ok(())
 }
 
 /// Create the main HTTP router

--- a/koduck-ai/src/clients/capability.rs
+++ b/koduck-ai/src/clients/capability.rs
@@ -3,6 +3,7 @@
 //! Implements startup version negotiation, TTL-based capability caching,
 //! and background refresh for memory/tool/llm gRPC clients.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -11,7 +12,8 @@ use tonic::transport::Endpoint;
 use tracing::{error, info, warn};
 
 use crate::clients::proto;
-use crate::config::CapabilitiesConfig;
+use crate::config::{CapabilitiesConfig, LlmConfig, LlmMode};
+use crate::llm::{ListModelsRequest, LlmProvider, RequestContext};
 use crate::reliability::{
     error::{AppError, ErrorCode, UpstreamService},
     error_mapper::{map_grpc_status, map_transport_error},
@@ -183,6 +185,106 @@ impl CapabilityCache {
         })
     }
 
+    pub async fn initial_negotiation_mode_aware(
+        &self,
+        memory_addr: &str,
+        tool_addr: &str,
+        llm_addr: &str,
+        llm_mode: LlmMode,
+        llm_config: &LlmConfig,
+        llm_provider: Arc<dyn LlmProvider>,
+    ) -> Result<NegotiationResult, AppError> {
+        let timeout = Duration::from_millis(self.config.startup_timeout_ms);
+
+        let memory_handle = tokio::time::timeout(timeout, fetch_memory_capability(memory_addr));
+        let tool_handle = tokio::time::timeout(timeout, fetch_tool_capability(tool_addr));
+        let llm_handle = match llm_mode {
+            LlmMode::Adapter => tokio::time::timeout(timeout, fetch_llm_capability(llm_addr))
+                .await
+                .map_err(|_| {
+                    map_transport_error(
+                        UpstreamService::Llm,
+                        "startup-capability-check",
+                        "llm service capability check timed out",
+                        "deadline exceeded",
+                    )
+                })?
+                .map_err(|e| map_grpc_status(UpstreamService::Llm, "startup-capability-check", &e)),
+            LlmMode::Direct => tokio::time::timeout(
+                timeout,
+                fetch_direct_llm_capability(
+                    llm_config,
+                    Arc::clone(&llm_provider),
+                    &self.config.required_version,
+                ),
+            )
+            .await
+            .map_err(|_| {
+                map_transport_error(
+                    UpstreamService::Llm,
+                    "startup-capability-check",
+                    "direct llm provider capability check timed out",
+                    "deadline exceeded",
+                )
+            })?,
+        };
+
+        let (memory_result, tool_result) = tokio::join!(memory_handle, tool_handle);
+
+        let memory_cap = memory_result
+            .map_err(|_| {
+                map_transport_error(
+                    UpstreamService::Memory,
+                    "startup-capability-check",
+                    "memory service capability check timed out",
+                    "deadline exceeded",
+                )
+            })?
+            .map_err(|e| map_grpc_status(UpstreamService::Memory, "startup-capability-check", &e))?;
+
+        let tool_cap = tool_handle_result(tool_result)?;
+        let llm_cap = llm_handle?;
+
+        info!(
+            memory.service = %memory_cap.service,
+            memory.contract_versions = ?memory_cap.contract_versions,
+            "Memory service capabilities negotiated"
+        );
+        info!(
+            tool.service = %tool_cap.service,
+            tool.contract_versions = ?tool_cap.contract_versions,
+            "Tool service capabilities negotiated"
+        );
+        info!(
+            llm.service = %llm_cap.service,
+            llm.contract_versions = ?llm_cap.contract_versions,
+            llm_mode = %llm_mode,
+            "LLM capabilities negotiated"
+        );
+
+        check_version_compatibility(&memory_cap, &tool_cap, &llm_cap, &self.config)?;
+
+        let memory_cached = CachedCapability::new(memory_cap);
+        let tool_cached = CachedCapability::new(tool_cap);
+        let llm_cached = CachedCapability::new(llm_cap);
+
+        *self.memory.write().await = Some(memory_cached.clone());
+        *self.tool.write().await = Some(tool_cached.clone());
+        *self.llm.write().await = Some(llm_cached.clone());
+
+        info!(
+            ttl_secs = self.config.ttl_secs,
+            llm_mode = %llm_mode,
+            "Capability cache populated"
+        );
+
+        Ok(NegotiationResult {
+            memory: memory_cached,
+            tool: tool_cached,
+            llm: llm_cached,
+        })
+    }
+
     /// Spawn a background task that periodically refreshes the capability cache.
     ///
     /// The task sleeps until TTL expires, then refreshes all three services.
@@ -203,6 +305,42 @@ impl CapabilityCache {
                 tokio::select! {
                     _ = tokio::time::sleep(ttl) => {
                         cache.refresh_all(&memory_addr, &tool_addr, &llm_addr).await;
+                    }
+                    _ = shutdown_rx.recv() => {
+                        info!("Capability refresh task shutting down");
+                        break;
+                    }
+                }
+            }
+        })
+    }
+
+    pub fn spawn_refresh_task_mode_aware(
+        self: &Arc<Self>,
+        memory_addr: String,
+        tool_addr: String,
+        llm_addr: String,
+        llm_mode: LlmMode,
+        llm_config: LlmConfig,
+        llm_provider: Arc<dyn LlmProvider>,
+        mut shutdown_rx: broadcast::Receiver<()>,
+    ) -> tokio::task::JoinHandle<()> {
+        let cache = Arc::clone(self);
+        let ttl = Duration::from_secs(self.config.ttl_secs);
+
+        tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    _ = tokio::time::sleep(ttl) => {
+                        cache.refresh_all_mode_aware(
+                            &memory_addr,
+                            &tool_addr,
+                            &llm_addr,
+                            llm_mode,
+                            &llm_config,
+                            &cache.config.required_version,
+                            Arc::clone(&llm_provider),
+                        ).await;
                     }
                     _ = shutdown_rx.recv() => {
                         info!("Capability refresh task shutting down");
@@ -259,6 +397,74 @@ impl CapabilityCache {
             }
             Err(e) => warn!(
                 error = %e,
+                "Failed to refresh llm capabilities (using cached data)"
+            ),
+        }
+    }
+
+    async fn refresh_all_mode_aware(
+        &self,
+        memory_addr: &str,
+        tool_addr: &str,
+        llm_addr: &str,
+        llm_mode: LlmMode,
+        llm_config: &LlmConfig,
+        required_version: &str,
+        llm_provider: Arc<dyn LlmProvider>,
+    ) {
+        match fetch_memory_capability(memory_addr).await {
+            Ok(cap) => {
+                info!(
+                    service = %cap.service,
+                    contract_versions = ?cap.contract_versions,
+                    "Memory capabilities refreshed"
+                );
+                *self.memory.write().await = Some(CachedCapability::new(cap));
+            }
+            Err(e) => warn!(
+                error = %e,
+                "Failed to refresh memory capabilities (using cached data)"
+            ),
+        }
+
+        match fetch_tool_capability(tool_addr).await {
+            Ok(cap) => {
+                info!(
+                    service = %cap.service,
+                    contract_versions = ?cap.contract_versions,
+                    "Tool capabilities refreshed"
+                );
+                *self.tool.write().await = Some(CachedCapability::new(cap));
+            }
+            Err(e) => warn!(
+                error = %e,
+                "Failed to refresh tool capabilities (using cached data)"
+            ),
+        }
+
+        let llm_result = match llm_mode {
+            LlmMode::Adapter => fetch_llm_capability(llm_addr)
+                .await
+                .map_err(|e| map_grpc_status(UpstreamService::Llm, "capability-refresh", &e)),
+            LlmMode::Direct => {
+                fetch_direct_llm_capability(llm_config, llm_provider, required_version).await
+            }
+                
+        };
+
+        match llm_result {
+            Ok(cap) => {
+                info!(
+                    service = %cap.service,
+                    contract_versions = ?cap.contract_versions,
+                    llm_mode = %llm_mode,
+                    "LLM capabilities refreshed"
+                );
+                *self.llm.write().await = Some(CachedCapability::new(cap));
+            }
+            Err(e) => warn!(
+                error = %e,
+                llm_mode = %llm_mode,
                 "Failed to refresh llm capabilities (using cached data)"
             ),
         }
@@ -364,6 +570,92 @@ async fn fetch_llm_capability(addr: &str) -> Result<proto::Capability, tonic::St
         .get_capabilities(tonic::Request::new(proto::RequestMeta::default()))
         .await?;
     Ok(response.into_inner())
+}
+
+async fn fetch_direct_llm_capability(
+    llm_config: &LlmConfig,
+    llm_provider: Arc<dyn LlmProvider>,
+    required_version: &str,
+) -> Result<proto::Capability, AppError> {
+    let providers = enabled_llm_providers(llm_config);
+    if providers.is_empty() {
+        return Err(AppError::new(
+            ErrorCode::InvalidArgument,
+            "no direct llm providers are enabled",
+        ));
+    }
+
+    let mut features = HashMap::new();
+    features.insert("mode".to_string(), "direct".to_string());
+    features.insert("default_provider".to_string(), llm_config.default_provider.clone());
+    features.insert("available_providers".to_string(), providers.join(","));
+    features.insert("supports_chat".to_string(), "true".to_string());
+    features.insert("supports_stream".to_string(), "true".to_string());
+    features.insert("supports_count_tokens".to_string(), "true".to_string());
+    features.insert("probe".to_string(), "list_models".to_string());
+
+    let mut limits = HashMap::new();
+    limits.insert("provider_count".to_string(), providers.len().to_string());
+    limits.insert("timeout_ms".to_string(), llm_config.timeout_ms.to_string());
+
+    for provider in &providers {
+        if let Some(provider_config) = llm_config.provider_config(provider) {
+            features.insert(
+                format!("provider.{}.configured_default_model", provider),
+                provider_config.default_model.clone(),
+            );
+            features.insert(
+                format!("provider.{}.base_url", provider),
+                provider_config.base_url.clone(),
+            );
+        }
+        let models = llm_provider
+            .list_models(ListModelsRequest {
+                meta: capability_request_context(provider, llm_config.timeout_ms),
+                provider: provider.clone(),
+            })
+            .await?;
+        limits.insert(
+            format!("provider.{}.models", provider),
+            models.len().to_string(),
+        );
+        if let Some(first_model) = models.first() {
+            features.insert(
+                format!("provider.{}.default_model", provider),
+                first_model.id.clone(),
+            );
+        }
+    }
+
+    Ok(proto::Capability {
+        service: "llm".to_string(),
+        contract_versions: vec![required_version.to_string()],
+        features,
+        limits,
+    })
+}
+
+fn enabled_llm_providers(llm_config: &LlmConfig) -> Vec<String> {
+    ["openai", "deepseek", "minimax"]
+        .into_iter()
+        .filter(|provider| {
+            llm_config
+                .provider_config(provider)
+                .map(|cfg| cfg.enabled)
+                .unwrap_or(false)
+        })
+        .map(str::to_string)
+        .collect()
+}
+
+fn capability_request_context(provider: &str, deadline_ms: u64) -> RequestContext {
+    RequestContext {
+        request_id: format!("startup-capability-check-{provider}"),
+        session_id: "capability-probe".to_string(),
+        user_id: "system".to_string(),
+        trace_id: format!("capability-probe-{provider}"),
+        deadline_ms,
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -475,8 +767,18 @@ fn collect_mismatches(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use async_trait::async_trait;
+    use futures::stream;
+
+    use super::*;
+    use crate::config::LlmProviderConfig;
+    use crate::llm::{
+        CountTokensRequest, CountTokensResponse, GenerateRequest, GenerateResponse, ListModelsRequest,
+        LlmProvider, ModelInfo, ProviderEventStream, StreamEvent,
+    };
 
     fn make_capability(service: &str, versions: Vec<&str>) -> proto::Capability {
         proto::Capability {
@@ -484,6 +786,42 @@ mod tests {
             contract_versions: versions.into_iter().map(String::from).collect(),
             features: HashMap::new(),
             limits: HashMap::new(),
+        }
+    }
+
+    struct MockDirectProvider;
+
+    #[async_trait]
+    impl LlmProvider for MockDirectProvider {
+        async fn generate(&self, _req: GenerateRequest) -> Result<GenerateResponse, AppError> {
+            unreachable!("generate is not used in capability tests")
+        }
+
+        async fn stream_generate(
+            &self,
+            _req: GenerateRequest,
+        ) -> Result<ProviderEventStream, AppError> {
+            Ok(Box::pin(stream::empty::<Result<StreamEvent, AppError>>()))
+        }
+
+        async fn list_models(&self, req: ListModelsRequest) -> Result<Vec<ModelInfo>, AppError> {
+            Ok(vec![ModelInfo {
+                id: format!("{}-model", req.provider),
+                provider: req.provider.clone(),
+                display_name: format!("{} model", req.provider),
+                max_context_tokens: 8192,
+                max_output_tokens: 4096,
+                supports_streaming: true,
+                supports_tools: false,
+                supported_features: vec!["chat".to_string(), "stream".to_string()],
+            }])
+        }
+
+        async fn count_tokens(
+            &self,
+            _req: CountTokensRequest,
+        ) -> Result<CountTokensResponse, AppError> {
+            unreachable!("count_tokens is not used in capability tests")
         }
     }
 
@@ -586,5 +924,78 @@ mod tests {
         assert!(json.contains("\"service\":\"memory\""));
         assert!(json.contains("\"expected_version\":\"v1\""));
         assert!(json.contains("\"severity\":\"critical\""));
+    }
+
+    #[test]
+    fn test_enabled_llm_providers_returns_only_enabled_entries() {
+        let llm_config = LlmConfig {
+            openai: LlmProviderConfig {
+                enabled: true,
+                ..LlmProviderConfig::default()
+            },
+            deepseek: LlmProviderConfig {
+                enabled: false,
+                ..LlmProviderConfig::default()
+            },
+            minimax: LlmProviderConfig {
+                enabled: true,
+                ..LlmProviderConfig::default()
+            },
+            ..LlmConfig::default()
+        };
+
+        assert_eq!(
+            enabled_llm_providers(&llm_config),
+            vec!["openai".to_string(), "minimax".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_fetch_direct_llm_capability_builds_static_capability_after_probe() {
+        let llm_config = LlmConfig {
+            default_provider: "openai".to_string(),
+            timeout_ms: 3210,
+            openai: LlmProviderConfig {
+                enabled: true,
+                base_url: "https://api.openai.com/v1".to_string(),
+                default_model: "gpt-4.1-mini".to_string(),
+                ..LlmProviderConfig::default()
+            },
+            deepseek: LlmProviderConfig {
+                enabled: true,
+                base_url: "https://api.deepseek.com/v1".to_string(),
+                default_model: "deepseek-chat".to_string(),
+                ..LlmProviderConfig::default()
+            },
+            minimax: LlmProviderConfig {
+                enabled: false,
+                ..LlmProviderConfig::default()
+            },
+            ..LlmConfig::default()
+        };
+
+        let capability = fetch_direct_llm_capability(
+            &llm_config,
+            Arc::new(MockDirectProvider),
+            "v1",
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(capability.service, "llm");
+        assert_eq!(capability.contract_versions, vec!["v1".to_string()]);
+        assert_eq!(capability.features.get("mode"), Some(&"direct".to_string()));
+        assert_eq!(
+            capability.features.get("available_providers"),
+            Some(&"openai,deepseek".to_string())
+        );
+        assert_eq!(
+            capability.limits.get("provider.openai.models"),
+            Some(&"1".to_string())
+        );
+        assert_eq!(
+            capability.limits.get("provider.deepseek.models"),
+            Some(&"1".to_string())
+        );
     }
 }

--- a/koduck-ai/src/llm/http.rs
+++ b/koduck-ai/src/llm/http.rs
@@ -303,7 +303,7 @@ mod tests {
             .build_json_request(Method::POST, &options, &json!({"model": "gpt"}))
             .unwrap();
 
-        assert_eq!(request.timeout(), Some(Duration::from_millis(1_500)));
+        assert_eq!(request.timeout(), Some(Duration::from_millis(1_500)).as_ref());
         assert_eq!(
             request.headers().get(ACCEPT),
             Some(&HeaderValue::from_static("application/json"))

--- a/koduck-ai/src/main.rs
+++ b/koduck-ai/src/main.rs
@@ -5,7 +5,7 @@ use tokio::sync::broadcast;
 use tracing::{error, info};
 use tracing_subscriber::EnvFilter;
 
-use koduck_ai::app::{self, build_state};
+use koduck_ai::app::{self, build_state, initialize_runtime};
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -35,10 +35,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     info!(config = %config, "Configuration loaded");
 
+    let state = build_state(config.clone());
+    let (shutdown_tx, _) = broadcast::channel::<()>(1);
+    initialize_runtime(&state, shutdown_tx.subscribe()).await?;
+
     // Create HTTP server
     let http_addr: SocketAddr = config.server.http_addr.parse()?;
     let http_listener = TcpListener::bind(http_addr).await?;
-    let state = build_state(config.clone());
     let http_app = app::create_router(state.clone());
 
     // Create metrics server
@@ -53,7 +56,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         "Servers listening"
     );
 
-    let (shutdown_tx, _) = broadcast::channel::<()>(1);
     let mut http_shutdown_rx = shutdown_tx.subscribe();
     let mut metrics_shutdown_rx = shutdown_tx.subscribe();
 


### PR DESCRIPTION
## Summary
- add mode-aware capability negotiation for direct and adapter llm modes
- initialize capability probing before the service starts listening and keep ttl refresh mode-aware
- add ADR 0019 and mark Task 3.3.5 as complete

## Verification
- docker build -t koduck-ai:dev ./koduck-ai
- docker run --rm -v /tmp/koduck-ai-task-3-3-5/koduck-ai:/app -w /app koduck-ai-builder cargo test clients::capability --lib

Closes #757