### PR TITLE
docs(auth-user): freeze tenant-id semantics v1

### DIFF
--- a/docs/design/koduck-auth-user-tenant-semantics.md
+++ b/docs/design/koduck-auth-user-tenant-semantics.md
@@ -54,12 +54,23 @@ V1 需要达成以下能力：
 5. 下游业务服务默认只相信网关注入的 `X-Tenant-Id`，不自行猜测租户。
 6. V1 不引入复杂的 tenant hierarchy、tenant admin console 或跨租户共享资源模型。
 
+### 4.1 Task 1.1 冻结结果
+
+为避免后续阶段再次出现跨服务歧义，V1 将 `tenant_id` 语义冻结为以下规则：
+
+1. `tenant_id` 的传输类型统一为字符串，数据库列类型统一为 `VARCHAR(128)`。
+2. `tenant_id` 的真值来源是 `koduck-user` 的租户真值 `tenants.id`，以及绑定在用户记录上的 `users.tenant_id`。
+3. `koduck-auth` 只负责在认证成功后读取并传播 `tenant_id`，不自行生成，也不从邮箱域名、角色名等隐式信号推断。
+4. 跨服务身份语义统一采用 `(tenant_id, user_id)`，单独的 `user_id` 不是完整身份主键。
+5. V1 不支持 tenant hierarchy、父子租户继承、跨租户共享资源或超级租户穿透访问。
+6. `tenant_id` 在 V1 中是扁平、不可推导、不可拆分的 opaque identifier。
+
 ---
 
 ## 5. 术语定义
 
 - `tenant_id`
-  - 租户的稳定唯一标识，建议使用字符串或 UUID
+  - 租户的稳定唯一标识；V1 统一为最长 128 字符的字符串标识
 - `user_id`
   - 用户在系统中的内部主键
 - `tenant-scoped identity`
@@ -170,6 +181,7 @@ CREATE TABLE tenants (
 ```
 
 V1 也可先不做复杂 tenant profile，只保留最小真值。
+`tenants.id` 即系统中 `tenant_id` 的唯一真值来源。
 
 ### 8.2 `users` 表
 
@@ -249,6 +261,8 @@ V1 可选方案：
 
 1. 登录请求显式带 `tenant_id`
 2. 网关或客户端已选定当前 tenant
+
+无论采用哪种交互形式，认证链路最终都必须从用户真值中确认 `tenant_id`，而不是从输入账号文本中推断。
 
 ### 9.2 角色
 

--- a/docs/implementation/koduck-auth-user-tenant-semantics-tasks.md
+++ b/docs/implementation/koduck-auth-user-tenant-semantics-tasks.md
@@ -27,6 +27,13 @@
 2. 明确 V1 不支持 tenant hierarchy
 3. 明确 `(tenant_id, user_id)` 为身份主键语义
 
+**冻结结果（2026-04-11）:**
+- `tenant_id` 统一定义为字符串类型，对应数据库 `VARCHAR(128)`
+- 真值来源为 `koduck-user` 的租户真值（`tenants.id`）及用户记录上的 `users.tenant_id`
+- `koduck-auth` 仅负责读取并传播 `tenant_id`，不做推断或再生成
+- V1 不支持 tenant hierarchy、父子租户继承或跨租户共享身份语义
+- 对外与对内身份语义统一采用 `(tenant_id, user_id)`
+
 **验收标准:**
 - [ ] `tenant_id` 语义在文档中固定
 - [ ] 各服务对 tenant 的解释一致

--- a/koduck-auth/docs/design/koduck-auth-user-service-design.md
+++ b/koduck-auth/docs/design/koduck-auth-user-service-design.md
@@ -6,6 +6,9 @@
 
 koduck-user 服务负责用户信息管理、角色权限管理，通过内部 API 向 koduck-auth 和其他服务提供用户数据支持。
 
+> 说明：本文档中的用户与角色模型已按 `docs/design/koduck-auth-user-tenant-semantics.md` 的 V1 冻结语义更新。
+> `tenant_id` 为最长 128 字符的字符串标识，跨服务身份语义统一为 `(tenant_id, user_id)`。
+
 ---
 
 ## 2. 服务边界划分
@@ -50,8 +53,9 @@ koduck-user 服务负责用户信息管理、角色权限管理，通过内部 A
 -- 用户表
 CREATE TABLE users (
     id BIGSERIAL PRIMARY KEY,
-    username VARCHAR(50) NOT NULL UNIQUE,
-    email VARCHAR(100) NOT NULL UNIQUE,
+    tenant_id VARCHAR(128) NOT NULL,
+    username VARCHAR(50) NOT NULL,
+    email VARCHAR(100) NOT NULL,
     password_hash VARCHAR(255) NOT NULL,
     nickname VARCHAR(50),
     avatar_url VARCHAR(255),
@@ -60,15 +64,19 @@ CREATE TABLE users (
     last_login_at TIMESTAMP,
     last_login_ip VARCHAR(45),
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (tenant_id, username),
+    UNIQUE (tenant_id, email)
 );
 
 -- 角色表
 CREATE TABLE roles (
     id SERIAL PRIMARY KEY,
-    name VARCHAR(50) NOT NULL UNIQUE,
+    tenant_id VARCHAR(128) NOT NULL,
+    name VARCHAR(50) NOT NULL,
     description VARCHAR(255),
-    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (tenant_id, name)
 );
 
 -- 权限表
@@ -84,24 +92,27 @@ CREATE TABLE permissions (
 -- 用户角色关联表
 CREATE TABLE user_roles (
     id BIGSERIAL PRIMARY KEY,
+    tenant_id VARCHAR(128) NOT NULL,
     user_id BIGINT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
     role_id INTEGER NOT NULL REFERENCES roles(id) ON DELETE CASCADE,
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    UNIQUE(user_id, role_id)
+    UNIQUE(tenant_id, user_id, role_id)
 );
 
 -- 角色权限关联表
 CREATE TABLE role_permissions (
     id BIGSERIAL PRIMARY KEY,
+    tenant_id VARCHAR(128) NOT NULL,
     role_id INTEGER NOT NULL REFERENCES roles(id) ON DELETE CASCADE,
     permission_id INTEGER NOT NULL REFERENCES permissions(id) ON DELETE CASCADE,
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    UNIQUE(role_id, permission_id)
+    UNIQUE(tenant_id, role_id, permission_id)
 );
 
 -- 用户凭证表（支持多因素认证）
 CREATE TABLE user_credentials (
     id BIGSERIAL PRIMARY KEY,
+    tenant_id VARCHAR(128) NOT NULL,
     user_id BIGINT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
     credential_type VARCHAR(20) NOT NULL, -- PASSWORD, TOTP, FIDO2, etc.
     credential_value VARCHAR(255) NOT NULL,
@@ -114,20 +125,20 @@ CREATE TABLE user_credentials (
 );
 
 -- 索引
-CREATE INDEX idx_users_username ON users(username);
-CREATE INDEX idx_users_email ON users(email);
+CREATE INDEX idx_users_tenant_username ON users(tenant_id, username);
+CREATE INDEX idx_users_tenant_email ON users(tenant_id, email);
 CREATE INDEX idx_users_status ON users(status);
-CREATE INDEX idx_user_roles_user_id ON user_roles(user_id);
-CREATE INDEX idx_user_roles_role_id ON user_roles(role_id);
-CREATE INDEX idx_role_permissions_role_id ON role_permissions(role_id);
-CREATE INDEX idx_role_permissions_permission_id ON role_permissions(permission_id);
-CREATE INDEX idx_user_credentials_user_id ON user_credentials(user_id);
+CREATE INDEX idx_user_roles_tenant_user_id ON user_roles(tenant_id, user_id);
+CREATE INDEX idx_user_roles_tenant_role_id ON user_roles(tenant_id, role_id);
+CREATE INDEX idx_role_permissions_tenant_role_id ON role_permissions(tenant_id, role_id);
+CREATE INDEX idx_role_permissions_tenant_permission_id ON role_permissions(tenant_id, permission_id);
+CREATE INDEX idx_user_credentials_tenant_user_id ON user_credentials(tenant_id, user_id);
 
 -- 初始化数据
-INSERT INTO roles (name, description) VALUES 
-    ('ROLE_USER', '普通用户'),
-    ('ROLE_ADMIN', '管理员'),
-    ('ROLE_SUPER_ADMIN', '超级管理员');
+INSERT INTO roles (tenant_id, name, description) VALUES
+    ('default', 'ROLE_USER', '普通用户'),
+    ('default', 'ROLE_ADMIN', '管理员'),
+    ('default', 'ROLE_SUPER_ADMIN', '超级管理员');
 
 INSERT INTO permissions (code, name, resource, action) VALUES
     ('user:read', '查看用户', 'user', 'read'),
@@ -250,12 +261,12 @@ public class UserSummaryResponse {
 
 | 方法 | 路径 | 描述 | 调用方 |
 |------|------|------|--------|
-| GET | `/internal/users/by-username/{username}` | 根据用户名查询 | koduck-auth |
-| GET | `/internal/users/by-email/{email}` | 根据邮箱查询 | koduck-auth |
-| POST | `/internal/users` | 创建用户（注册回调） | koduck-auth |
-| PUT | `/internal/users/{userId}/last-login` | 更新最后登录时间 | koduck-auth |
-| GET | `/internal/users/{userId}/roles` | 获取用户角色 | koduck-auth |
-| GET | `/internal/users/{userId}/permissions` | 获取用户权限 | koduck-auth, 其他服务 |
+| GET | `/internal/users/by-username/{username}` | 根据用户名查询（需 `X-Tenant-Id`） | koduck-auth |
+| GET | `/internal/users/by-email/{email}` | 根据邮箱查询（需 `X-Tenant-Id`） | koduck-auth |
+| POST | `/internal/users` | 创建用户（注册回调，需 `X-Tenant-Id`） | koduck-auth |
+| PUT | `/internal/users/{userId}/last-login` | 更新最后登录时间（需 `X-Tenant-Id`） | koduck-auth |
+| GET | `/internal/users/{userId}/roles` | 获取用户角色（需 `X-Tenant-Id`） | koduck-auth |
+| GET | `/internal/users/{userId}/permissions` | 获取用户权限（需 `X-Tenant-Id`） | koduck-auth, 其他服务 |
 
 ---
 
@@ -284,9 +295,10 @@ public class InternalUserController {
      */
     @GetMapping("/users/by-username/{username}")
     public ResponseEntity<UserDetailsResponse> findByUsername(
+            @RequestHeader("X-Tenant-Id") String tenantId,
             @PathVariable String username,
             @RequestHeader(value = "X-Consumer-Username", required = false) String consumer) {
-        return userService.findByUsername(username)
+        return userService.findByUsername(tenantId, username)
             .map(ResponseEntity::ok)
             .orElse(ResponseEntity.notFound().build());
     }
@@ -296,8 +308,9 @@ public class InternalUserController {
      */
     @GetMapping("/users/by-email/{email}")
     public ResponseEntity<UserDetailsResponse> findByEmail(
+            @RequestHeader("X-Tenant-Id") String tenantId,
             @PathVariable String email) {
-        return userService.findByEmail(email)
+        return userService.findByEmail(tenantId, email)
             .map(ResponseEntity::ok)
             .orElse(ResponseEntity.notFound().build());
     }
@@ -307,8 +320,9 @@ public class InternalUserController {
      */
     @PostMapping("/users")
     public ResponseEntity<UserDetailsResponse> createUser(
+            @RequestHeader("X-Tenant-Id") String tenantId,
             @RequestBody @Valid CreateUserRequest request) {
-        UserDetailsResponse user = userService.createUser(request);
+        UserDetailsResponse user = userService.createUser(tenantId, request);
         return ResponseEntity.ok(user);
     }
     
@@ -317,9 +331,10 @@ public class InternalUserController {
      */
     @PutMapping("/users/{userId}/last-login")
     public ResponseEntity<Void> updateLastLogin(
+            @RequestHeader("X-Tenant-Id") String tenantId,
             @PathVariable Long userId,
             @RequestBody LastLoginUpdateRequest request) {
-        userService.updateLastLogin(userId, request);
+        userService.updateLastLogin(tenantId, userId, request);
         return ResponseEntity.ok().build();
     }
     
@@ -327,8 +342,10 @@ public class InternalUserController {
      * 获取用户角色
      */
     @GetMapping("/users/{userId}/roles")
-    public ResponseEntity<List<String>> getUserRoles(@PathVariable Long userId) {
-        List<String> roles = userService.getUserRoles(userId);
+    public ResponseEntity<List<String>> getUserRoles(
+            @RequestHeader("X-Tenant-Id") String tenantId,
+            @PathVariable Long userId) {
+        List<String> roles = userService.getUserRoles(tenantId, userId);
         return ResponseEntity.ok(roles);
     }
     
@@ -336,8 +353,10 @@ public class InternalUserController {
      * 获取用户权限
      */
     @GetMapping("/users/{userId}/permissions")
-    public ResponseEntity<List<String>> getUserPermissions(@PathVariable Long userId) {
-        List<String> permissions = userService.getUserPermissions(userId);
+    public ResponseEntity<List<String>> getUserPermissions(
+            @RequestHeader("X-Tenant-Id") String tenantId,
+            @PathVariable Long userId) {
+        List<String> permissions = userService.getUserPermissions(tenantId, userId);
         return ResponseEntity.ok(permissions);
     }
 }
@@ -443,22 +462,23 @@ public class UserServiceImpl implements UserService {
     // 内部 API 方法
     @Override
     @Transactional(readOnly = true)
-    public Optional<UserDetailsResponse> findByUsername(String username) {
-        return userRepository.findByUsername(username)
+    public Optional<UserDetailsResponse> findByUsername(String tenantId, String username) {
+        return userRepository.findByTenantIdAndUsername(tenantId, username)
             .map(this::buildUserDetailsResponse);
     }
     
     @Override
     @Transactional(readOnly = true)
-    public Optional<UserDetailsResponse> findByEmail(String email) {
-        return userRepository.findByEmail(email)
+    public Optional<UserDetailsResponse> findByEmail(String tenantId, String email) {
+        return userRepository.findByTenantIdAndEmail(tenantId, email)
             .map(this::buildUserDetailsResponse);
     }
     
     @Override
     @Transactional
-    public UserDetailsResponse createUser(CreateUserRequest request) {
+    public UserDetailsResponse createUser(String tenantId, CreateUserRequest request) {
         User user = User.builder()
+            .tenantId(tenantId)
             .username(request.getUsername())
             .email(request.getEmail())
             .passwordHash(request.getPasswordHash())
@@ -472,8 +492,8 @@ public class UserServiceImpl implements UserService {
     
     @Override
     @Transactional
-    public void updateLastLogin(Long userId, LastLoginUpdateRequest request) {
-        userRepository.updateLastLogin(userId, request.getLoginTime(), request.getIpAddress());
+    public void updateLastLogin(String tenantId, Long userId, LastLoginUpdateRequest request) {
+        userRepository.updateLastLogin(tenantId, userId, request.getLoginTime(), request.getIpAddress());
     }
     
     // ... 其他方法实现
@@ -507,6 +527,9 @@ spring:
   flyway:
     enabled: true
     locations: classpath:db/migration
+
+tenant:
+  default-id: ${KODUCK_DEFAULT_TENANT_ID:default}
 
 # 文件存储（头像上传）
 storage:

--- a/koduck-user/docs/adr/0017-freeze-tenant-id-semantics.md
+++ b/koduck-user/docs/adr/0017-freeze-tenant-id-semantics.md
@@ -1,0 +1,132 @@
+# ADR-0017: 冻结 Auth/User `tenant_id` V1 语义
+
+## 元数据
+
+- **状态**: 已接受
+- **日期**: 2026-04-11
+- **作者**: @hailingu
+- **相关**: #759, docs/implementation/koduck-auth-user-tenant-semantics-tasks.md Task 1.1, ADR-0016
+
+---
+
+## 背景与问题陈述
+
+`koduck-auth` 与 `koduck-user` 已经有多租户设计草案，但现有模块设计文档仍残留单租户语义：用户名、邮箱、角色名被描述为全局唯一，内部 API 也没有固定 `X-Tenant-Id` 上下文来源。
+
+如果在 Phase 2 之前不冻结 `tenant_id` 的 V1 语义，后续数据库迁移、JWT claims、internal API、gRPC 与 APISIX 透传会各自做出不同假设，导致同一个用户身份在跨服务调用中被不一致解释。
+
+---
+
+## 决策驱动因素
+
+1. **跨服务一致性**: `koduck-auth`、`koduck-user`、APISIX 以及下游业务服务必须对租户有同一个解释。
+2. **迁移可执行性**: 数据库字段类型、索引与唯一约束需要先有稳定定义。
+3. **认证安全性**: 不能允许认证链路通过邮箱域名、角色名等弱信号推断租户。
+4. **范围收敛**: V1 目标是打通租户身份语义，不引入 hierarchy 或跨租户共享模型。
+
+---
+
+## 考虑的选项
+
+### 选项 1：延后冻结，等数据库与接口改造时再逐步决定
+
+**优点**:
+- 前期文档改动少
+
+**缺点**:
+- 各模块会在实现期形成不同假设
+- 后续返工成本高，容易出现 schema / JWT / header 不一致
+
+### 选项 2：现在冻结最小但完整的 V1 语义（选定）
+
+**优点**:
+- 为 Phase 2-5 提供统一边界
+- 可以直接约束数据库、JWT、header、internal API 与 gRPC
+
+**缺点**:
+- 需要现在就放弃部分未来扩展自由度
+
+### 选项 3：直接引入 hierarchy / tenant admin / 超级租户
+
+**优点**:
+- 一次性覆盖未来复杂场景
+
+**缺点**:
+- 超出当前任务范围
+- 会显著拉高迁移与实现复杂度
+
+---
+
+## 决策结果
+
+采用 **选项 2**，冻结 `tenant_id` 的 V1 语义如下：
+
+1. `tenant_id` 统一使用字符串语义，数据库列类型固定为 `VARCHAR(128)`。
+2. `tenant_id` 的真值来源是 `koduck-user` 的租户真值 `tenants.id` 以及用户记录上的 `users.tenant_id`。
+3. `koduck-auth` 只负责读取并传播 `tenant_id`，不自行生成，也不从邮箱域名、角色名或其他隐式信息推断租户。
+4. 跨服务用户身份统一解释为 `(tenant_id, user_id)`；单独的 `user_id` 不能作为完整身份语义。
+5. APISIX 与下游服务统一消费认证链路传出的 `X-Tenant-Id`，不以自行解析 JWT 作为主路径。
+6. V1 不支持 tenant hierarchy、父子租户继承、跨租户共享资源或超级租户穿透访问。
+
+---
+
+## 实施细节
+
+### 文档落点
+
+| 文件 | 变更说明 |
+|------|------|
+| `docs/design/koduck-auth-user-tenant-semantics.md` | 新增 Task 1.1 冻结结果，明确类型、长度、来源与 V1 边界 |
+| `docs/implementation/koduck-auth-user-tenant-semantics-tasks.md` | 回填 Task 1.1 冻结结果 |
+| `koduck-user/docs/design/koduck-auth-user-service-design.md` | 修正为租户化 schema、internal API 与上下文要求 |
+| `koduck-auth/docs/design/koduck-auth-user-service-design.md` | 同步与 `koduck-user` 相同的跨服务设计约束 |
+
+### 语义约束
+
+1. `tenant_id` 是 opaque identifier，不约定前缀编码、层级语法或可解析结构。
+2. 认证链路必须先确认租户，再允许用户名或邮箱查找用户。
+3. 用户与角色的唯一性语义从“全局唯一”切换为“租户内唯一”。
+
+---
+
+## 权衡与影响
+
+### 正向影响
+
+- Phase 2-5 的实现拥有统一契约基础。
+- 模块文档不再与根设计草案冲突。
+- 为后续 `koduck-ai`、`memory` 等服务提供统一身份语义。
+
+### 负向影响
+
+- 未来如果需要 hierarchy，需要额外 ADR 扩展，而不是在 V1 中隐式兼容。
+- 部分旧文档示例需要同步改写为带租户上下文的版本。
+
+### 缓解措施
+
+- 将 hierarchy、跨租户共享等需求显式留给后续 ADR。
+- 在每个后续阶段任务中继续引用本 ADR 作为约束基线。
+
+---
+
+## 兼容性影响
+
+1. **接口兼容性**: 当前任务仅冻结语义，不直接引入运行时代码破坏，但后续 internal API、JWT 与 gRPC 将基于本语义增加 `tenant_id`。
+2. **数据兼容性**: 存量数据将在后续阶段以 `default` tenant 过渡，不要求当前阶段完成迁移。
+3. **认知兼容性**: 所有服务必须停止使用“全局唯一用户名、邮箱、角色名”的旧前提。
+
+---
+
+## 相关文档
+
+- [koduck-auth-user-tenant-semantics.md](../../../docs/design/koduck-auth-user-tenant-semantics.md)
+- [koduck-auth-user-tenant-semantics-tasks.md](../../../docs/implementation/koduck-auth-user-tenant-semantics-tasks.md)
+- [koduck-auth-user-service-design.md](../design/koduck-auth-user-service-design.md)
+
+---
+
+## 变更日志
+
+| 日期 | 变更 | 作者 |
+|------|------|------|
+| 2026-04-11 | 初始版本 | @hailingu |

--- a/koduck-user/docs/design/koduck-auth-user-service-design.md
+++ b/koduck-user/docs/design/koduck-auth-user-service-design.md
@@ -6,6 +6,9 @@
 
 koduck-user 服务负责用户信息管理、角色权限管理，通过内部 API 向 koduck-auth 和其他服务提供用户数据支持。
 
+> 说明：本文档中的用户与角色模型已按 `docs/design/koduck-auth-user-tenant-semantics.md` 的 V1 冻结语义更新。
+> `tenant_id` 为最长 128 字符的字符串标识，跨服务身份语义统一为 `(tenant_id, user_id)`。
+
 ---
 
 ## 2. 服务边界划分
@@ -50,8 +53,9 @@ koduck-user 服务负责用户信息管理、角色权限管理，通过内部 A
 -- 用户表
 CREATE TABLE users (
     id BIGSERIAL PRIMARY KEY,
-    username VARCHAR(50) NOT NULL UNIQUE,
-    email VARCHAR(100) NOT NULL UNIQUE,
+    tenant_id VARCHAR(128) NOT NULL,
+    username VARCHAR(50) NOT NULL,
+    email VARCHAR(100) NOT NULL,
     password_hash VARCHAR(255) NOT NULL,
     nickname VARCHAR(50),
     avatar_url VARCHAR(255),
@@ -60,15 +64,19 @@ CREATE TABLE users (
     last_login_at TIMESTAMP,
     last_login_ip VARCHAR(45),
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (tenant_id, username),
+    UNIQUE (tenant_id, email)
 );
 
 -- 角色表
 CREATE TABLE roles (
     id SERIAL PRIMARY KEY,
-    name VARCHAR(50) NOT NULL UNIQUE,
+    tenant_id VARCHAR(128) NOT NULL,
+    name VARCHAR(50) NOT NULL,
     description VARCHAR(255),
-    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (tenant_id, name)
 );
 
 -- 权限表
@@ -84,24 +92,27 @@ CREATE TABLE permissions (
 -- 用户角色关联表
 CREATE TABLE user_roles (
     id BIGSERIAL PRIMARY KEY,
+    tenant_id VARCHAR(128) NOT NULL,
     user_id BIGINT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
     role_id INTEGER NOT NULL REFERENCES roles(id) ON DELETE CASCADE,
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    UNIQUE(user_id, role_id)
+    UNIQUE(tenant_id, user_id, role_id)
 );
 
 -- 角色权限关联表
 CREATE TABLE role_permissions (
     id BIGSERIAL PRIMARY KEY,
+    tenant_id VARCHAR(128) NOT NULL,
     role_id INTEGER NOT NULL REFERENCES roles(id) ON DELETE CASCADE,
     permission_id INTEGER NOT NULL REFERENCES permissions(id) ON DELETE CASCADE,
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    UNIQUE(role_id, permission_id)
+    UNIQUE(tenant_id, role_id, permission_id)
 );
 
 -- 用户凭证表（支持多因素认证）
 CREATE TABLE user_credentials (
     id BIGSERIAL PRIMARY KEY,
+    tenant_id VARCHAR(128) NOT NULL,
     user_id BIGINT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
     credential_type VARCHAR(20) NOT NULL, -- PASSWORD, TOTP, FIDO2, etc.
     credential_value VARCHAR(255) NOT NULL,
@@ -114,20 +125,20 @@ CREATE TABLE user_credentials (
 );
 
 -- 索引
-CREATE INDEX idx_users_username ON users(username);
-CREATE INDEX idx_users_email ON users(email);
+CREATE INDEX idx_users_tenant_username ON users(tenant_id, username);
+CREATE INDEX idx_users_tenant_email ON users(tenant_id, email);
 CREATE INDEX idx_users_status ON users(status);
-CREATE INDEX idx_user_roles_user_id ON user_roles(user_id);
-CREATE INDEX idx_user_roles_role_id ON user_roles(role_id);
-CREATE INDEX idx_role_permissions_role_id ON role_permissions(role_id);
-CREATE INDEX idx_role_permissions_permission_id ON role_permissions(permission_id);
-CREATE INDEX idx_user_credentials_user_id ON user_credentials(user_id);
+CREATE INDEX idx_user_roles_tenant_user_id ON user_roles(tenant_id, user_id);
+CREATE INDEX idx_user_roles_tenant_role_id ON user_roles(tenant_id, role_id);
+CREATE INDEX idx_role_permissions_tenant_role_id ON role_permissions(tenant_id, role_id);
+CREATE INDEX idx_role_permissions_tenant_permission_id ON role_permissions(tenant_id, permission_id);
+CREATE INDEX idx_user_credentials_tenant_user_id ON user_credentials(tenant_id, user_id);
 
 -- 初始化数据
-INSERT INTO roles (name, description) VALUES 
-    ('ROLE_USER', '普通用户'),
-    ('ROLE_ADMIN', '管理员'),
-    ('ROLE_SUPER_ADMIN', '超级管理员');
+INSERT INTO roles (tenant_id, name, description) VALUES
+    ('default', 'ROLE_USER', '普通用户'),
+    ('default', 'ROLE_ADMIN', '管理员'),
+    ('default', 'ROLE_SUPER_ADMIN', '超级管理员');
 
 INSERT INTO permissions (code, name, resource, action) VALUES
     ('user:read', '查看用户', 'user', 'read'),
@@ -250,12 +261,12 @@ public class UserSummaryResponse {
 
 | 方法 | 路径 | 描述 | 调用方 |
 |------|------|------|--------|
-| GET | `/internal/users/by-username/{username}` | 根据用户名查询 | koduck-auth |
-| GET | `/internal/users/by-email/{email}` | 根据邮箱查询 | koduck-auth |
-| POST | `/internal/users` | 创建用户（注册回调） | koduck-auth |
-| PUT | `/internal/users/{userId}/last-login` | 更新最后登录时间 | koduck-auth |
-| GET | `/internal/users/{userId}/roles` | 获取用户角色 | koduck-auth |
-| GET | `/internal/users/{userId}/permissions` | 获取用户权限 | koduck-auth, 其他服务 |
+| GET | `/internal/users/by-username/{username}` | 根据用户名查询（需 `X-Tenant-Id`） | koduck-auth |
+| GET | `/internal/users/by-email/{email}` | 根据邮箱查询（需 `X-Tenant-Id`） | koduck-auth |
+| POST | `/internal/users` | 创建用户（注册回调，需 `X-Tenant-Id`） | koduck-auth |
+| PUT | `/internal/users/{userId}/last-login` | 更新最后登录时间（需 `X-Tenant-Id`） | koduck-auth |
+| GET | `/internal/users/{userId}/roles` | 获取用户角色（需 `X-Tenant-Id`） | koduck-auth |
+| GET | `/internal/users/{userId}/permissions` | 获取用户权限（需 `X-Tenant-Id`） | koduck-auth, 其他服务 |
 
 ---
 
@@ -284,9 +295,10 @@ public class InternalUserController {
      */
     @GetMapping("/users/by-username/{username}")
     public ResponseEntity<UserDetailsResponse> findByUsername(
+            @RequestHeader("X-Tenant-Id") String tenantId,
             @PathVariable String username,
             @RequestHeader(value = "X-Consumer-Username", required = false) String consumer) {
-        return userService.findByUsername(username)
+        return userService.findByUsername(tenantId, username)
             .map(ResponseEntity::ok)
             .orElse(ResponseEntity.notFound().build());
     }
@@ -296,8 +308,9 @@ public class InternalUserController {
      */
     @GetMapping("/users/by-email/{email}")
     public ResponseEntity<UserDetailsResponse> findByEmail(
+            @RequestHeader("X-Tenant-Id") String tenantId,
             @PathVariable String email) {
-        return userService.findByEmail(email)
+        return userService.findByEmail(tenantId, email)
             .map(ResponseEntity::ok)
             .orElse(ResponseEntity.notFound().build());
     }
@@ -307,8 +320,9 @@ public class InternalUserController {
      */
     @PostMapping("/users")
     public ResponseEntity<UserDetailsResponse> createUser(
+            @RequestHeader("X-Tenant-Id") String tenantId,
             @RequestBody @Valid CreateUserRequest request) {
-        UserDetailsResponse user = userService.createUser(request);
+        UserDetailsResponse user = userService.createUser(tenantId, request);
         return ResponseEntity.ok(user);
     }
     
@@ -317,9 +331,10 @@ public class InternalUserController {
      */
     @PutMapping("/users/{userId}/last-login")
     public ResponseEntity<Void> updateLastLogin(
+            @RequestHeader("X-Tenant-Id") String tenantId,
             @PathVariable Long userId,
             @RequestBody LastLoginUpdateRequest request) {
-        userService.updateLastLogin(userId, request);
+        userService.updateLastLogin(tenantId, userId, request);
         return ResponseEntity.ok().build();
     }
     
@@ -327,8 +342,10 @@ public class InternalUserController {
      * 获取用户角色
      */
     @GetMapping("/users/{userId}/roles")
-    public ResponseEntity<List<String>> getUserRoles(@PathVariable Long userId) {
-        List<String> roles = userService.getUserRoles(userId);
+    public ResponseEntity<List<String>> getUserRoles(
+            @RequestHeader("X-Tenant-Id") String tenantId,
+            @PathVariable Long userId) {
+        List<String> roles = userService.getUserRoles(tenantId, userId);
         return ResponseEntity.ok(roles);
     }
     
@@ -336,8 +353,10 @@ public class InternalUserController {
      * 获取用户权限
      */
     @GetMapping("/users/{userId}/permissions")
-    public ResponseEntity<List<String>> getUserPermissions(@PathVariable Long userId) {
-        List<String> permissions = userService.getUserPermissions(userId);
+    public ResponseEntity<List<String>> getUserPermissions(
+            @RequestHeader("X-Tenant-Id") String tenantId,
+            @PathVariable Long userId) {
+        List<String> permissions = userService.getUserPermissions(tenantId, userId);
         return ResponseEntity.ok(permissions);
     }
 }
@@ -443,22 +462,23 @@ public class UserServiceImpl implements UserService {
     // 内部 API 方法
     @Override
     @Transactional(readOnly = true)
-    public Optional<UserDetailsResponse> findByUsername(String username) {
-        return userRepository.findByUsername(username)
+    public Optional<UserDetailsResponse> findByUsername(String tenantId, String username) {
+        return userRepository.findByTenantIdAndUsername(tenantId, username)
             .map(this::buildUserDetailsResponse);
     }
     
     @Override
     @Transactional(readOnly = true)
-    public Optional<UserDetailsResponse> findByEmail(String email) {
-        return userRepository.findByEmail(email)
+    public Optional<UserDetailsResponse> findByEmail(String tenantId, String email) {
+        return userRepository.findByTenantIdAndEmail(tenantId, email)
             .map(this::buildUserDetailsResponse);
     }
     
     @Override
     @Transactional
-    public UserDetailsResponse createUser(CreateUserRequest request) {
+    public UserDetailsResponse createUser(String tenantId, CreateUserRequest request) {
         User user = User.builder()
+            .tenantId(tenantId)
             .username(request.getUsername())
             .email(request.getEmail())
             .passwordHash(request.getPasswordHash())
@@ -472,8 +492,8 @@ public class UserServiceImpl implements UserService {
     
     @Override
     @Transactional
-    public void updateLastLogin(Long userId, LastLoginUpdateRequest request) {
-        userRepository.updateLastLogin(userId, request.getLoginTime(), request.getIpAddress());
+    public void updateLastLogin(String tenantId, Long userId, LastLoginUpdateRequest request) {
+        userRepository.updateLastLogin(tenantId, userId, request.getLoginTime(), request.getIpAddress());
     }
     
     // ... 其他方法实现
@@ -507,6 +527,9 @@ spring:
   flyway:
     enabled: true
     locations: classpath:db/migration
+
+tenant:
+  default-id: ${KODUCK_DEFAULT_TENANT_ID:default}
 
 # 文件存储（头像上传）
 storage:


### PR DESCRIPTION
## Summary
- freeze `tenant_id` V1 semantics in the root auth/user tenant design and task docs
- add ADR to codify source, storage type, `(tenant_id, user_id)` identity semantics, and explicit non-support for tenant hierarchy in V1
- align duplicated auth/user service design docs with tenant-scoped uniqueness and `X-Tenant-Id` internal API context

## Verification
- `docker build -t koduck-user:dev ./koduck-user`
- `kubectl rollout restart deployment/dev-koduck-user -n koduck-dev`
- `kubectl rollout status deployment/dev-koduck-user -n koduck-dev --timeout=180s`

Closes #759
