### PR TITLE
feat(user): switch uniqueness constraints to tenant scope

### DIFF
--- a/docs/implementation/koduck-auth-user-tenant-semantics-tasks.md
+++ b/docs/implementation/koduck-auth-user-tenant-semantics-tasks.md
@@ -100,9 +100,15 @@
    - `unique (tenant_id, name)`
 3. 为存量数据回填默认 tenant
 
+**执行结果（2026-04-11）:**
+- `koduck-user` 新增迁移 `V3__switch_uniqueness_constraints_to_tenant_scope.sql`，将 `users` 和 `roles` 的全局唯一约束切换为租户内唯一
+- 迁移在切约束前再次将 `users.tenant_id` 与 `roles.tenant_id` 的空值收口到 `default`
+- 新增 ADR `0019-switch-uniqueness-constraints-to-tenant-scope.md` 固化该阶段的决策与兼容性影响
+- 扩展 `UserTenantSchemaMigrationIntegrationTest`，验证旧约束已移除，且“跨租户可重复、租户内不可重复”的行为成立
+
 **验收标准:**
-- [ ] 不再使用全局唯一
-- [ ] 存量数据可迁移
+- [x] 不再使用全局唯一
+- [x] 存量数据可迁移
 
 ---
 

--- a/koduck-user/docs/adr/0019-switch-uniqueness-constraints-to-tenant-scope.md
+++ b/koduck-user/docs/adr/0019-switch-uniqueness-constraints-to-tenant-scope.md
@@ -1,0 +1,133 @@
+# ADR-0019: Task 2.3 将用户与角色唯一约束切换为租户内唯一
+
+## 元数据
+
+- **状态**: 已接受
+- **日期**: 2026-04-11
+- **作者**: @hailingu
+- **相关**: #768, docs/implementation/koduck-auth-user-tenant-semantics-tasks.md Task 2.3, ADR-0018
+
+---
+
+## 背景与问题陈述
+
+Task 2.1 已经为 `koduck-user` 引入 `tenant_id` 与最小租户真值，但当前数据库仍保留旧的全局唯一约束：
+
+1. `users.username` 仍然是全局唯一
+2. `users.email` 仍然是全局唯一
+3. `roles.name` 仍然是全局唯一
+
+这会直接违背 Task 1.1 已冻结的租户语义，即身份唯一性应以 `(tenant_id, user_id)` 为主，用户名、邮箱、角色名也只能在租户内唯一，而不是在全局范围唯一。
+
+---
+
+## 决策驱动因素
+
+1. **语义一致性**: schema 约束必须与根设计文档中的租户边界一致。
+2. **平滑迁移**: 已有单租户数据需要继续落在 `default` tenant 下，不要求人工搬迁。
+3. **任务边界清晰**: Task 2.3 只处理约束切换，不提前引入 Task 3.x 的 repository / API 逻辑改造。
+4. **低风险落地**: 优先通过数据库迁移完成约束替换，避免把运行时行为变更耦合进同一次交付。
+
+---
+
+## 考虑的选项
+
+### 选项 1：继续保留全局唯一，等待 Task 3.x 再统一调整
+
+**优点**:
+- 当前改动最少
+
+**缺点**:
+- 与冻结的租户语义冲突
+- 会阻塞后续租户内查询与写入改造
+
+### 选项 2：在 Task 2.3 通过迁移脚本切换为租户内唯一（选定）
+
+**优点**:
+- 变更范围集中在 schema
+- 与 Task 2.1 的 `default` tenant 回填策略天然衔接
+- 为后续 repository / internal API 租户化扫清数据库约束障碍
+
+**缺点**:
+- 运行时查询逻辑仍将在 Task 3.x 才全面显式带 tenant
+
+### 选项 3：直接同时修改 schema、实体、repository、API
+
+**优点**:
+- 一次性覆盖更多层次
+
+**缺点**:
+- 变更过大，超出 Task 2.3 范围
+- 难以区分 schema 约束问题和业务逻辑问题
+
+---
+
+## 决策结果
+
+采用 **选项 2**，通过新的 Flyway 迁移将唯一约束切换为租户内唯一：
+
+1. `users` 从 `UNIQUE (username)` 切换为 `UNIQUE (tenant_id, username)`
+2. `users` 从 `UNIQUE (email)` 切换为 `UNIQUE (tenant_id, email)`
+3. `roles` 从 `UNIQUE (name)` 切换为 `UNIQUE (tenant_id, name)`
+4. 在切换前再次将空 `tenant_id` 收口到 `default`，确保存量单租户数据可平滑迁移
+
+---
+
+## 实施细节
+
+### 变更文件
+
+| 文件 | 变更说明 |
+|------|------|
+| `koduck-user/src/main/resources/db/migration/V3__switch_uniqueness_constraints_to_tenant_scope.sql` | 删除旧的全局唯一约束并添加租户内唯一约束 |
+| `koduck-user/src/test/java/com/koduck/integration/UserTenantSchemaMigrationIntegrationTest.java` | 验证约束名称与跨租户/租户内的唯一性行为 |
+| `docs/implementation/koduck-auth-user-tenant-semantics-tasks.md` | 回填 Task 2.3 的执行结果与 checklist |
+
+### 迁移策略
+
+1. 再次将 `users.tenant_id` / `roles.tenant_id` 中的空值回填为 `default`
+2. 删除旧约束 `uk_users_username`、`uk_users_email`、`uk_roles_name`
+3. 新增租户内唯一约束 `uk_users_tenant_username`、`uk_users_tenant_email`、`uk_roles_tenant_name`
+
+---
+
+## 权衡与影响
+
+### 正向影响
+
+- `koduck-user` 的数据库唯一性规则与多租户设计正式一致。
+- 后续可以在不同租户中使用相同用户名、邮箱和角色名。
+- Task 3.x 可以在不再受全局唯一约束阻碍的前提下推进 repository / API 租户化。
+
+### 负向影响
+
+- 应用层当前仍可能存在默认的全局查询路径，该部分需要在后续任务中继续收口。
+
+### 缓解措施
+
+- 在 Task 3.1 / 3.2 中继续推进 repository 与 internal API 显式带 tenant。
+- 用集成测试直接验证迁移后的唯一性行为，避免只改约束名而漏掉真实行为。
+
+---
+
+## 兼容性影响
+
+1. **数据兼容性**: 现有数据仍保留在 `default` tenant 中，可直接迁移。
+2. **运行时兼容性**: 本任务不变更 API 契约，仅调整数据库唯一约束。
+3. **演进兼容性**: 后续可以在新增租户时复用同名用户名、邮箱和角色名。
+
+---
+
+## 相关文档
+
+- [koduck-auth-user-tenant-semantics.md](../../../docs/design/koduck-auth-user-tenant-semantics.md)
+- [koduck-auth-user-tenant-semantics-tasks.md](../../../docs/implementation/koduck-auth-user-tenant-semantics-tasks.md)
+- [ADR-0018](./0018-add-tenant-columns-and-minimal-tenant-truth.md)
+
+---
+
+## 变更日志
+
+| 日期 | 变更 | 作者 |
+|------|------|------|
+| 2026-04-11 | 初始版本 | @hailingu |

--- a/koduck-user/src/main/resources/db/migration/V3__switch_uniqueness_constraints_to_tenant_scope.sql
+++ b/koduck-user/src/main/resources/db/migration/V3__switch_uniqueness_constraints_to_tenant_scope.sql
@@ -1,0 +1,40 @@
+-- ============================================================
+-- V3__switch_uniqueness_constraints_to_tenant_scope.sql
+-- 模块: koduck-user
+-- 目标数据库: PostgreSQL 14+
+-- 目标: 将用户与角色唯一约束切换为租户内唯一
+-- ============================================================
+
+-- ------------------------------------------------------------
+-- 1. 默认 tenant 收口
+-- ------------------------------------------------------------
+
+UPDATE users
+SET tenant_id = 'default'
+WHERE tenant_id IS NULL;
+
+UPDATE roles
+SET tenant_id = 'default'
+WHERE tenant_id IS NULL;
+
+-- ------------------------------------------------------------
+-- 2. 切换用户唯一约束
+-- ------------------------------------------------------------
+
+ALTER TABLE users
+    DROP CONSTRAINT IF EXISTS uk_users_username,
+    DROP CONSTRAINT IF EXISTS uk_users_email;
+
+ALTER TABLE users
+    ADD CONSTRAINT uk_users_tenant_username UNIQUE (tenant_id, username),
+    ADD CONSTRAINT uk_users_tenant_email UNIQUE (tenant_id, email);
+
+-- ------------------------------------------------------------
+-- 3. 切换角色唯一约束
+-- ------------------------------------------------------------
+
+ALTER TABLE roles
+    DROP CONSTRAINT IF EXISTS uk_roles_name;
+
+ALTER TABLE roles
+    ADD CONSTRAINT uk_roles_tenant_name UNIQUE (tenant_id, name);

--- a/koduck-user/src/test/java/com/koduck/integration/UserTenantSchemaMigrationIntegrationTest.java
+++ b/koduck-user/src/test/java/com/koduck/integration/UserTenantSchemaMigrationIntegrationTest.java
@@ -3,6 +3,7 @@ package com.koduck.integration;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
@@ -11,6 +12,7 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SpringBootTest
 @Testcontainers(disabledWithoutDocker = true)
@@ -46,6 +48,86 @@ class UserTenantSchemaMigrationIntegrationTest {
                 "SELECT COUNT(*) FROM tenants WHERE id = 'default'",
                 Integer.class);
         assertEquals(1, tenantCount);
+
+        assertEquals(1, countConstraint("users", "uk_users_tenant_username"));
+        assertEquals(1, countConstraint("users", "uk_users_tenant_email"));
+        assertEquals(1, countConstraint("roles", "uk_roles_tenant_name"));
+        assertEquals(0, countConstraint("users", "uk_users_username"));
+        assertEquals(0, countConstraint("users", "uk_users_email"));
+        assertEquals(0, countConstraint("roles", "uk_roles_name"));
+    }
+
+    @Test
+    void shouldUseTenantScopedUniqueness() {
+        jdbcTemplate.update(
+                "INSERT INTO tenants (id, name, status) VALUES (?, ?, ?) ON CONFLICT (id) DO NOTHING",
+                "tenant-b",
+                "Tenant B",
+                "ACTIVE");
+
+        jdbcTemplate.update(
+                """
+                INSERT INTO users (tenant_id, username, email, password_hash, status)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                "default",
+                "shared-user",
+                "shared@example.com",
+                "hash-1",
+                1);
+
+        jdbcTemplate.update(
+                """
+                INSERT INTO users (tenant_id, username, email, password_hash, status)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                "tenant-b",
+                "shared-user",
+                "shared@example.com",
+                "hash-2",
+                1);
+
+        assertThrows(
+                DuplicateKeyException.class,
+                () -> jdbcTemplate.update(
+                        """
+                        INSERT INTO users (tenant_id, username, email, password_hash, status)
+                        VALUES (?, ?, ?, ?, ?)
+                        """,
+                        "default",
+                        "shared-user",
+                        "other@example.com",
+                        "hash-3",
+                        1));
+
+        jdbcTemplate.update(
+                """
+                INSERT INTO roles (tenant_id, name, description)
+                VALUES (?, ?, ?)
+                """,
+                "default",
+                "ROLE_AUDITOR",
+                "first");
+
+        jdbcTemplate.update(
+                """
+                INSERT INTO roles (tenant_id, name, description)
+                VALUES (?, ?, ?)
+                """,
+                "tenant-b",
+                "ROLE_AUDITOR",
+                "second");
+
+        assertThrows(
+                DuplicateKeyException.class,
+                () -> jdbcTemplate.update(
+                        """
+                        INSERT INTO roles (tenant_id, name, description)
+                        VALUES (?, ?, ?)
+                        """,
+                        "tenant-b",
+                        "ROLE_AUDITOR",
+                        "duplicate"));
     }
 
     private int countColumn(String tableName, String columnName) {
@@ -60,6 +142,21 @@ class UserTenantSchemaMigrationIntegrationTest {
                 Integer.class,
                 tableName,
                 columnName);
+        return count == null ? 0 : count;
+    }
+
+    private int countConstraint(String tableName, String constraintName) {
+        Integer count = jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM information_schema.table_constraints
+                WHERE table_schema = 'public'
+                  AND table_name = ?
+                  AND constraint_name = ?
+                """,
+                Integer.class,
+                tableName,
+                constraintName);
         return count == null ? 0 : count;
     }
 }


### PR DESCRIPTION
## Summary
- add a Flyway V3 migration that replaces global user and role uniqueness with tenant-scoped constraints
- add an ADR and mark Task 2.3 as complete in the tenant semantics task list
- extend the migration integration test to verify tenant-scoped uniqueness behavior

## Validation
- mvn -f koduck-user/pom.xml -Dtest=UserTenantSchemaMigrationIntegrationTest test
- docker build -t koduck-user:dev ./koduck-user
- kubectl rollout restart deployment/dev-koduck-user -n koduck-dev
- kubectl rollout status deployment/dev-koduck-user -n koduck-dev --timeout=180s

Closes #768