### PR TITLE
docs(auth-user): inventory tenant-id contract impacts

### DIFF
--- a/docs/design/koduck-auth-user-tenant-contract-inventory.md
+++ b/docs/design/koduck-auth-user-tenant-contract-inventory.md
@@ -1,0 +1,133 @@
+# Koduck Auth / User Tenant 契约影响清单（Task 1.2）
+
+> 基线设计：
+> [`/Users/guhailin/Git/koduck-quant/docs/design/koduck-auth-user-tenant-semantics.md`](/Users/guhailin/Git/koduck-quant/docs/design/koduck-auth-user-tenant-semantics.md)
+>
+> 任务来源：
+> [`/Users/guhailin/Git/koduck-quant/docs/implementation/koduck-auth-user-tenant-semantics-tasks.md`](/Users/guhailin/Git/koduck-quant/docs/implementation/koduck-auth-user-tenant-semantics-tasks.md)
+
+## 1. 目标
+
+本清单用于固定 Task 1.2 的盘点结果：
+
+1. 哪些 JWT / OIDC / introspection 契约必须增加 `tenant_id`
+2. 哪些 internal HTTP API 通过 `X-Tenant-Id` 传递租户上下文，哪些 DTO 需要显式增加字段
+3. 哪些 gRPC message 需要显式增加 `tenant_id`，哪些保持不变
+
+本文档只定义 **影响边界**，不在本任务中直接修改运行时代码或 proto。
+
+---
+
+## 2. 盘点原则
+
+1. **JWT 是租户身份源之一**：凡是直接暴露 JWT claims 或其投影结果的契约，都必须能表达 `tenant_id`。
+2. **internal HTTP 优先使用 header**：`koduck-auth -> koduck-user` 的内部 HTTP 调用统一使用 `X-Tenant-Id` 作为请求上下文，避免在每个 body DTO 中重复携带租户字段。
+3. **gRPC 显式字段优先**：当前 gRPC 契约没有统一 header 约定，因此请求/响应消息中凡是需要表达身份作用域，都要显式带 `tenant_id`。
+4. **返回身份就返回租户**：任何回传用户身份、token 校验结果或 introspection 结果的响应，都不应只返回裸 `user_id`。
+5. **边界收敛**：Task 1.2 只盘点 Auth/User 当前主链路，不扩展到 APISIX 配置细节或下游业务服务自定义协议。
+
+---
+
+## 3. JWT / OIDC / Introspection 影响清单
+
+| 契约面 | 当前位置 | 需要的 `tenant_id` 变更 | 说明 |
+|------|------|------|------|
+| JWT Claims | `koduck-auth/src/model/token.rs` `Claims` | 新增 `tenant_id: String` | access / refresh token 都需要保留租户语义，避免 refresh / validate 链路丢失 tenant |
+| JWT 生成器 | `koduck-auth/src/jwt/generator.rs` | 生成 access / refresh token 时写入 `tenant_id` | `tenant_id` 来源于用户真值，不在生成器内部推断 |
+| JWT 校验器 / claims 解析 | `koduck-auth/src/jwt/validator.rs`、`try_extract_claims_without_verification` | 校验后可读出 `tenant_id` | 后续 revoke / refresh / introspection 需要使用 |
+| OIDC discovery | `koduck-auth/src/http/handler/oidc.rs` `claims_supported` | 增加 `"tenant_id"` | discovery 需要对外声明 claim 能力 |
+| HTTP introspection 结果 | `koduck-auth/src/model/token.rs` `TokenIntrospectionResult` | 新增 `tenant_id` | `/oauth/introspect` 的 JSON 响应直接来自该模型 |
+| 对内 token validate 响应 | `koduck-auth/docs/design/koduck-auth-api.yaml` `TokenValidationResult`、`koduck-user/src/main/java/com/koduck/client/dto/TokenIntrospectionResponse.java` | 新增 `tenantId` / `tenant_id` | `koduck-user` 反向调用 `koduck-auth` 自省时也要拿到租户 |
+
+### 3.1 JWT 边界说明
+
+1. `tenant_id` 是 JWT claims 的一部分，不是 OIDC `scope` 的替代物。
+2. `tenant_id` 不通过 `roles`、`aud`、`iss` 或 `sub` 派生。
+3. `TokenPair` 本身不额外增加顶层 `tenant_id` 字段；V1 以 token claims 为准。
+
+---
+
+## 4. Internal HTTP API 影响清单
+
+### 4.1 请求上下文
+
+以下 `koduck-auth -> koduck-user` 内部接口统一要求增加请求头：
+
+- `X-Tenant-Id`
+
+适用路径：
+
+- `GET /internal/users/by-username/{username}`
+- `GET /internal/users/by-email/{email}`
+- `POST /internal/users`
+- `PUT /internal/users/{userId}/last-login`
+- `GET /internal/users/{userId}/roles`
+- `GET /internal/users/{userId}/permissions`
+
+### 4.2 DTO 盘点
+
+| DTO / 契约 | 当前位置 | 变更类型 | 结论 |
+|------|------|------|------|
+| `UserDetailsResponse` | `koduck-user/src/main/java/com/koduck/dto/user/user/UserDetailsResponse.java` | 返回 DTO 新增字段 | 需要新增 `tenantId`，因为它承担身份回传语义 |
+| `InternalUserDetails` | `koduck-auth/src/service/auth_service.rs` | auth 侧客户端 DTO 新增字段 | 需要新增 `tenant_id` / `tenantId` 映射，与 `UserDetailsResponse` 对齐 |
+| `CreateUserRequest` | `koduck-user/src/main/java/com/koduck/dto/user/user/CreateUserRequest.java` | 请求体是否加字段 | **不新增**；租户由 `X-Tenant-Id` header 提供 |
+| `InternalCreateUserRequest` | `koduck-auth/src/service/auth_service.rs` | auth 侧请求 DTO 是否加字段 | **不新增**；请求头负责传递租户上下文 |
+| `LastLoginUpdateRequest` | `koduck-user/src/main/java/com/koduck/dto/user/user/LastLoginUpdateRequest.java` | 请求体是否加字段 | **不新增**；租户由 `X-Tenant-Id` header 提供 |
+| `LastLoginUpdatePayload` | `koduck-auth/src/service/auth_service.rs` | auth 侧请求 DTO 是否加字段 | **不新增**；请求头负责传递租户上下文 |
+| `koduck-auth ↔ koduck-user` internal contract 文档 | `koduck-user/docs/contracts/koduck-auth-user-internal-api-contract.md` | 契约文档调整 | 需要把 `X-Tenant-Id` 列为必需 header，并说明 body DTO 不重复携带 `tenant_id` |
+
+### 4.3 Internal API 边界说明
+
+1. internal HTTP 不采用“header + body 双写 `tenant_id`”。
+2. 对于 `findByUsername / findByEmail` 这类会跨租户歧义的接口，`X-Tenant-Id` 是必需上下文，不允许省略。
+3. 返回 `UserDetailsResponse` 时显式返回 `tenantId`，用于调用方校验 header 与用户真值一致。
+
+---
+
+## 5. gRPC 影响清单
+
+| Message | 当前文件 | 变更结论 | 说明 |
+|------|------|------|------|
+| `ValidateCredentialsRequest` | `koduck-auth/proto/koduck/auth/v1/auth.proto` | 新增 `tenant_id` | 登录输入 username/email 时必须同时确定租户 |
+| `ValidateCredentialsResponse` | 同上 | 通过 `UserInfo.tenant_id` 回传 | 不单独增加顶层字段，避免重复 |
+| `ValidateTokenResponse` | 同上 | 新增 `tenant_id` | token 校验结果不能只返回裸 `user_id` |
+| `GetUserRequest` | 同上 | 新增 `tenant_id` | 尤其 username/email 查询必须带租户作用域；按 `user_id` 查询也统一保留该字段 |
+| `GetUserResponse` | 同上 | 通过 `UserInfo.tenant_id` 回传 | 下游拿到用户信息时应同时拿到 tenant |
+| `GetUserRolesRequest` | 同上 | 新增 `tenant_id` | `(tenant_id, user_id)` 才是完整身份 |
+| `GetUserRolesResponse` | 同上 | 新增 `tenant_id` | 便于调用方与日志链路保持一致 |
+| `RevokeTokenRequest` | 同上 | 新增 `tenant_id` | 防止吊销和审计链路只按 `user_id` 解释 |
+| `LogoutRequest` | 同上 | 新增 `tenant_id` | 与 refresh token 吊销链路保持一致 |
+| `IntrospectTokenResponse` | 同上 | 新增 `tenant_id` | introspection 是 JWT claims 的投影结果，必须返回 tenant |
+| `RefreshTokenRequest` | 同上 | **不新增** | V1 依赖 refresh token 自身 claims 保持租户一致 |
+| `RefreshTokenResponse` | 同上 | **不新增** | 返回 token pair 即可，租户仍以 claims 为准 |
+| `GenerateTokenPairRequest` | 同上 | 新增 `tenant_id` | 内部直接生成 token 时必须显式给出租户 |
+| `GenerateTokenPairResponse` | 同上 | **不新增** | 返回 token pair 即可，不重复回传 tenant 顶层字段 |
+| `UserInfo` | 同上 | 新增 `tenant_id` | 作为多个响应复用的嵌套身份模型 |
+
+### 5.1 gRPC 边界说明
+
+1. 由于当前 gRPC 设计没有统一 metadata 约定，`tenant_id` 不能只放在 metadata 而不进 message。
+2. 需要唯一定位用户的 request，一律显式带 `tenant_id`。
+3. `UserInfo` 是复用型身份载体，后续凡返回用户信息的 response 都应通过它承载 `tenant_id`。
+4. `RefreshTokenRequest/Response` 和 `GenerateTokenPairResponse` 不重复暴露 `tenant_id` 顶层字段，以免形成“token claims 与响应字段双真值”。
+
+---
+
+## 6. 不在 Task 1.2 直接修改的内容
+
+以下内容属于后续阶段，不在本任务中直接实现：
+
+1. proto / OpenAPI / Java DTO / Rust model 的实际字段变更
+2. APISIX 路由或插件的 header 注入实现
+3. 数据库 schema 迁移与存量数据回填
+4. 下游服务（`koduck-ai`、`memory` 等）的消费改造
+
+---
+
+## 7. 结论
+
+Task 1.2 的契约边界已经明确：
+
+1. **JWT / introspection** 必须把 `tenant_id` 当作一等身份字段。
+2. **internal HTTP** 统一用 `X-Tenant-Id` 传请求上下文，只有身份回传 DTO 才新增字段。
+3. **gRPC** 因无统一 header 语义，凡是涉及用户身份、token 校验、token 生成、角色权限查询的 message，都要显式纳入 `tenant_id` 或通过 `UserInfo` 回传。

--- a/docs/design/koduck-auth-user-tenant-semantics.md
+++ b/docs/design/koduck-auth-user-tenant-semantics.md
@@ -307,6 +307,22 @@ V1 更推荐用 header，与网关透传保持一致。
 - `getTenantId()`
 - `HEADER_TENANT_ID = "X-Tenant-Id"`
 
+### 10.4 Task 1.2 契约盘点结果
+
+Task 1.2 已将 `tenant_id` 的契约影响拆分为三类：
+
+1. **JWT / OIDC / introspection**
+   - `Claims`、`TokenIntrospectionResult`、OIDC discovery 的 `claims_supported` 都需要显式补充 `tenant_id`
+   - 与 token 校验相关的对内响应需要返回 `tenant_id`，避免下游只能依赖 `user_id`
+2. **internal HTTP API**
+   - `koduck-auth -> koduck-user` 的内部调用统一通过 `X-Tenant-Id` 传递租户上下文
+   - 请求体 DTO 不重复新增 `tenant_id`，除非该 DTO 本身承担身份回传语义
+3. **gRPC**
+   - 因当前 gRPC 契约没有统一 header 约定，凡是需要唯一标识用户或生成/校验 token 的 message，都要显式增加 `tenant_id` 字段，或通过嵌套 `UserInfo` 回传
+
+完整影响矩阵见：
+- [`docs/design/koduck-auth-user-tenant-contract-inventory.md`](/Users/guhailin/Git/koduck-quant/docs/design/koduck-auth-user-tenant-contract-inventory.md)
+
 ---
 
 ## 11. 迁移策略

--- a/docs/implementation/koduck-auth-user-tenant-semantics-tasks.md
+++ b/docs/implementation/koduck-auth-user-tenant-semantics-tasks.md
@@ -44,9 +44,16 @@
 2. 盘点需要增加 `tenant_id` 的 internal API DTO
 3. 盘点需要增加 `tenant_id` 的 gRPC 消息
 
+**盘点结果（2026-04-11）:**
+- JWT / OIDC / introspection 侧，`Claims`、`TokenIntrospectionResult`、OIDC discovery `claims_supported` 与对内 token validate 响应都需要纳入 `tenant_id`
+- internal HTTP 侧，`koduck-auth -> koduck-user` 统一通过 `X-Tenant-Id` 传请求上下文；`UserDetailsResponse` / auth 侧 `InternalUserDetails` 需要回传 `tenant_id`，`CreateUserRequest` / `LastLoginUpdateRequest` 不在 body 中重复新增
+- gRPC 侧，`ValidateCredentialsRequest`、`ValidateTokenResponse`、`GetUserRequest`、`GetUserRolesRequest/Response`、`RevokeTokenRequest`、`LogoutRequest`、`IntrospectTokenResponse`、`GenerateTokenPairRequest`、`UserInfo` 需要显式纳入 `tenant_id` 或通过嵌套 `UserInfo` 回传
+- `RefreshTokenRequest/Response` 与 `GenerateTokenPairResponse` 不额外增加顶层 `tenant_id`，以 JWT claims 作为单一真值
+- 完整清单见 `docs/design/koduck-auth-user-tenant-contract-inventory.md`
+
 **验收标准:**
-- [ ] 影响接口清单完整
-- [ ] 契约改动边界清晰
+- [x] 影响接口清单完整
+- [x] 契约改动边界清晰
 
 ---
 

--- a/koduck-auth/docs/adr/0022-inventory-tenant-id-contract-impacts.md
+++ b/koduck-auth/docs/adr/0022-inventory-tenant-id-contract-impacts.md
@@ -1,0 +1,138 @@
+# ADR-0022: Task 1.2 租户契约影响清单冻结
+
+## 元数据
+
+- **状态**: 已接受
+- **日期**: 2026-04-11
+- **作者**: @hailingu
+- **相关**: #761, docs/implementation/koduck-auth-user-tenant-semantics-tasks.md Task 1.2, ADR-0021
+
+---
+
+## 背景与问题陈述
+
+Task 1.1 已冻结 `tenant_id` 的语义，但还没有明确“哪些现有 JWT、internal API、gRPC 契约必须调整，哪些不需要动”。如果没有这层盘点，后续各阶段很容易出现两类问题：
+
+1. 漏改关键返回结构，导致下游只能拿到 `user_id` 而拿不到租户。
+2. 在 internal HTTP 和 gRPC 上重复设计 `tenant_id` 的传递方式，形成 header、body、message 三套不一致语义。
+
+因此需要先冻结 Task 1.2 的契约影响边界，再进入 Phase 2-5 的实现。
+
+---
+
+## 决策驱动因素
+
+1. **完整性**: 必须列清所有会被多租户语义影响的契约面，而不是只列设计文档中提到的几个代表项。
+2. **一致性**: HTTP internal API 与 gRPC 需要采用清晰且一致的传递规则。
+3. **最小重复**: 避免在 header、body、response 同时重复携带 `tenant_id`，造成双真值。
+4. **可实施性**: 后续开发任务需要直接依据本清单逐项落代码与测试。
+
+---
+
+## 考虑的选项
+
+### 选项 1：仅在根设计文档中保留抽象描述
+
+**优点**:
+- 文档最少
+
+**缺点**:
+- 无法告诉实施者具体该改哪个 DTO、哪个 message
+- 容易在 auth/user 两边产生理解偏差
+
+### 选项 2：补一份专门的契约影响清单，并同步关键合同文档（选定）
+
+**优点**:
+- 能直接映射到 JWT model、internal DTO、proto message
+- 便于后续按阶段实现
+
+**缺点**:
+- 文档维护成本略有增加
+
+### 选项 3：直接修改所有 proto / DTO / OpenAPI，而不先盘点
+
+**优点**:
+- 看起来推进更快
+
+**缺点**:
+- 在数据库和运行时语义尚未全面落地前，容易做出过度或错误改动
+- 缺少边界文档，不利于审查
+
+---
+
+## 决策结果
+
+采用 **选项 2**，冻结 Task 1.2 的契约盘点规则：
+
+1. **JWT / OIDC / introspection**
+   - 所有直接表达 claims 或 claims 投影的结构，都要补充 `tenant_id`
+2. **internal HTTP API**
+   - `koduck-auth -> koduck-user` 统一通过 `X-Tenant-Id` 传递租户上下文
+   - 请求体 DTO 默认不重复增加 `tenant_id`
+   - 身份回传 DTO（如 `UserDetailsResponse`）需要显式增加 `tenantId`
+3. **gRPC**
+   - 由于当前没有统一 metadata 约定，涉及身份作用域的 request/response message 必须显式增加 `tenant_id`，或通过 `UserInfo` 回传
+4. **边界排除**
+   - `RefreshTokenRequest/Response` 与 `GenerateTokenPairResponse` 不额外增加顶层 `tenant_id`，避免与 JWT claims 形成双真值
+
+---
+
+## 实施细节
+
+### 文档落点
+
+| 文件 | 变更说明 |
+|------|------|
+| `docs/design/koduck-auth-user-tenant-semantics.md` | 增加 Task 1.2 契约盘点摘要与入口链接 |
+| `docs/design/koduck-auth-user-tenant-contract-inventory.md` | 新增完整影响清单 |
+| `koduck-user/docs/contracts/koduck-auth-user-internal-api-contract.md` | 固定 `X-Tenant-Id` header 语义与 DTO 边界 |
+
+### 关键边界
+
+1. `X-Tenant-Id` 是 internal HTTP 的单一请求上下文来源。
+2. gRPC 不依赖隐式 metadata，而是依赖显式 message 字段。
+3. `tenant_id` 只在“返回身份”时进入响应 DTO，不在普通更新类 body 中重复出现。
+
+---
+
+## 权衡与影响
+
+### 正向影响
+
+- 后续 Phase 3-5 可直接按清单落地，不需要再次猜测契约边界。
+- HTTP 和 gRPC 的租户传递策略更清晰。
+- 审查时可以直接对照“是否漏项”。
+
+### 负向影响
+
+- 需要维护一份额外的契约盘点文档。
+- 某些现有设计文档中的示例会暂时落后于目标契约，直到后续实现阶段同步更新。
+
+### 缓解措施
+
+- 将完整清单集中在单一文档中，减少分散维护成本。
+- 后续实现 PR 需明确引用本 ADR 与影响清单。
+
+---
+
+## 兼容性影响
+
+1. **运行时兼容性**: 本任务仅冻结清单，不直接修改运行时代码。
+2. **接口兼容性**: 后续实现会对部分 proto、DTO、OpenAPI 产生非向后兼容变更，需要在相关阶段评估灰度路径。
+3. **调用方兼容性**: 下游未来需要显式消费 `tenant_id` 或 `X-Tenant-Id`，不能继续只依赖 `user_id`。
+
+---
+
+## 相关文档
+
+- [koduck-auth-user-tenant-semantics.md](../../../docs/design/koduck-auth-user-tenant-semantics.md)
+- [koduck-auth-user-tenant-contract-inventory.md](../../../docs/design/koduck-auth-user-tenant-contract-inventory.md)
+- [koduck-auth-user-internal-api-contract.md](../../../koduck-user/docs/contracts/koduck-auth-user-internal-api-contract.md)
+
+---
+
+## 变更日志
+
+| 日期 | 变更 | 作者 |
+|------|------|------|
+| 2026-04-11 | 初始版本 | @hailingu |

--- a/koduck-user/docs/contracts/koduck-auth-user-internal-api-contract.md
+++ b/koduck-user/docs/contracts/koduck-auth-user-internal-api-contract.md
@@ -10,12 +10,20 @@
 
 | 场景 | 接口 | 请求 | 成功 | 失败 |
 |------|------|------|------|------|
-| 按用户名查询用户 | `GET /internal/users/by-username/{username}` | Header: `X-Consumer-Username`（可选） | `200` + `UserDetailsResponse` | `404`（无响应体） |
-| 按邮箱查询用户 | `GET /internal/users/by-email/{email}` | Header: `X-Consumer-Username`（可选） | `200` + `UserDetailsResponse` | `404`（无响应体） |
-| 创建用户 | `POST /internal/users` | JSON: `CreateUserRequest` | `200` + `UserDetailsResponse` | `400`（校验失败，`ApiResponse`） / `409`（username/email 冲突，`ApiResponse`） |
-| 更新登录信息 | `PUT /internal/users/{userId}/last-login` | JSON: `LastLoginUpdateRequest` | `200`（空体） | `404`（用户不存在，`ApiResponse`） |
-| 查询角色 | `GET /internal/users/{userId}/roles` | - | `200` + `List<String>` | `404`（用户不存在，`ApiResponse`） |
-| 查询权限 | `GET /internal/users/{userId}/permissions` | - | `200` + `List<String>` | `404`（用户不存在，`ApiResponse`） |
+| 按用户名查询用户 | `GET /internal/users/by-username/{username}` | Header: `X-Tenant-Id`（必需）, `X-Consumer-Username`（可选） | `200` + `UserDetailsResponse` | `404`（无响应体） |
+| 按邮箱查询用户 | `GET /internal/users/by-email/{email}` | Header: `X-Tenant-Id`（必需）, `X-Consumer-Username`（可选） | `200` + `UserDetailsResponse` | `404`（无响应体） |
+| 创建用户 | `POST /internal/users` | Header: `X-Tenant-Id`（必需） + JSON: `CreateUserRequest` | `200` + `UserDetailsResponse` | `400`（校验失败，`ApiResponse`） / `409`（username/email 冲突，`ApiResponse`） |
+| 更新登录信息 | `PUT /internal/users/{userId}/last-login` | Header: `X-Tenant-Id`（必需） + JSON: `LastLoginUpdateRequest` | `200`（空体） | `404`（用户不存在，`ApiResponse`） |
+| 查询角色 | `GET /internal/users/{userId}/roles` | Header: `X-Tenant-Id`（必需） | `200` + `List<String>` | `404`（用户不存在，`ApiResponse`） |
+| 查询权限 | `GET /internal/users/{userId}/permissions` | Header: `X-Tenant-Id`（必需） | `200` + `List<String>` | `404`（用户不存在，`ApiResponse`） |
+
+---
+
+## 租户字段边界
+
+1. `X-Tenant-Id` 是 internal API 的统一租户上下文来源。
+2. `CreateUserRequest` 和 `LastLoginUpdateRequest` **不**在 body 中重复新增 `tenant_id`；租户上下文由 header 传递。
+3. `UserDetailsResponse` 在多租户改造后需要增加 `tenantId`，用于让调用方确认返回身份与请求上下文一致。
 
 ---
 


### PR DESCRIPTION
## Summary
- add a dedicated tenant contract inventory for Task 1.2 covering JWT/OIDC, internal HTTP API, and gRPC surfaces
- add ADR-0022 to freeze the contract-impact boundaries and the header-vs-message rules for tenant propagation
- update the root tenant semantics doc, internal API contract doc, and Task 1.2 checklist/results to reflect the completed inventory

## Verification
- `docker build -t koduck-auth:dev ./koduck-auth`
- `kubectl rollout restart deployment/dev-koduck-auth -n koduck-dev`
- `kubectl rollout status deployment/dev-koduck-auth -n koduck-dev --timeout=180s`

Closes #761
