### PR TITLE
feat(user): align entities and repositories with tenant scope

### DIFF
--- a/docs/implementation/koduck-auth-user-tenant-semantics-tasks.md
+++ b/docs/implementation/koduck-auth-user-tenant-semantics-tasks.md
@@ -119,9 +119,15 @@
 1. 更新 `User`、`Role` 等实体
 2. Repository 查询显式带 `tenant_id`
 
+**执行结果（2026-04-11）:**
+- `koduck-user` 的 `User`、`Role`、`UserRole`、`RolePermission`、`UserCredential` 实体均补充了 `tenantId` 字段，并与当前表结构保持一致
+- `UserRepository`、`RoleRepository`、`UserRoleRepository`、`RolePermissionRepository` 已切换为 tenant-aware 查询方法
+- `UserServiceImpl`、`RoleServiceImpl`、`PermissionServiceImpl` 在 Task 3.2 引入 header 之前，统一通过 `default` tenant 调用 repository，避免继续走全局范围查询
+- 新增 ADR `0020-align-entities-and-repositories-with-tenant-scope.md` 记录本阶段的边界、权衡与兼容策略
+
 **验收标准:**
-- [ ] 查询不再是全局范围
-- [ ] 实体与表结构一致
+- [x] 查询不再是全局范围
+- [x] 实体与表结构一致
 
 ### Task 3.2: Internal API 增加租户上下文
 **详细要求:**

--- a/koduck-user/docs/adr/0020-align-entities-and-repositories-with-tenant-scope.md
+++ b/koduck-user/docs/adr/0020-align-entities-and-repositories-with-tenant-scope.md
@@ -1,0 +1,129 @@
+# ADR-0020: Task 3.1 让 koduck-user 实体与 Repository 对齐 tenant scope
+
+## 元数据
+
+- **状态**: 已接受
+- **日期**: 2026-04-11
+- **作者**: @hailingu
+- **相关**: #770, docs/implementation/koduck-auth-user-tenant-semantics-tasks.md Task 3.1, ADR-0019
+
+---
+
+## 背景与问题陈述
+
+Task 2.1 与 Task 2.3 已经完成 `koduck-user` 的 tenant 列引入和租户内唯一约束切换，但应用层仍存在两类不一致：
+
+1. `User`、`Role`、`UserRole`、`RolePermission`、`UserCredential` 实体没有 `tenant_id`
+2. `UserRepository`、`RoleRepository`、`UserRoleRepository`、`RolePermissionRepository` 仍以全局范围查询为主
+
+如果不先完成这一层收口，后续 Task 3.2 的 internal API 租户上下文和 Task 3.3 的 `UserContext` 扩展就会继续建立在全局查询假设上。
+
+---
+
+## 决策驱动因素
+
+1. **实体一致性**: JPA 实体必须与当前数据库 schema 对齐。
+2. **查询收口**: Repository 需要显式表达 tenant scope，避免继续跨租户读取。
+3. **渐进兼容**: 在 Task 3.2 引入 `X-Tenant-Id` 之前，需要一个可运行的默认 tenant 兼容路径。
+4. **任务边界清晰**: 本任务处理实体与 repository，不修改 internal API 契约。
+
+---
+
+## 考虑的选项
+
+### 选项 1：只补实体字段，Repository 暂时保持全局
+
+**优点**:
+- 改动较少
+
+**缺点**:
+- “查询不再是全局范围”的验收标准无法满足
+- 后续 Task 3.2 仍需要先清理 repository 全局方法
+
+### 选项 2：实体与 Repository 一起 tenant-aware，并在服务层先收口到 `default` tenant（选定）
+
+**优点**:
+- 直接满足 Task 3.1 的两个验收标准
+- 为 Task 3.2 留出清晰的 header 注入点
+- 不提前改变对外/internal API 结构
+
+**缺点**:
+- 在 `X-Tenant-Id` 引入前，服务层仍需保留默认 tenant 过渡逻辑
+
+### 选项 3：等 Task 3.2 / 3.3 再一起修改
+
+**优点**:
+- 减少本任务修改量
+
+**缺点**:
+- 违背任务拆分顺序
+- 风险和改动面过大
+
+---
+
+## 决策结果
+
+采用 **选项 2**：
+
+1. 为 `User`、`Role`、`UserRole`、`RolePermission`、`UserCredential` 增加 `tenantId` 字段，并与表结构保持一致
+2. 将 repository 主查询路径切为 tenant-aware 形式，例如 `findByTenantIdAndUsername`
+3. 在 `UserServiceImpl`、`RoleServiceImpl`、`PermissionServiceImpl` 中统一通过 `default` tenant 调用 repository，先消除全局查询
+4. `InternalUserController` 的 header 契约留给 Task 3.2 再扩展
+
+---
+
+## 实施细节
+
+### 变更文件
+
+| 文件 | 变更说明 |
+|------|------|
+| `koduck-user/src/main/java/com/koduck/entity/user/*.java` | 为核心实体补充 `tenantId` 字段，并让实体注解与当前 schema 对齐 |
+| `koduck-user/src/main/java/com/koduck/repository/user/*.java` | 将用户、角色、关系表 repository 改为显式 tenant-aware 查询 |
+| `koduck-user/src/main/java/com/koduck/service/impl/*.java` | 现阶段统一通过 `default` tenant 调用 repository，去除全局范围查询 |
+| `koduck-user/src/test/java/...` | 调整测试到 tenant-aware repository 语义 |
+| `docs/implementation/koduck-auth-user-tenant-semantics-tasks.md` | 回填 Task 3.1 执行结果与 checklist |
+
+---
+
+## 权衡与影响
+
+### 正向影响
+
+- 实体与数据库 schema 正式一致。
+- Repository 查询不再默认走全局范围。
+- Task 3.2 可以直接在服务层上方注入 `X-Tenant-Id`，无需再回头重构 repository。
+
+### 负向影响
+
+- 当前阶段的 tenant 来源仍是固定的 `default`。
+- internal API 仍未显式暴露租户上下文。
+
+### 缓解措施
+
+- 在 Task 3.2 中扩展 `InternalUserController` 支持 `X-Tenant-Id`。
+- 在 Task 3.3 中把 `tenant_id` 纳入 `UserContext`，替代固定默认值。
+
+---
+
+## 兼容性影响
+
+1. **运行时兼容性**: 现有调用链仍可工作，因为服务层暂时统一使用 `default` tenant。
+2. **数据兼容性**: 继续沿用前序任务中对 `default` tenant 的回填策略。
+3. **接口兼容性**: 本任务不修改 HTTP/internal API 输入输出结构。
+
+---
+
+## 相关文档
+
+- [koduck-auth-user-tenant-semantics.md](../../../docs/design/koduck-auth-user-tenant-semantics.md)
+- [koduck-auth-user-tenant-semantics-tasks.md](../../../docs/implementation/koduck-auth-user-tenant-semantics-tasks.md)
+- [ADR-0019](./0019-switch-uniqueness-constraints-to-tenant-scope.md)
+
+---
+
+## 变更日志
+
+| 日期 | 变更 | 作者 |
+|------|------|------|
+| 2026-04-11 | 初始版本 | @hailingu |

--- a/koduck-user/src/main/java/com/koduck/entity/user/Role.java
+++ b/koduck-user/src/main/java/com/koduck/entity/user/Role.java
@@ -25,15 +25,21 @@ import java.time.LocalDateTime;
 @Table(name = "roles")
 public class Role {
 
+    public static final String DEFAULT_TENANT_ID = "default";
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;
 
-    @Column(name = "name", nullable = false, length = 50, unique = true)
+    @Column(name = "name", nullable = false, length = 50)
     private String name;
 
     @Column(name = "description", length = 255)
     private String description;
+
+    @Column(name = "tenant_id", nullable = false, length = 128)
+    @Builder.Default
+    private String tenantId = DEFAULT_TENANT_ID;
 
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)

--- a/koduck-user/src/main/java/com/koduck/entity/user/RolePermission.java
+++ b/koduck-user/src/main/java/com/koduck/entity/user/RolePermission.java
@@ -23,6 +23,8 @@ import java.time.LocalDateTime;
 @Table(name = "role_permissions")
 public class RolePermission {
 
+    public static final String DEFAULT_TENANT_ID = "default";
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -32,6 +34,10 @@ public class RolePermission {
 
     @Column(name = "permission_id", nullable = false)
     private Integer permissionId;
+
+    @Column(name = "tenant_id", nullable = false, length = 128)
+    @Builder.Default
+    private String tenantId = DEFAULT_TENANT_ID;
 
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)

--- a/koduck-user/src/main/java/com/koduck/entity/user/User.java
+++ b/koduck-user/src/main/java/com/koduck/entity/user/User.java
@@ -28,14 +28,16 @@ import java.time.LocalDateTime;
 @Table(name = "users")
 public class User {
 
+    public static final String DEFAULT_TENANT_ID = "default";
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "username", nullable = false, length = 50, unique = true)
+    @Column(name = "username", nullable = false, length = 50)
     private String username;
 
-    @Column(name = "email", nullable = false, length = 100, unique = true)
+    @Column(name = "email", nullable = false, length = 100)
     private String email;
 
     @Column(name = "password_hash", nullable = false, length = 255)
@@ -46,6 +48,10 @@ public class User {
 
     @Column(name = "avatar_url", length = 255)
     private String avatarUrl;
+
+    @Column(name = "tenant_id", nullable = false, length = 128)
+    @Builder.Default
+    private String tenantId = DEFAULT_TENANT_ID;
 
     @Enumerated(EnumType.ORDINAL)
     @Column(name = "status", nullable = false)

--- a/koduck-user/src/main/java/com/koduck/entity/user/UserCredential.java
+++ b/koduck-user/src/main/java/com/koduck/entity/user/UserCredential.java
@@ -26,6 +26,8 @@ import java.time.LocalDateTime;
 @Table(name = "user_credentials")
 public class UserCredential {
 
+    public static final String DEFAULT_TENANT_ID = "default";
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -38,6 +40,10 @@ public class UserCredential {
 
     @Column(name = "credential_value", nullable = false, length = 255)
     private String credentialValue;
+
+    @Column(name = "tenant_id", nullable = false, length = 128)
+    @Builder.Default
+    private String tenantId = DEFAULT_TENANT_ID;
 
     @Column(name = "environment", nullable = false, length = 20)
     @Builder.Default

--- a/koduck-user/src/main/java/com/koduck/entity/user/UserRole.java
+++ b/koduck-user/src/main/java/com/koduck/entity/user/UserRole.java
@@ -23,6 +23,8 @@ import java.time.LocalDateTime;
 @Table(name = "user_roles")
 public class UserRole {
 
+    public static final String DEFAULT_TENANT_ID = "default";
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -32,6 +34,10 @@ public class UserRole {
 
     @Column(name = "role_id", nullable = false)
     private Integer roleId;
+
+    @Column(name = "tenant_id", nullable = false, length = 128)
+    @Builder.Default
+    private String tenantId = DEFAULT_TENANT_ID;
 
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)

--- a/koduck-user/src/main/java/com/koduck/repository/user/RolePermissionRepository.java
+++ b/koduck-user/src/main/java/com/koduck/repository/user/RolePermissionRepository.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 public interface RolePermissionRepository extends JpaRepository<RolePermission, Long> {
 
-    List<RolePermission> findByRoleId(Integer roleId);
+    List<RolePermission> findByTenantIdAndRoleId(String tenantId, Integer roleId);
 
-    void deleteByRoleId(Integer roleId);
+    void deleteByTenantIdAndRoleId(String tenantId, Integer roleId);
 }

--- a/koduck-user/src/main/java/com/koduck/repository/user/RoleRepository.java
+++ b/koduck-user/src/main/java/com/koduck/repository/user/RoleRepository.java
@@ -3,11 +3,16 @@ package com.koduck.repository.user;
 import com.koduck.entity.user.Role;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface RoleRepository extends JpaRepository<Role, Integer> {
 
-    Optional<Role> findByName(String name);
+    List<Role> findAllByTenantId(String tenantId);
 
-    boolean existsByName(String name);
+    Optional<Role> findByIdAndTenantId(Integer id, String tenantId);
+
+    Optional<Role> findByTenantIdAndName(String tenantId, String name);
+
+    boolean existsByTenantIdAndName(String tenantId, String name);
 }

--- a/koduck-user/src/main/java/com/koduck/repository/user/UserRepository.java
+++ b/koduck-user/src/main/java/com/koduck/repository/user/UserRepository.java
@@ -14,21 +14,38 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
-    Optional<User> findByUsername(String username);
+    Optional<User> findByIdAndTenantId(Long id, String tenantId);
 
-    Optional<User> findByEmail(String email);
+    Optional<User> findByTenantIdAndUsername(String tenantId, String username);
 
-    boolean existsByUsername(String username);
+    Optional<User> findByTenantIdAndEmail(String tenantId, String email);
 
-    boolean existsByEmail(String email);
+    boolean existsByTenantIdAndUsername(String tenantId, String username);
 
-    Page<User> findByUsernameContainingOrEmailContaining(String username, String email, Pageable pageable);
+    boolean existsByTenantIdAndEmail(String tenantId, String email);
 
-    Page<User> findByStatus(UserStatus status, Pageable pageable);
+    @Query("""
+            SELECT u FROM User u
+            WHERE u.tenantId = :tenantId
+              AND (LOWER(u.username) LIKE LOWER(CONCAT('%', :keyword, '%'))
+                OR LOWER(u.email) LIKE LOWER(CONCAT('%', :keyword, '%')))
+            """)
+    Page<User> searchByTenantIdAndKeyword(@Param("tenantId") String tenantId,
+                                          @Param("keyword") String keyword,
+                                          Pageable pageable);
+
+    Page<User> findByTenantIdAndStatus(String tenantId, UserStatus status, Pageable pageable);
+
+    Page<User> findByTenantId(String tenantId, Pageable pageable);
 
     @Modifying
-    @Query("UPDATE User u SET u.lastLoginAt = :loginTime, u.lastLoginIp = :ipAddress WHERE u.id = :userId")
-    int updateLastLogin(@Param("userId") Long userId,
+    @Query("""
+            UPDATE User u
+            SET u.lastLoginAt = :loginTime, u.lastLoginIp = :ipAddress
+            WHERE u.id = :userId AND u.tenantId = :tenantId
+            """)
+    int updateLastLogin(@Param("tenantId") String tenantId,
+                        @Param("userId") Long userId,
                         @Param("loginTime") LocalDateTime loginTime,
                         @Param("ipAddress") String ipAddress);
 }

--- a/koduck-user/src/main/java/com/koduck/repository/user/UserRoleRepository.java
+++ b/koduck-user/src/main/java/com/koduck/repository/user/UserRoleRepository.java
@@ -10,21 +10,21 @@ import java.util.List;
 
 public interface UserRoleRepository extends JpaRepository<UserRole, Long> {
 
-    boolean existsByUserIdAndRoleId(Long userId, Integer roleId);
+    boolean existsByTenantIdAndUserIdAndRoleId(String tenantId, Long userId, Integer roleId);
 
-    long countByRoleId(Integer roleId);
+    long countByTenantIdAndRoleId(String tenantId, Integer roleId);
 
-    List<UserRole> findByUserId(Long userId);
+    List<UserRole> findByTenantIdAndUserId(String tenantId, Long userId);
 
     @Modifying
-    void deleteByUserIdAndRoleId(Long userId, Integer roleId);
+    void deleteByTenantIdAndUserIdAndRoleId(String tenantId, Long userId, Integer roleId);
 
-    @Query("SELECT ur.roleId FROM UserRole ur WHERE ur.userId = :userId")
-    List<Integer> findRoleIdsByUserId(@Param("userId") Long userId);
+    @Query("SELECT ur.roleId FROM UserRole ur WHERE ur.tenantId = :tenantId AND ur.userId = :userId")
+    List<Integer> findRoleIdsByTenantIdAndUserId(@Param("tenantId") String tenantId, @Param("userId") Long userId);
 
     @Query("SELECT DISTINCT p.code FROM UserRole ur " +
            "JOIN RolePermission rp ON rp.roleId = ur.roleId " +
            "JOIN Permission p ON p.id = rp.permissionId " +
-           "WHERE ur.userId = :userId")
-    List<String> findPermissionsByUserId(@Param("userId") Long userId);
+           "WHERE ur.tenantId = :tenantId AND rp.tenantId = :tenantId AND ur.userId = :userId")
+    List<String> findPermissionsByTenantIdAndUserId(@Param("tenantId") String tenantId, @Param("userId") Long userId);
 }

--- a/koduck-user/src/main/java/com/koduck/service/impl/PermissionServiceImpl.java
+++ b/koduck-user/src/main/java/com/koduck/service/impl/PermissionServiceImpl.java
@@ -13,6 +13,8 @@ import java.util.List;
 @Service
 public class PermissionServiceImpl implements PermissionService {
 
+    private static final String DEFAULT_TENANT_ID = "default";
+
     private final PermissionRepository permissionRepository;
     private final UserRoleRepository userRoleRepository;
 
@@ -33,7 +35,7 @@ public class PermissionServiceImpl implements PermissionService {
     @Override
     @Transactional(readOnly = true)
     public List<String> getUserPermissions(Long userId) {
-        return userRoleRepository.findPermissionsByUserId(userId);
+        return userRoleRepository.findPermissionsByTenantIdAndUserId(DEFAULT_TENANT_ID, userId);
     }
 
     private PermissionInfo buildPermissionInfo(Permission permission) {

--- a/koduck-user/src/main/java/com/koduck/service/impl/RoleServiceImpl.java
+++ b/koduck-user/src/main/java/com/koduck/service/impl/RoleServiceImpl.java
@@ -32,6 +32,8 @@ import java.util.stream.Collectors;
 @Service
 public class RoleServiceImpl implements RoleService {
 
+    private static final String DEFAULT_TENANT_ID = Role.DEFAULT_TENANT_ID;
+
     private static final Set<String> PROTECTED_ROLES = Set.of(
             "ROLE_USER",
             "ROLE_ADMIN",
@@ -56,7 +58,7 @@ public class RoleServiceImpl implements RoleService {
     @Override
     @Transactional(readOnly = true)
     public List<RoleInfo> listRoles() {
-        return roleRepository.findAll().stream()
+        return roleRepository.findAllByTenantId(DEFAULT_TENANT_ID).stream()
                 .map(this::buildRoleInfo)
                 .toList();
     }
@@ -72,11 +74,12 @@ public class RoleServiceImpl implements RoleService {
     @Override
     @Transactional
     public RoleResponse createRole(CreateRoleRequest request) {
-        if (roleRepository.existsByName(request.getName())) {
+        if (roleRepository.existsByTenantIdAndName(DEFAULT_TENANT_ID, request.getName())) {
             throw new RoleAlreadyExistsException(request.getName());
         }
 
         Role role = Role.builder()
+                .tenantId(DEFAULT_TENANT_ID)
                 .name(request.getName())
                 .description(request.getDescription())
                 .build();
@@ -91,7 +94,7 @@ public class RoleServiceImpl implements RoleService {
         Role role = findRoleOrThrow(roleId);
 
         if (request.getName() != null && !request.getName().equals(role.getName())) {
-            if (roleRepository.existsByName(request.getName())) {
+            if (roleRepository.existsByTenantIdAndName(DEFAULT_TENANT_ID, request.getName())) {
                 throw new RoleAlreadyExistsException(request.getName());
             }
             role.setName(request.getName());
@@ -118,7 +121,7 @@ public class RoleServiceImpl implements RoleService {
             throw new RoleHasUsersException(roleId);
         }
 
-        rolePermissionRepository.deleteByRoleId(roleId);
+        rolePermissionRepository.deleteByTenantIdAndRoleId(DEFAULT_TENANT_ID, roleId);
         roleRepository.delete(role);
     }
 
@@ -139,10 +142,11 @@ public class RoleServiceImpl implements RoleService {
         }
 
         // 全量替换：先删除再插入
-        rolePermissionRepository.deleteByRoleId(roleId);
+        rolePermissionRepository.deleteByTenantIdAndRoleId(DEFAULT_TENANT_ID, roleId);
 
         List<RolePermission> rolePermissions = permissions.stream()
                 .map(p -> RolePermission.builder()
+                        .tenantId(DEFAULT_TENANT_ID)
                         .roleId(roleId)
                         .permissionId(p.getId())
                         .build())
@@ -156,7 +160,7 @@ public class RoleServiceImpl implements RoleService {
     public List<PermissionInfo> getRolePermissions(Integer roleId) {
         findRoleOrThrow(roleId);
 
-        return rolePermissionRepository.findByRoleId(roleId).stream()
+        return rolePermissionRepository.findByTenantIdAndRoleId(DEFAULT_TENANT_ID, roleId).stream()
                 .map(rp -> permissionRepository.findById(rp.getPermissionId()))
                 .filter(java.util.Optional::isPresent)
                 .map(java.util.Optional::get)
@@ -167,12 +171,12 @@ public class RoleServiceImpl implements RoleService {
     // === 私有辅助方法 ===
 
     private Role findRoleOrThrow(Integer roleId) {
-        return roleRepository.findById(roleId)
+        return roleRepository.findByIdAndTenantId(roleId, DEFAULT_TENANT_ID)
                 .orElseThrow(() -> new RoleNotFoundException(roleId));
     }
 
     private boolean hasAssociatedUsers(Integer roleId) {
-        return userRoleRepository.countByRoleId(roleId) > 0;
+        return userRoleRepository.countByTenantIdAndRoleId(DEFAULT_TENANT_ID, roleId) > 0;
     }
 
     private RoleInfo buildRoleInfo(Role role) {

--- a/koduck-user/src/main/java/com/koduck/service/impl/UserServiceImpl.java
+++ b/koduck-user/src/main/java/com/koduck/service/impl/UserServiceImpl.java
@@ -33,6 +33,8 @@ import java.util.Optional;
 @Service
 public class UserServiceImpl implements UserService {
 
+    private static final String DEFAULT_TENANT_ID = User.DEFAULT_TENANT_ID;
+
     private final UserRepository userRepository;
     private final RoleRepository roleRepository;
     private final UserRoleRepository userRoleRepository;
@@ -61,7 +63,7 @@ public class UserServiceImpl implements UserService {
         User user = findUserOrThrow(currentUserId);
 
         if (request.getEmail() != null && !request.getEmail().equals(user.getEmail())) {
-            if (userRepository.existsByEmail(request.getEmail())) {
+            if (userRepository.existsByTenantIdAndEmail(DEFAULT_TENANT_ID, request.getEmail())) {
                 throw new EmailAlreadyExistsException(request.getEmail());
             }
             user.setEmail(request.getEmail());
@@ -80,7 +82,7 @@ public class UserServiceImpl implements UserService {
     @Override
     @Transactional(readOnly = true)
     public List<String> getCurrentUserPermissions(Long currentUserId) {
-        return userRoleRepository.findPermissionsByUserId(currentUserId);
+        return userRoleRepository.findPermissionsByTenantIdAndUserId(DEFAULT_TENANT_ID, currentUserId);
     }
 
     // === 公开 API: 管理员 ===
@@ -91,12 +93,11 @@ public class UserServiceImpl implements UserService {
         Page<User> users;
 
         if (StringUtils.hasText(keyword)) {
-            users = userRepository.findByUsernameContainingOrEmailContaining(
-                    keyword, keyword, pageable);
+            users = userRepository.searchByTenantIdAndKeyword(DEFAULT_TENANT_ID, keyword, pageable);
         } else if (StringUtils.hasText(status)) {
-            users = userRepository.findByStatus(UserStatus.valueOf(status), pageable);
+            users = userRepository.findByTenantIdAndStatus(DEFAULT_TENANT_ID, UserStatus.valueOf(status), pageable);
         } else {
-            users = userRepository.findAll(pageable);
+            users = userRepository.findByTenantId(DEFAULT_TENANT_ID, pageable);
         }
 
         Page<UserSummaryResponse> mapped = users.map(this::buildUserSummaryResponse);
@@ -127,7 +128,7 @@ public class UserServiceImpl implements UserService {
         User user = findUserOrThrow(userId);
 
         if (request.getEmail() != null && !request.getEmail().equals(user.getEmail())) {
-            if (userRepository.existsByEmail(request.getEmail())) {
+            if (userRepository.existsByTenantIdAndEmail(DEFAULT_TENANT_ID, request.getEmail())) {
                 throw new EmailAlreadyExistsException(request.getEmail());
             }
             user.setEmail(request.getEmail());
@@ -150,7 +151,7 @@ public class UserServiceImpl implements UserService {
     @Override
     @Transactional
     public void deleteUser(Long userId) {
-        if (!userRepository.existsById(userId)) {
+        if (userRepository.findByIdAndTenantId(userId, DEFAULT_TENANT_ID).isEmpty()) {
             throw new UserNotFoundException(userId);
         }
         userRepository.deleteById(userId);
@@ -161,15 +162,16 @@ public class UserServiceImpl implements UserService {
     public void assignRole(Long userId, Integer roleId) {
         findUserOrThrow(userId);
 
-        if (!roleRepository.existsById(roleId)) {
+        if (roleRepository.findByIdAndTenantId(roleId, DEFAULT_TENANT_ID).isEmpty()) {
             throw new RoleNotFoundException(roleId);
         }
 
-        if (userRoleRepository.existsByUserIdAndRoleId(userId, roleId)) {
+        if (userRoleRepository.existsByTenantIdAndUserIdAndRoleId(DEFAULT_TENANT_ID, userId, roleId)) {
             return;
         }
 
         UserRole userRole = UserRole.builder()
+                .tenantId(DEFAULT_TENANT_ID)
                 .userId(userId)
                 .roleId(roleId)
                 .build();
@@ -182,19 +184,19 @@ public class UserServiceImpl implements UserService {
     public void removeRole(Long userId, Integer roleId) {
         findUserOrThrow(userId);
 
-        if (!roleRepository.existsById(roleId)) {
+        if (roleRepository.findByIdAndTenantId(roleId, DEFAULT_TENANT_ID).isEmpty()) {
             throw new RoleNotFoundException(roleId);
         }
 
-        userRoleRepository.deleteByUserIdAndRoleId(userId, roleId);
+        userRoleRepository.deleteByTenantIdAndUserIdAndRoleId(DEFAULT_TENANT_ID, userId, roleId);
     }
 
     @Override
     @Transactional(readOnly = true)
     public List<RoleInfo> getUserRolesInfo(Long userId) {
-        List<Integer> roleIds = userRoleRepository.findRoleIdsByUserId(userId);
+        List<Integer> roleIds = userRoleRepository.findRoleIdsByTenantIdAndUserId(DEFAULT_TENANT_ID, userId);
         return roleIds.stream()
-                .map(roleId -> roleRepository.findById(roleId))
+                .map(roleId -> roleRepository.findByIdAndTenantId(roleId, DEFAULT_TENANT_ID))
                 .filter(Optional::isPresent)
                 .map(Optional::get)
                 .map(this::buildRoleInfo)
@@ -206,25 +208,25 @@ public class UserServiceImpl implements UserService {
     @Override
     @Transactional(readOnly = true)
     public Optional<UserDetailsResponse> findByUsername(String username) {
-        return userRepository.findByUsername(username)
+        return userRepository.findByTenantIdAndUsername(DEFAULT_TENANT_ID, username)
                 .map(this::buildUserDetailsResponse);
     }
 
     @Override
     @Transactional(readOnly = true)
     public Optional<UserDetailsResponse> findByEmail(String email) {
-        return userRepository.findByEmail(email)
+        return userRepository.findByTenantIdAndEmail(DEFAULT_TENANT_ID, email)
                 .map(this::buildUserDetailsResponse);
     }
 
     @Override
     @Transactional
     public UserDetailsResponse createUser(CreateUserRequest request) {
-        if (userRepository.existsByUsername(request.getUsername())) {
+        if (userRepository.existsByTenantIdAndUsername(DEFAULT_TENANT_ID, request.getUsername())) {
             throw new UsernameAlreadyExistsException(request.getUsername());
         }
 
-        if (userRepository.existsByEmail(request.getEmail())) {
+        if (userRepository.existsByTenantIdAndEmail(DEFAULT_TENANT_ID, request.getEmail())) {
             throw new EmailAlreadyExistsException(request.getEmail());
         }
 
@@ -234,6 +236,7 @@ public class UserServiceImpl implements UserService {
         }
 
         User user = User.builder()
+                .tenantId(DEFAULT_TENANT_ID)
                 .username(request.getUsername())
                 .email(request.getEmail())
                 .passwordHash(request.getPasswordHash())
@@ -242,10 +245,11 @@ public class UserServiceImpl implements UserService {
                 .build();
 
         User saved = userRepository.save(user);
-        Role defaultRole = roleRepository.findByName("ROLE_USER")
+        Role defaultRole = roleRepository.findByTenantIdAndName(DEFAULT_TENANT_ID, "ROLE_USER")
                 .orElseThrow(() -> new RoleNotFoundException("ROLE_USER"));
-        if (!userRoleRepository.existsByUserIdAndRoleId(saved.getId(), defaultRole.getId())) {
+        if (!userRoleRepository.existsByTenantIdAndUserIdAndRoleId(DEFAULT_TENANT_ID, saved.getId(), defaultRole.getId())) {
             userRoleRepository.save(UserRole.builder()
+                    .tenantId(DEFAULT_TENANT_ID)
                     .userId(saved.getId())
                     .roleId(defaultRole.getId())
                     .build());
@@ -257,16 +261,16 @@ public class UserServiceImpl implements UserService {
     @Transactional
     public void updateLastLogin(Long userId, LastLoginUpdateRequest request) {
         findUserOrThrow(userId);
-        userRepository.updateLastLogin(userId, request.getLoginTime(), request.getIpAddress());
+        userRepository.updateLastLogin(DEFAULT_TENANT_ID, userId, request.getLoginTime(), request.getIpAddress());
     }
 
     @Override
     @Transactional(readOnly = true)
     public List<String> getUserRoles(Long userId) {
         findUserOrThrow(userId);
-        List<Integer> roleIds = userRoleRepository.findRoleIdsByUserId(userId);
+        List<Integer> roleIds = userRoleRepository.findRoleIdsByTenantIdAndUserId(DEFAULT_TENANT_ID, userId);
         return roleIds.stream()
-                .map(roleId -> roleRepository.findById(roleId))
+                .map(roleId -> roleRepository.findByIdAndTenantId(roleId, DEFAULT_TENANT_ID))
                 .filter(Optional::isPresent)
                 .map(Optional::get)
                 .map(Role::getName)
@@ -277,13 +281,13 @@ public class UserServiceImpl implements UserService {
     @Transactional(readOnly = true)
     public List<String> getUserPermissions(Long userId) {
         findUserOrThrow(userId);
-        return userRoleRepository.findPermissionsByUserId(userId);
+        return userRoleRepository.findPermissionsByTenantIdAndUserId(DEFAULT_TENANT_ID, userId);
     }
 
     // === 私有辅助方法 ===
 
     private User findUserOrThrow(Long userId) {
-        return userRepository.findById(userId)
+        return userRepository.findByIdAndTenantId(userId, DEFAULT_TENANT_ID)
                 .orElseThrow(() -> new UserNotFoundException(userId));
     }
 

--- a/koduck-user/src/test/java/com/koduck/integration/InternalUserControllerIntegrationTest.java
+++ b/koduck-user/src/test/java/com/koduck/integration/InternalUserControllerIntegrationTest.java
@@ -35,6 +35,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Testcontainers(disabledWithoutDocker = true)
 class InternalUserControllerIntegrationTest {
 
+    private static final String DEFAULT_TENANT_ID = "default";
+
     @Container
     static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:15-alpine")
             .withDatabaseName("koduck_user_test")
@@ -85,9 +87,10 @@ class InternalUserControllerIntegrationTest {
                 .andExpect(jsonPath("$.username").value(request.getUsername()))
                 .andExpect(jsonPath("$.email").value(request.getEmail()));
 
-        User created = userRepository.findByUsername(request.getUsername()).orElseThrow();
+        User created = userRepository.findByTenantIdAndUsername(DEFAULT_TENANT_ID, request.getUsername()).orElseThrow();
         assertNotNull(created.getId());
-        assertEquals(1, userRoleRepository.findByUserId(created.getId()).size(), "new user should have default role");
+        assertEquals(1, userRoleRepository.findByTenantIdAndUserId(DEFAULT_TENANT_ID, created.getId()).size(),
+                "new user should have default role");
 
         mockMvc.perform(get("/internal/users/by-username/{username}", request.getUsername())
                         .header("X-Consumer-Username", "koduck-auth"))
@@ -100,6 +103,7 @@ class InternalUserControllerIntegrationTest {
     void shouldPersistLastLoginUpdateViaInternalController() throws Exception {
         String unique = String.valueOf(System.nanoTime());
         User user = userRepository.save(User.builder()
+                .tenantId(DEFAULT_TENANT_ID)
                 .username("login-user-" + unique)
                 .email("login-" + unique + "@koduck.local")
                 .passwordHash("hash")

--- a/koduck-user/src/test/java/com/koduck/service/impl/UserServiceImplTest.java
+++ b/koduck-user/src/test/java/com/koduck/service/impl/UserServiceImplTest.java
@@ -30,6 +30,8 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class UserServiceImplTest {
 
+    private static final String DEFAULT_TENANT_ID = "default";
+
     @Mock
     private UserRepository userRepository;
     @Mock
@@ -61,12 +63,13 @@ class UserServiceImplTest {
                 .nickname("New Nick")
                 .build();
 
-        when(userRepository.findById(userId)).thenReturn(Optional.of(existing));
-        when(userRepository.existsByEmail("new@koduck.com")).thenReturn(false);
+        when(userRepository.findByIdAndTenantId(userId, DEFAULT_TENANT_ID)).thenReturn(Optional.of(existing));
+        when(userRepository.existsByTenantIdAndEmail(DEFAULT_TENANT_ID, "new@koduck.com")).thenReturn(false);
         when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
-        when(userRoleRepository.findRoleIdsByUserId(userId)).thenReturn(List.of(1));
-        when(roleRepository.findById(1)).thenReturn(Optional.of(Role.builder()
+        when(userRoleRepository.findRoleIdsByTenantIdAndUserId(DEFAULT_TENANT_ID, userId)).thenReturn(List.of(1));
+        when(roleRepository.findByIdAndTenantId(1, DEFAULT_TENANT_ID)).thenReturn(Optional.of(Role.builder()
                 .id(1)
+                .tenantId(DEFAULT_TENANT_ID)
                 .name("ROLE_USER")
                 .description("default")
                 .build()));
@@ -88,15 +91,17 @@ class UserServiceImplTest {
         Long userId = 1002L;
         Integer roleId = 2;
 
-        when(userRepository.findById(userId)).thenReturn(Optional.of(User.builder()
+        when(userRepository.findByIdAndTenantId(userId, DEFAULT_TENANT_ID)).thenReturn(Optional.of(User.builder()
                 .id(userId)
+                .tenantId(DEFAULT_TENANT_ID)
                 .username("admin")
                 .email("admin@koduck.com")
                 .passwordHash("hash")
                 .status(UserStatus.ACTIVE)
                 .build()));
-        when(roleRepository.existsById(roleId)).thenReturn(true);
-        when(userRoleRepository.existsByUserIdAndRoleId(userId, roleId)).thenReturn(true);
+        when(roleRepository.findByIdAndTenantId(roleId, DEFAULT_TENANT_ID))
+                .thenReturn(Optional.of(Role.builder().id(roleId).tenantId(DEFAULT_TENANT_ID).name("ROLE_ADMIN").build()));
+        when(userRoleRepository.existsByTenantIdAndUserIdAndRoleId(DEFAULT_TENANT_ID, userId, roleId)).thenReturn(true);
 
         userService.assignRole(userId, roleId);
 
@@ -108,13 +113,13 @@ class UserServiceImplTest {
         Long userId = 1003L;
         List<String> aggregatedPermissions = List.of("user:read", "role:write");
 
-        when(userRoleRepository.findPermissionsByUserId(userId)).thenReturn(aggregatedPermissions);
+        when(userRoleRepository.findPermissionsByTenantIdAndUserId(DEFAULT_TENANT_ID, userId)).thenReturn(aggregatedPermissions);
 
         List<String> result = userService.getCurrentUserPermissions(userId);
 
         assertEquals(2, result.size());
         assertTrue(result.contains("user:read"));
         assertTrue(result.contains("role:write"));
-        verify(userRoleRepository).findPermissionsByUserId(userId);
+        verify(userRoleRepository).findPermissionsByTenantIdAndUserId(DEFAULT_TENANT_ID, userId);
     }
 }


### PR DESCRIPTION
## Summary
- add tenantId fields to koduck-user entities so the JPA model matches the tenantized schema
- replace global repository lookups with tenant-aware methods and route service queries through the default tenant
- record the Task 3.1 ADR and mark the checklist as complete

## Validation
- mvn -f koduck-user/pom.xml test
- docker build -t koduck-user:dev ./koduck-user
- kubectl rollout restart deployment/dev-koduck-user -n koduck-dev
- kubectl rollout status deployment/dev-koduck-user -n koduck-dev --timeout=180s

Closes #770