### PR TITLE
feat(auth): add tenant-aware security domain schema

### DIFF
--- a/docs/implementation/koduck-auth-user-tenant-semantics-tasks.md
+++ b/docs/implementation/koduck-auth-user-tenant-semantics-tasks.md
@@ -81,9 +81,15 @@
 1. 为 `refresh_tokens`、`password_reset_tokens`、`audit_logs` 增加 `tenant_id`
 2. 为查询建立租户维度索引
 
+**执行结果（2026-04-11）:**
+- `koduck-auth` 新增迁移 `202604110001_add_tenant_to_security_tables.sql`，为 `refresh_tokens`、`password_reset_tokens`、`audit_logs` 增加 `tenant_id`
+- 对存量数据统一回填 `default`，并将三张表的 `tenant_id` 设为 `NOT NULL DEFAULT 'default'`
+- 为 token / audit 检索补充租户维度索引
+- `RefreshTokenRepository` 与 `PasswordResetRepository` 新增 tenant-aware 保存、查询、吊销/标记方法，无 tenant 参数的方法默认落到 `default`
+
 **验收标准:**
-- [ ] 安全域表具备 `tenant_id`
-- [ ] 按租户查询可用
+- [x] 安全域表具备 `tenant_id`
+- [x] 按租户查询可用
 
 ### Task 2.3: 唯一约束切换为租户内唯一
 **详细要求:**

--- a/koduck-auth/docs/adr/0023-add-tenant-id-to-security-domain-tables.md
+++ b/koduck-auth/docs/adr/0023-add-tenant-id-to-security-domain-tables.md
@@ -1,0 +1,134 @@
+# ADR-0023: Task 2.2 为 koduck-auth 安全域表增加 tenant_id
+
+## 元数据
+
+- **状态**: 已接受
+- **日期**: 2026-04-11
+- **作者**: @hailingu
+- **相关**: #765, docs/implementation/koduck-auth-user-tenant-semantics-tasks.md Task 2.2, ADR-0022
+
+---
+
+## 背景与问题陈述
+
+Task 2.1 已经为 `koduck-user` 建立了租户化 schema 基线，但 `koduck-auth` 的安全域仍然只有单租户语义：
+
+1. `refresh_tokens` 没有 `tenant_id`
+2. `password_reset_tokens` 没有 `tenant_id`
+3. `audit_logs` 没有 `tenant_id`
+
+这会导致 refresh、password reset、审计查询都只能按 `user_id` 或 token hash 理解身份，无法满足多租户设计中“安全域表显式增加 `tenant_id`”的要求。
+
+---
+
+## 决策驱动因素
+
+1. **安全隔离**: token 与审计记录必须保留租户维度，避免跨租户误关联。
+2. **查询效率**: 后续 refresh、revoke、审计检索需要租户维度索引，而不是全表扫描。
+3. **渐进演进**: 保持当前调用链仍能以 `default` tenant 继续运行，同时为后续 tenant-aware 调用埋好接口。
+4. **实现边界**: 本任务聚焦 schema 和最小仓储承接，不提前混入 Task 4 的完整认证租户化逻辑。
+
+---
+
+## 考虑的选项
+
+### 选项 1：只加列，不补任何仓储层承接
+
+**优点**:
+- 改动最小
+
+**缺点**:
+- “按租户查询可用”只能停留在数据库层，代码层无法使用
+
+### 选项 2：加列、回填、补索引，并在仓储层增加最小 tenant-aware 方法（选定）
+
+**优点**:
+- schema 与代码两侧都能承接租户过滤
+- 对现有默认单租户链路影响最小
+
+**缺点**:
+- 仓储层会出现 default tenant 兼容方法与 tenant-aware 方法并存
+
+### 选项 3：等 Task 4 再一次性重构 auth 全链路
+
+**优点**:
+- 看起来更集中
+
+**缺点**:
+- 无法满足当前任务拆分
+- 风险过于集中
+
+---
+
+## 决策结果
+
+采用 **选项 2**：
+
+1. 为 `refresh_tokens`、`password_reset_tokens`、`audit_logs` 增加 `tenant_id VARCHAR(128) NOT NULL DEFAULT 'default'`
+2. 对现有记录回填 `default`
+3. 增加租户维度索引，重点覆盖 `(tenant_id, user_id)` 与 `(tenant_id, created_at / expires_at)`
+4. 在 token / password reset 仓储层新增按租户保存、查询、吊销的方法
+5. 保留现有无 tenant 参数的方法，让其默认落到 `default`，保证旧链路兼容
+
+---
+
+## 实施细节
+
+### 变更文件
+
+| 文件 | 变更说明 |
+|------|------|
+| `koduck-auth/migrations/202604110001_add_tenant_to_security_tables.sql` | 为安全域表新增 `tenant_id`、回填默认值、补索引 |
+| `koduck-auth/src/model/token.rs` | 为 token 记录模型补充 `tenant_id` 字段 |
+| `koduck-auth/src/repository/refresh_token_repository.rs` | 新增 tenant-aware 保存、查询、吊销方法 |
+| `koduck-auth/src/repository/password_reset_repository.rs` | 新增 tenant-aware 保存、查询、标记使用方法 |
+
+### 兼容策略
+
+1. 默认 tenant 仍使用 `default`
+2. 旧调用链继续调用无 tenant 参数的方法
+3. 新的 tenant-aware 方法供后续 Task 4.x 直接接入
+
+---
+
+## 权衡与影响
+
+### 正向影响
+
+- refresh / password reset / audit log 都拥有显式租户维度。
+- 仓储层已经可以按租户过滤，而不必等待完整 auth 重构。
+- 旧链路依然能继续运行。
+
+### 负向影响
+
+- 默认兼容方法与 tenant-aware 方法会短期并存。
+- `audit_logs` 目前只完成 schema 演进，业务写入 tenant 仍留到后续链路改造。
+
+### 缓解措施
+
+- 在 Task 4.3 中将登录、refresh、审计链路切换到 tenant-aware 调用。
+- 保持 default tenant 兼容窗口，避免一次性破坏现有链路。
+
+---
+
+## 兼容性影响
+
+1. **运行时兼容性**: 旧链路继续使用 `default` tenant，不要求当前业务代码立即改造。
+2. **数据兼容性**: 存量 token 与审计记录会回填 `default`。
+3. **调用方兼容性**: 对外/对内 API 暂不变化，变化主要在 schema 与仓储层。
+
+---
+
+## 相关文档
+
+- [koduck-auth-user-tenant-semantics.md](../../../docs/design/koduck-auth-user-tenant-semantics.md)
+- [koduck-auth-user-tenant-semantics-tasks.md](../../../docs/implementation/koduck-auth-user-tenant-semantics-tasks.md)
+- [ADR-0022](./0022-inventory-tenant-id-contract-impacts.md)
+
+---
+
+## 变更日志
+
+| 日期 | 变更 | 作者 |
+|------|------|------|
+| 2026-04-11 | 初始版本 | @hailingu |

--- a/koduck-auth/migrations/202604110001_add_tenant_to_security_tables.sql
+++ b/koduck-auth/migrations/202604110001_add_tenant_to_security_tables.sql
@@ -1,0 +1,51 @@
+-- ============================================================
+-- 202604110001_add_tenant_to_security_tables.sql
+-- 模块: koduck-auth
+-- 目标数据库: PostgreSQL 14+
+-- 目标: 为安全域表增加 tenant_id 与租户索引
+-- ============================================================
+
+ALTER TABLE refresh_tokens
+    ADD COLUMN IF NOT EXISTS tenant_id VARCHAR(128);
+
+ALTER TABLE password_reset_tokens
+    ADD COLUMN IF NOT EXISTS tenant_id VARCHAR(128);
+
+ALTER TABLE audit_logs
+    ADD COLUMN IF NOT EXISTS tenant_id VARCHAR(128);
+
+UPDATE refresh_tokens
+SET tenant_id = 'default'
+WHERE tenant_id IS NULL;
+
+UPDATE password_reset_tokens
+SET tenant_id = 'default'
+WHERE tenant_id IS NULL;
+
+UPDATE audit_logs
+SET tenant_id = 'default'
+WHERE tenant_id IS NULL;
+
+ALTER TABLE refresh_tokens
+    ALTER COLUMN tenant_id SET DEFAULT 'default',
+    ALTER COLUMN tenant_id SET NOT NULL;
+
+ALTER TABLE password_reset_tokens
+    ALTER COLUMN tenant_id SET DEFAULT 'default',
+    ALTER COLUMN tenant_id SET NOT NULL;
+
+ALTER TABLE audit_logs
+    ALTER COLUMN tenant_id SET DEFAULT 'default',
+    ALTER COLUMN tenant_id SET NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_refresh_tokens_tenant_id ON refresh_tokens(tenant_id);
+CREATE INDEX IF NOT EXISTS idx_refresh_tokens_tenant_user_id ON refresh_tokens(tenant_id, user_id);
+CREATE INDEX IF NOT EXISTS idx_refresh_tokens_tenant_expires_at ON refresh_tokens(tenant_id, expires_at);
+
+CREATE INDEX IF NOT EXISTS idx_password_reset_tokens_tenant_id ON password_reset_tokens(tenant_id);
+CREATE INDEX IF NOT EXISTS idx_password_reset_tokens_tenant_user_id ON password_reset_tokens(tenant_id, user_id);
+CREATE INDEX IF NOT EXISTS idx_password_reset_tokens_tenant_expires_at ON password_reset_tokens(tenant_id, expires_at);
+
+CREATE INDEX IF NOT EXISTS idx_audit_logs_tenant_id ON audit_logs(tenant_id);
+CREATE INDEX IF NOT EXISTS idx_audit_logs_tenant_created_at ON audit_logs(tenant_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_audit_logs_tenant_user_created ON audit_logs(tenant_id, user_id, created_at);

--- a/koduck-auth/src/model/token.rs
+++ b/koduck-auth/src/model/token.rs
@@ -31,6 +31,7 @@ pub struct Claims {
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct RefreshTokenRecord {
     pub id: i64,
+    pub tenant_id: String,
     pub user_id: i64,
     pub token_hash: String,
     pub expires_at: DateTime<Utc>,
@@ -42,6 +43,7 @@ pub struct RefreshTokenRecord {
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct PasswordResetToken {
     pub id: i64,
+    pub tenant_id: String,
     pub user_id: i64,
     pub token_hash: String,
     pub expires_at: DateTime<Utc>,

--- a/koduck-auth/src/repository/password_reset_repository.rs
+++ b/koduck-auth/src/repository/password_reset_repository.rs
@@ -13,6 +13,8 @@ pub struct PasswordResetRepository {
     pool: PgPool,
 }
 
+const DEFAULT_TENANT_ID: &str = "default";
+
 impl PasswordResetRepository {
     /// Create new password reset repository
     pub fn new(pool: PgPool) -> Self {
@@ -26,13 +28,26 @@ impl PasswordResetRepository {
         token_hash: &str,
         expires_at: DateTime<Utc>,
     ) -> Result<PasswordResetToken> {
+        self.save_for_tenant(DEFAULT_TENANT_ID, user_id, token_hash, expires_at)
+            .await
+    }
+
+    /// Save password reset token in a tenant scope
+    pub async fn save_for_tenant(
+        &self,
+        tenant_id: &str,
+        user_id: i64,
+        token_hash: &str,
+        expires_at: DateTime<Utc>,
+    ) -> Result<PasswordResetToken> {
         let token = sqlx::query_as::<_, PasswordResetToken>(
             r#"
-            INSERT INTO password_reset_tokens (user_id, token_hash, expires_at)
-            VALUES ($1, $2, $3)
-            RETURNING id, user_id, token_hash, expires_at, created_at, used_at
+            INSERT INTO password_reset_tokens (tenant_id, user_id, token_hash, expires_at)
+            VALUES ($1, $2, $3, $4)
+            RETURNING id, tenant_id, user_id, token_hash, expires_at, created_at, used_at
             "#,
         )
+        .bind(tenant_id)
         .bind(user_id)
         .bind(token_hash)
         .bind(expires_at)
@@ -45,13 +60,23 @@ impl PasswordResetRepository {
 
     /// Find token by hash
     pub async fn find_by_token(&self, token_hash: &str) -> Result<Option<PasswordResetToken>> {
+        self.find_by_token_in_tenant(DEFAULT_TENANT_ID, token_hash).await
+    }
+
+    /// Find token by hash in a tenant scope
+    pub async fn find_by_token_in_tenant(
+        &self,
+        tenant_id: &str,
+        token_hash: &str,
+    ) -> Result<Option<PasswordResetToken>> {
         let token = sqlx::query_as::<_, PasswordResetToken>(
             r#"
-            SELECT id, user_id, token_hash, expires_at, created_at, used_at
+            SELECT id, tenant_id, user_id, token_hash, expires_at, created_at, used_at
             FROM password_reset_tokens
-            WHERE token_hash = $1
+            WHERE tenant_id = $1 AND token_hash = $2
             "#,
         )
+        .bind(tenant_id)
         .bind(token_hash)
         .fetch_optional(&self.pool)
         .await
@@ -62,13 +87,19 @@ impl PasswordResetRepository {
 
     /// Mark token as used
     pub async fn mark_as_used(&self, token_hash: &str) -> Result<()> {
+        self.mark_as_used_in_tenant(DEFAULT_TENANT_ID, token_hash).await
+    }
+
+    /// Mark token as used in a tenant scope
+    pub async fn mark_as_used_in_tenant(&self, tenant_id: &str, token_hash: &str) -> Result<()> {
         sqlx::query(
             r#"
             UPDATE password_reset_tokens
             SET used_at = NOW()
-            WHERE token_hash = $1 AND used_at IS NULL
+            WHERE tenant_id = $1 AND token_hash = $2 AND used_at IS NULL
             "#,
         )
+        .bind(tenant_id)
         .bind(token_hash)
         .execute(&self.pool)
         .await
@@ -102,13 +133,27 @@ impl PasswordResetRepository {
         token_hash: &str,
         expires_at: DateTime<Utc>,
     ) -> Result<PasswordResetToken> {
+        self.save_with_tx_for_tenant(tx, DEFAULT_TENANT_ID, user_id, token_hash, expires_at)
+            .await
+    }
+
+    /// Save password reset token within a transaction and tenant scope
+    pub async fn save_with_tx_for_tenant(
+        &self,
+        tx: &mut Transaction<'_, Postgres>,
+        tenant_id: &str,
+        user_id: i64,
+        token_hash: &str,
+        expires_at: DateTime<Utc>,
+    ) -> Result<PasswordResetToken> {
         let token = sqlx::query_as::<_, PasswordResetToken>(
             r#"
-            INSERT INTO password_reset_tokens (user_id, token_hash, expires_at)
-            VALUES ($1, $2, $3)
-            RETURNING id, user_id, token_hash, expires_at, created_at, used_at
+            INSERT INTO password_reset_tokens (tenant_id, user_id, token_hash, expires_at)
+            VALUES ($1, $2, $3, $4)
+            RETURNING id, tenant_id, user_id, token_hash, expires_at, created_at, used_at
             "#,
         )
+        .bind(tenant_id)
         .bind(user_id)
         .bind(token_hash)
         .bind(expires_at)
@@ -125,13 +170,25 @@ impl PasswordResetRepository {
         tx: &mut Transaction<'_, Postgres>,
         token_hash: &str,
     ) -> Result<()> {
+        self.mark_as_used_with_tx_in_tenant(tx, DEFAULT_TENANT_ID, token_hash)
+            .await
+    }
+
+    /// Mark token as used within a transaction and tenant scope
+    pub async fn mark_as_used_with_tx_in_tenant(
+        &self,
+        tx: &mut Transaction<'_, Postgres>,
+        tenant_id: &str,
+        token_hash: &str,
+    ) -> Result<()> {
         sqlx::query(
             r#"
             UPDATE password_reset_tokens
             SET used_at = NOW()
-            WHERE token_hash = $1 AND used_at IS NULL
+            WHERE tenant_id = $1 AND token_hash = $2 AND used_at IS NULL
             "#,
         )
+        .bind(tenant_id)
         .bind(token_hash)
         .execute(&mut **tx)
         .await

--- a/koduck-auth/src/repository/refresh_token_repository.rs
+++ b/koduck-auth/src/repository/refresh_token_repository.rs
@@ -13,6 +13,8 @@ pub struct RefreshTokenRepository {
     pool: PgPool,
 }
 
+const DEFAULT_TENANT_ID: &str = "default";
+
 impl RefreshTokenRepository {
     /// Create new refresh token repository
     pub fn new(pool: PgPool) -> Self {
@@ -26,13 +28,26 @@ impl RefreshTokenRepository {
         token_hash: &str,
         expires_at: DateTime<Utc>,
     ) -> Result<RefreshTokenRecord> {
+        self.save_for_tenant(DEFAULT_TENANT_ID, user_id, token_hash, expires_at)
+            .await
+    }
+
+    /// Save refresh token in a tenant scope
+    pub async fn save_for_tenant(
+        &self,
+        tenant_id: &str,
+        user_id: i64,
+        token_hash: &str,
+        expires_at: DateTime<Utc>,
+    ) -> Result<RefreshTokenRecord> {
         let token = sqlx::query_as::<_, RefreshTokenRecord>(
             r#"
-            INSERT INTO refresh_tokens (user_id, token_hash, expires_at)
-            VALUES ($1, $2, $3)
-            RETURNING id, user_id, token_hash, expires_at, created_at, revoked_at
+            INSERT INTO refresh_tokens (tenant_id, user_id, token_hash, expires_at)
+            VALUES ($1, $2, $3, $4)
+            RETURNING id, tenant_id, user_id, token_hash, expires_at, created_at, revoked_at
             "#,
         )
+        .bind(tenant_id)
         .bind(user_id)
         .bind(token_hash)
         .bind(expires_at)
@@ -45,13 +60,23 @@ impl RefreshTokenRepository {
 
     /// Find token by hash
     pub async fn find_by_token(&self, token_hash: &str) -> Result<Option<RefreshTokenRecord>> {
+        self.find_by_token_in_tenant(DEFAULT_TENANT_ID, token_hash).await
+    }
+
+    /// Find token by hash in a tenant scope
+    pub async fn find_by_token_in_tenant(
+        &self,
+        tenant_id: &str,
+        token_hash: &str,
+    ) -> Result<Option<RefreshTokenRecord>> {
         let token = sqlx::query_as::<_, RefreshTokenRecord>(
             r#"
-            SELECT id, user_id, token_hash, expires_at, created_at, revoked_at
+            SELECT id, tenant_id, user_id, token_hash, expires_at, created_at, revoked_at
             FROM refresh_tokens
-            WHERE token_hash = $1
+            WHERE tenant_id = $1 AND token_hash = $2
             "#,
         )
+        .bind(tenant_id)
         .bind(token_hash)
         .fetch_optional(&self.pool)
         .await
@@ -62,13 +87,19 @@ impl RefreshTokenRepository {
 
     /// Revoke token
     pub async fn revoke(&self, token_hash: &str) -> Result<()> {
+        self.revoke_in_tenant(DEFAULT_TENANT_ID, token_hash).await
+    }
+
+    /// Revoke token in a tenant scope
+    pub async fn revoke_in_tenant(&self, tenant_id: &str, token_hash: &str) -> Result<()> {
         sqlx::query(
             r#"
             UPDATE refresh_tokens
             SET revoked_at = NOW()
-            WHERE token_hash = $1 AND revoked_at IS NULL
+            WHERE tenant_id = $1 AND token_hash = $2 AND revoked_at IS NULL
             "#,
         )
+        .bind(tenant_id)
         .bind(token_hash)
         .execute(&self.pool)
         .await
@@ -79,13 +110,24 @@ impl RefreshTokenRepository {
 
     /// Revoke all user tokens
     pub async fn revoke_all_user_tokens(&self, user_id: i64) -> Result<u64> {
+        self.revoke_all_user_tokens_in_tenant(DEFAULT_TENANT_ID, user_id)
+            .await
+    }
+
+    /// Revoke all user tokens in a tenant scope
+    pub async fn revoke_all_user_tokens_in_tenant(
+        &self,
+        tenant_id: &str,
+        user_id: i64,
+    ) -> Result<u64> {
         let result = sqlx::query(
             r#"
             UPDATE refresh_tokens
             SET revoked_at = NOW()
-            WHERE user_id = $1 AND revoked_at IS NULL
+            WHERE tenant_id = $1 AND user_id = $2 AND revoked_at IS NULL
             "#,
         )
+        .bind(tenant_id)
         .bind(user_id)
         .execute(&self.pool)
         .await
@@ -119,13 +161,27 @@ impl RefreshTokenRepository {
         token_hash: &str,
         expires_at: DateTime<Utc>,
     ) -> Result<RefreshTokenRecord> {
+        self.save_with_tx_for_tenant(tx, DEFAULT_TENANT_ID, user_id, token_hash, expires_at)
+            .await
+    }
+
+    /// Save refresh token within a transaction and tenant scope
+    pub async fn save_with_tx_for_tenant(
+        &self,
+        tx: &mut Transaction<'_, Postgres>,
+        tenant_id: &str,
+        user_id: i64,
+        token_hash: &str,
+        expires_at: DateTime<Utc>,
+    ) -> Result<RefreshTokenRecord> {
         let token = sqlx::query_as::<_, RefreshTokenRecord>(
             r#"
-            INSERT INTO refresh_tokens (user_id, token_hash, expires_at)
-            VALUES ($1, $2, $3)
-            RETURNING id, user_id, token_hash, expires_at, created_at, revoked_at
+            INSERT INTO refresh_tokens (tenant_id, user_id, token_hash, expires_at)
+            VALUES ($1, $2, $3, $4)
+            RETURNING id, tenant_id, user_id, token_hash, expires_at, created_at, revoked_at
             "#,
         )
+        .bind(tenant_id)
         .bind(user_id)
         .bind(token_hash)
         .bind(expires_at)
@@ -142,13 +198,25 @@ impl RefreshTokenRepository {
         tx: &mut Transaction<'_, Postgres>,
         token_hash: &str,
     ) -> Result<()> {
+        self.revoke_with_tx_in_tenant(tx, DEFAULT_TENANT_ID, token_hash)
+            .await
+    }
+
+    /// Revoke token within a transaction and tenant scope
+    pub async fn revoke_with_tx_in_tenant(
+        &self,
+        tx: &mut Transaction<'_, Postgres>,
+        tenant_id: &str,
+        token_hash: &str,
+    ) -> Result<()> {
         sqlx::query(
             r#"
             UPDATE refresh_tokens
             SET revoked_at = NOW()
-            WHERE token_hash = $1 AND revoked_at IS NULL
+            WHERE tenant_id = $1 AND token_hash = $2 AND revoked_at IS NULL
             "#,
         )
+        .bind(tenant_id)
         .bind(token_hash)
         .execute(&mut **tx)
         .await
@@ -163,13 +231,25 @@ impl RefreshTokenRepository {
         tx: &mut Transaction<'_, Postgres>,
         user_id: i64,
     ) -> Result<u64> {
+        self.revoke_all_user_tokens_with_tx_in_tenant(tx, DEFAULT_TENANT_ID, user_id)
+            .await
+    }
+
+    /// Revoke all user tokens within a transaction and tenant scope
+    pub async fn revoke_all_user_tokens_with_tx_in_tenant(
+        &self,
+        tx: &mut Transaction<'_, Postgres>,
+        tenant_id: &str,
+        user_id: i64,
+    ) -> Result<u64> {
         let result = sqlx::query(
             r#"
             UPDATE refresh_tokens
             SET revoked_at = NOW()
-            WHERE user_id = $1 AND revoked_at IS NULL
+            WHERE tenant_id = $1 AND user_id = $2 AND revoked_at IS NULL
             "#,
         )
+        .bind(tenant_id)
         .bind(user_id)
         .execute(&mut **tx)
         .await


### PR DESCRIPTION
## Summary
- add a tenant-id migration for auth security-domain tables and backfill existing rows
- add tenant-aware refresh-token and password-reset repository methods with default-tenant compatibility
- record the Task 2.2 ADR and mark the checklist as complete

Closes #765