### PR TITLE
feat(user): add tenant-id schema baseline

### DIFF
--- a/docs/implementation/koduck-auth-user-tenant-semantics-tasks.md
+++ b/docs/implementation/koduck-auth-user-tenant-semantics-tasks.md
@@ -65,9 +65,16 @@
 2. 评估并为 `user_roles`、`role_permissions`、`user_credentials` 增加租户语义
 3. 新增 `tenants` 表或最小租户真值
 
+**执行结果（2026-04-11）:**
+- `koduck-user` 新增 Flyway `V2__add_tenant_columns.sql`，为 `users`、`roles`、`user_roles`、`role_permissions`、`user_credentials` 增加 `tenant_id`
+- 新增 `tenants` 表并写入最小租户真值 `default`
+- 对现有数据执行 `default` tenant 回填，并为新增列设置 `NOT NULL DEFAULT 'default'`
+- 增加基础 tenant 索引，唯一约束切换保留到 Task 2.3
+- 新增 Testcontainers 迁移验证测试，确认 schema 迁移可执行
+
 **验收标准:**
-- [ ] 主表具备 `tenant_id`
-- [ ] 迁移脚本可执行
+- [x] 主表具备 `tenant_id`
+- [x] 迁移脚本可执行
 
 ### Task 2.2: `koduck-auth` 安全域表增加 `tenant_id`
 **详细要求:**

--- a/koduck-user/docs/adr/0018-add-tenant-columns-and-minimal-tenant-truth.md
+++ b/koduck-user/docs/adr/0018-add-tenant-columns-and-minimal-tenant-truth.md
@@ -1,0 +1,135 @@
+# ADR-0018: Task 2.1 为 koduck-user 增加 tenant_id 与最小租户真值
+
+## 元数据
+
+- **状态**: 已接受
+- **日期**: 2026-04-11
+- **作者**: @hailingu
+- **相关**: #763, docs/implementation/koduck-auth-user-tenant-semantics-tasks.md Task 2.1, ADR-0017
+
+---
+
+## 背景与问题陈述
+
+Task 1.1 和 Task 1.2 已经冻结了 `tenant_id` 的语义与契约边界，但 `koduck-user` 数据库仍然是单租户结构：
+
+1. `users` 与 `roles` 没有 `tenant_id`
+2. `user_roles`、`role_permissions`、`user_credentials` 也没有租户作用域字段
+3. 数据库中不存在最小租户真值表，无法给后续认证链路提供稳定来源
+
+如果不先完成这层 schema 演进，后续 Task 2.3 的唯一约束切换、Task 3.x 的 repository 租户化都会缺少基础。
+
+---
+
+## 决策驱动因素
+
+1. **渐进迁移**: 先加列和最小真值，再在后续任务中切唯一约束与查询逻辑。
+2. **兼容上线**: 迁移应允许现有单租户数据在 `default` tenant 下继续工作。
+3. **关系完整性**: 关系表与凭证表也要具备租户语义，否则后续查询仍需跨表推导。
+4. **低风险**: 本任务不提前修改业务查询逻辑，避免把 schema 迁移和行为改造混在一起。
+
+---
+
+## 考虑的选项
+
+### 选项 1：只给 `users`、`roles` 加 `tenant_id`
+
+**优点**:
+- 改动最少
+
+**缺点**:
+- 关系表与凭证表仍缺少租户语义
+- 后续 token / 角色 / 权限链路仍需额外 join 推导
+
+### 选项 2：给主表、关系表、凭证表一起补 tenant 列，并新增最小 `tenants` 表（选定）
+
+**优点**:
+- 为后续多租户查询打下统一 schema 基础
+- `default` tenant 过渡路径清晰
+
+**缺点**:
+- 本阶段会先出现“有 tenant 列但唯一约束仍未切换”的过渡状态
+
+### 选项 3：等 Task 3 再一起修改 schema 和 repository
+
+**优点**:
+- 单次改动覆盖更多内容
+
+**缺点**:
+- 风险集中，难以定位问题
+- 违背任务拆分顺序
+
+---
+
+## 决策结果
+
+采用 **选项 2**，在 `koduck-user` 引入最小多租户 schema：
+
+1. 新增 `tenants` 表，作为最小租户真值，插入默认租户 `default`
+2. 为 `users`、`roles` 增加 `tenant_id VARCHAR(128) NOT NULL DEFAULT 'default'`
+3. 为 `user_roles`、`role_permissions`、`user_credentials` 增加 `tenant_id VARCHAR(128) NOT NULL DEFAULT 'default'`
+4. 增加基础 tenant 索引，但暂不切换用户/角色唯一约束；该动作留给 Task 2.3
+5. 通过 Flyway 迁移脚本完成回填，保证现有数据可平滑进入默认租户
+
+---
+
+## 实施细节
+
+### 变更文件
+
+| 文件 | 变更说明 |
+|------|------|
+| `koduck-user/src/main/resources/db/migration/V2__add_tenant_columns.sql` | 新增租户真值表、tenant 列、默认回填与索引 |
+| `koduck-user/src/test/java/com/koduck/integration/UserTenantSchemaMigrationIntegrationTest.java` | 用 Testcontainers 验证迁移后的 schema |
+
+### 迁移策略
+
+1. 先创建 `tenants` 表并写入 `default`
+2. 再为业务表增加 `tenant_id`
+3. 回填已有数据为 `default`
+4. 将 `tenant_id` 设为 `NOT NULL` 且保留默认值
+5. 唯一约束仍保持旧形态，等待 Task 2.3 再切换
+
+---
+
+## 权衡与影响
+
+### 正向影响
+
+- 为后续 repository 和 internal API 租户化提供 schema 基础。
+- 默认 tenant 让现有数据和旧代码仍能继续工作。
+- 关系表和凭证表不必在运行时再通过 join 推导 tenant。
+
+### 负向影响
+
+- 当前阶段仍处于“schema 已多租户化，唯一约束尚未切换”的过渡状态。
+- 业务代码暂时还不会主动使用这些 tenant 列。
+
+### 缓解措施
+
+- 在 Task 2.3 明确切换租户内唯一约束。
+- 在 Task 3.1 再统一更新实体与 repository 查询。
+
+---
+
+## 兼容性影响
+
+1. **运行时兼容性**: 现有写入路径可继续依赖 `DEFAULT 'default'` 正常工作。
+2. **数据兼容性**: 存量数据会被回填到 `default` tenant，不要求手工迁移。
+3. **调用方兼容性**: 当前任务不改变对外/内部 API 契约。
+
+---
+
+## 相关文档
+
+- [koduck-auth-user-tenant-semantics.md](../../../docs/design/koduck-auth-user-tenant-semantics.md)
+- [koduck-auth-user-tenant-semantics-tasks.md](../../../docs/implementation/koduck-auth-user-tenant-semantics-tasks.md)
+- [ADR-0017](./0017-freeze-tenant-id-semantics.md)
+
+---
+
+## 变更日志
+
+| 日期 | 变更 | 作者 |
+|------|------|------|
+| 2026-04-11 | 初始版本 | @hailingu |

--- a/koduck-user/src/main/resources/db/migration/V2__add_tenant_columns.sql
+++ b/koduck-user/src/main/resources/db/migration/V2__add_tenant_columns.sql
@@ -1,0 +1,103 @@
+-- ============================================================
+-- V2__add_tenant_columns.sql
+-- 模块: koduck-user
+-- 目标数据库: PostgreSQL 14+
+-- 目标: 引入最小租户真值与 tenant_id 基础列
+-- ============================================================
+
+-- ------------------------------------------------------------
+-- 1. 最小租户真值
+-- ------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS tenants (
+    id          VARCHAR(128)    PRIMARY KEY,
+    name        VARCHAR(128)    NOT NULL,
+    status      VARCHAR(32)     NOT NULL DEFAULT 'ACTIVE',
+    created_at  TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at  TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+INSERT INTO tenants (id, name, status)
+VALUES ('default', 'Default Tenant', 'ACTIVE')
+ON CONFLICT (id) DO NOTHING;
+
+CREATE TRIGGER trg_tenants_updated_at
+    BEFORE UPDATE ON tenants
+    FOR EACH ROW EXECUTE FUNCTION trigger_set_updated_at();
+
+-- ------------------------------------------------------------
+-- 2. 主表 tenant_id
+-- ------------------------------------------------------------
+
+ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS tenant_id VARCHAR(128);
+
+ALTER TABLE roles
+    ADD COLUMN IF NOT EXISTS tenant_id VARCHAR(128);
+
+-- ------------------------------------------------------------
+-- 3. 关系表 / 凭证表 tenant 语义
+-- ------------------------------------------------------------
+
+ALTER TABLE user_roles
+    ADD COLUMN IF NOT EXISTS tenant_id VARCHAR(128);
+
+ALTER TABLE role_permissions
+    ADD COLUMN IF NOT EXISTS tenant_id VARCHAR(128);
+
+ALTER TABLE user_credentials
+    ADD COLUMN IF NOT EXISTS tenant_id VARCHAR(128);
+
+-- ------------------------------------------------------------
+-- 4. 默认 tenant 回填与约束
+-- ------------------------------------------------------------
+
+UPDATE users
+SET tenant_id = 'default'
+WHERE tenant_id IS NULL;
+
+UPDATE roles
+SET tenant_id = 'default'
+WHERE tenant_id IS NULL;
+
+UPDATE user_roles
+SET tenant_id = 'default'
+WHERE tenant_id IS NULL;
+
+UPDATE role_permissions
+SET tenant_id = 'default'
+WHERE tenant_id IS NULL;
+
+UPDATE user_credentials
+SET tenant_id = 'default'
+WHERE tenant_id IS NULL;
+
+ALTER TABLE users
+    ALTER COLUMN tenant_id SET DEFAULT 'default',
+    ALTER COLUMN tenant_id SET NOT NULL;
+
+ALTER TABLE roles
+    ALTER COLUMN tenant_id SET DEFAULT 'default',
+    ALTER COLUMN tenant_id SET NOT NULL;
+
+ALTER TABLE user_roles
+    ALTER COLUMN tenant_id SET DEFAULT 'default',
+    ALTER COLUMN tenant_id SET NOT NULL;
+
+ALTER TABLE role_permissions
+    ALTER COLUMN tenant_id SET DEFAULT 'default',
+    ALTER COLUMN tenant_id SET NOT NULL;
+
+ALTER TABLE user_credentials
+    ALTER COLUMN tenant_id SET DEFAULT 'default',
+    ALTER COLUMN tenant_id SET NOT NULL;
+
+-- ------------------------------------------------------------
+-- 5. 基础索引（唯一约束切换在 Task 2.3）
+-- ------------------------------------------------------------
+
+CREATE INDEX IF NOT EXISTS idx_users_tenant_id ON users (tenant_id);
+CREATE INDEX IF NOT EXISTS idx_roles_tenant_id ON roles (tenant_id);
+CREATE INDEX IF NOT EXISTS idx_user_roles_tenant_user_id ON user_roles (tenant_id, user_id);
+CREATE INDEX IF NOT EXISTS idx_role_permissions_tenant_role_id ON role_permissions (tenant_id, role_id);
+CREATE INDEX IF NOT EXISTS idx_user_credentials_tenant_user_id ON user_credentials (tenant_id, user_id);

--- a/koduck-user/src/test/java/com/koduck/integration/UserTenantSchemaMigrationIntegrationTest.java
+++ b/koduck-user/src/test/java/com/koduck/integration/UserTenantSchemaMigrationIntegrationTest.java
@@ -1,0 +1,65 @@
+package com.koduck.integration;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest
+@Testcontainers(disabledWithoutDocker = true)
+class UserTenantSchemaMigrationIntegrationTest {
+
+    @Container
+    static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:15-alpine")
+            .withDatabaseName("koduck_user_tenant_test")
+            .withUsername("test")
+            .withPassword("test");
+
+    @DynamicPropertySource
+    static void configureDataSource(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", POSTGRES::getJdbcUrl);
+        registry.add("spring.datasource.username", POSTGRES::getUsername);
+        registry.add("spring.datasource.password", POSTGRES::getPassword);
+        registry.add("spring.flyway.enabled", () -> true);
+    }
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Test
+    void shouldApplyTenantSchemaMigration() {
+        assertEquals(1, countColumn("tenants", "id"));
+        assertEquals(1, countColumn("users", "tenant_id"));
+        assertEquals(1, countColumn("roles", "tenant_id"));
+        assertEquals(1, countColumn("user_roles", "tenant_id"));
+        assertEquals(1, countColumn("role_permissions", "tenant_id"));
+        assertEquals(1, countColumn("user_credentials", "tenant_id"));
+
+        Integer tenantCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM tenants WHERE id = 'default'",
+                Integer.class);
+        assertEquals(1, tenantCount);
+    }
+
+    private int countColumn(String tableName, String columnName) {
+        Integer count = jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM information_schema.columns
+                WHERE table_schema = 'public'
+                  AND table_name = ?
+                  AND column_name = ?
+                """,
+                Integer.class,
+                tableName,
+                columnName);
+        return count == null ? 0 : count;
+    }
+}


### PR DESCRIPTION
## Summary
- add Flyway V2 migration for `koduck-user` to create `tenants` and add `tenant_id` columns to users, roles, relation tables, and credentials
- backfill the default tenant, keep `tenant_id` as `NOT NULL DEFAULT 'default'`, and add baseline tenant indexes while leaving unique-constraint switching to Task 2.3
- add ADR-0018 and a Testcontainers-based schema migration verification test, and mark Task 2.1 checklist items complete

## Verification
- `mvn -f koduck-user/pom.xml -Dtest=UserTenantSchemaMigrationIntegrationTest test`
- `docker build -t koduck-user:dev ./koduck-user`
- `kubectl rollout restart deployment/dev-koduck-user -n koduck-dev`
- `kubectl rollout status deployment/dev-koduck-user -n koduck-dev --timeout=180s`

Closes #763
