### PR TITLE
feat(user): add tenant context to internal api

### DIFF
--- a/docs/implementation/koduck-auth-user-tenant-semantics-tasks.md
+++ b/docs/implementation/koduck-auth-user-tenant-semantics-tasks.md
@@ -134,9 +134,15 @@
 1. internal API 支持 `X-Tenant-Id`
 2. `findByUsername / findByEmail / getUserRoles / getUserPermissions` 默认按租户作用域执行
 
+**执行结果（2026-04-11）:**
+- `InternalUserController` 现已支持读取 `X-Tenant-Id`，并在缺失时兼容回退到 `default` tenant
+- `UserService` / `UserServiceImpl` 的 internal API 相关方法均增加 `tenantId` 参数，用户读取、角色读取、权限读取与创建用户路径按租户作用域执行
+- controller 审计日志增加 tenantId 记录，便于后续链路排查
+- 新增 ADR `0021-add-tenant-context-to-internal-user-api.md`，明确“显式支持 header，旧路径回退 default”的兼容策略
+
 **验收标准:**
-- [ ] internal API 不会跨租户串读
-- [ ] 旧路径兼容策略明确
+- [x] internal API 不会跨租户串读
+- [x] 旧路径兼容策略明确
 
 ### Task 3.3: `UserContext` 扩展 `tenant_id`
 **详细要求:**

--- a/koduck-user/docs/adr/0021-add-tenant-context-to-internal-user-api.md
+++ b/koduck-user/docs/adr/0021-add-tenant-context-to-internal-user-api.md
@@ -1,0 +1,129 @@
+# ADR-0021: Task 3.2 为 internal user API 增加 tenant context
+
+## 元数据
+
+- **状态**: 已接受
+- **日期**: 2026-04-11
+- **作者**: @hailingu
+- **相关**: #772, docs/implementation/koduck-auth-user-tenant-semantics-tasks.md Task 3.2, ADR-0020
+
+---
+
+## 背景与问题陈述
+
+Task 3.1 已经让 `koduck-user` 的实体与 repository 具备 tenant-aware 查询能力，但 `InternalUserController` 仍未显式接收租户上下文：
+
+1. internal API 没有 `X-Tenant-Id`
+2. `findByUsername` / `findByEmail` / `getUserRoles` / `getUserPermissions` 只能走默认租户
+3. 旧的 internal 调用链缺少明确兼容策略
+
+这会让后续 `koduck-auth` 接入时继续存在跨租户串读风险。
+
+---
+
+## 决策驱动因素
+
+1. **契约一致性**: internal API 需要显式表达租户上下文。
+2. **读路径隔离**: 用户定位、角色读取、权限读取都必须按 tenant scope 执行。
+3. **兼容过渡**: 在调用方尚未全部升级前，缺失 `X-Tenant-Id` 的旧路径需要有稳定默认行为。
+4. **任务边界清晰**: 本任务只处理 internal API，不提前引入 `UserContext` 改造。
+
+---
+
+## 考虑的选项
+
+### 选项 1：要求 `X-Tenant-Id` 必填，缺失直接拒绝
+
+**优点**:
+- 语义最严格
+
+**缺点**:
+- 会立即打断尚未升级的调用方
+
+### 选项 2：增加 `X-Tenant-Id`，缺失时回退到 `default` tenant（选定）
+
+**优点**:
+- 满足租户化契约
+- 对旧调用方保持平滑兼容
+- 后续可以在 Task 3.3 / 4.x 再逐步强化
+
+**缺点**:
+- 过渡阶段仍存在“未显式传 header 但走默认租户”的兼容路径
+
+### 选项 3：继续只在 service 层固定 `default`
+
+**优点**:
+- 改动最少
+
+**缺点**:
+- internal API 仍无法表达真实租户上下文
+- 不满足 Task 3.2 的要求
+
+---
+
+## 决策结果
+
+采用 **选项 2**：
+
+1. `InternalUserController` 支持读取 `X-Tenant-Id`
+2. `findByUsername` / `findByEmail` / `createUser` / `updateLastLogin` / `getUserRoles` / `getUserPermissions` 将 tenantId 传入 `UserService`
+3. 当 `X-Tenant-Id` 缺失或为空时，兼容回退到 `default` tenant
+4. 审计日志中记录 tenantId，便于后续排查
+
+---
+
+## 实施细节
+
+### 变更文件
+
+| 文件 | 变更说明 |
+|------|------|
+| `koduck-user/src/main/java/com/koduck/controller/user/InternalUserController.java` | 增加 `X-Tenant-Id` 读取、默认租户回退和审计日志扩展 |
+| `koduck-user/src/main/java/com/koduck/service/UserService.java` | internal API 方法签名增加 tenantId |
+| `koduck-user/src/main/java/com/koduck/service/impl/UserServiceImpl.java` | internal API 查询按传入 tenantId 执行 |
+| `koduck-user/src/test/java/...` | 补充自定义租户与默认租户兼容测试 |
+| `docs/implementation/koduck-auth-user-tenant-semantics-tasks.md` | 回填 Task 3.2 执行结果与 checklist |
+
+---
+
+## 权衡与影响
+
+### 正向影响
+
+- internal API 正式具备租户上下文。
+- 用户、角色、权限等内部读路径可按租户隔离。
+- `koduck-auth` 后续可直接传递 `X-Tenant-Id`。
+
+### 负向影响
+
+- 过渡阶段仍保留 `default` tenant 回退逻辑。
+- internal service 接口签名有所变化，需要同步测试桩和调用方。
+
+### 缓解措施
+
+- 在 ADR 与任务清单中明确“缺失 header 回退 default”的兼容策略。
+- 在 Task 3.3 中继续将 tenant 上下文提升到统一的 `UserContext`。
+
+---
+
+## 兼容性影响
+
+1. **调用方兼容性**: 未传 `X-Tenant-Id` 的旧 internal 调用仍可落到 `default` tenant。
+2. **运行时兼容性**: 已升级调用方可以按 header 显式控制租户作用域。
+3. **数据兼容性**: 不涉及额外 schema 变更。
+
+---
+
+## 相关文档
+
+- [koduck-auth-user-tenant-semantics.md](../../../docs/design/koduck-auth-user-tenant-semantics.md)
+- [koduck-auth-user-tenant-semantics-tasks.md](../../../docs/implementation/koduck-auth-user-tenant-semantics-tasks.md)
+- [ADR-0020](./0020-align-entities-and-repositories-with-tenant-scope.md)
+
+---
+
+## 变更日志
+
+| 日期 | 变更 | 作者 |
+|------|------|------|
+| 2026-04-11 | 初始版本 | @hailingu |

--- a/koduck-user/src/main/java/com/koduck/controller/user/InternalUserController.java
+++ b/koduck-user/src/main/java/com/koduck/controller/user/InternalUserController.java
@@ -26,6 +26,7 @@ import java.util.List;
 @RequestMapping("/internal")
 public class InternalUserController {
 
+    private static final String DEFAULT_TENANT_ID = "default";
     private static final Logger log = LoggerFactory.getLogger(InternalUserController.class);
 
     private final UserService userService;
@@ -37,10 +38,12 @@ public class InternalUserController {
     @GetMapping("/users/by-username/{username}")
     public ResponseEntity<UserDetailsResponse> findByUsername(
             @PathVariable String username,
-            @RequestHeader(value = "X-Consumer-Username", required = false) String consumer) {
+            @RequestHeader(value = "X-Consumer-Username", required = false) String consumer,
+            @RequestHeader(value = "X-Tenant-Id", required = false) String tenantId) {
         String consumerName = requireConsumer(consumer);
-        logAudit(consumerName, "findByUsername", username);
-        return userService.findByUsername(username)
+        String resolvedTenantId = resolveTenantId(tenantId);
+        logAudit(consumerName, resolvedTenantId, "findByUsername", username);
+        return userService.findByUsername(resolvedTenantId, username)
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());
     }
@@ -48,10 +51,12 @@ public class InternalUserController {
     @GetMapping("/users/by-email/{email}")
     public ResponseEntity<UserDetailsResponse> findByEmail(
             @PathVariable String email,
-            @RequestHeader(value = "X-Consumer-Username", required = false) String consumer) {
+            @RequestHeader(value = "X-Consumer-Username", required = false) String consumer,
+            @RequestHeader(value = "X-Tenant-Id", required = false) String tenantId) {
         String consumerName = requireConsumer(consumer);
-        logAudit(consumerName, "findByEmail", email);
-        return userService.findByEmail(email)
+        String resolvedTenantId = resolveTenantId(tenantId);
+        logAudit(consumerName, resolvedTenantId, "findByEmail", email);
+        return userService.findByEmail(resolvedTenantId, email)
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());
     }
@@ -59,39 +64,47 @@ public class InternalUserController {
     @PostMapping("/users")
     public ResponseEntity<UserDetailsResponse> createUser(
             @RequestBody @Valid CreateUserRequest request,
-            @RequestHeader(value = "X-Consumer-Username", required = false) String consumer) {
+            @RequestHeader(value = "X-Consumer-Username", required = false) String consumer,
+            @RequestHeader(value = "X-Tenant-Id", required = false) String tenantId) {
         String consumerName = requireConsumer(consumer);
-        logAudit(consumerName, "createUser", request.getUsername());
-        return ResponseEntity.ok(userService.createUser(request));
+        String resolvedTenantId = resolveTenantId(tenantId);
+        logAudit(consumerName, resolvedTenantId, "createUser", request.getUsername());
+        return ResponseEntity.ok(userService.createUser(resolvedTenantId, request));
     }
 
     @PutMapping("/users/{userId}/last-login")
     public ResponseEntity<Void> updateLastLogin(
             @PathVariable Long userId,
             @RequestBody @Valid LastLoginUpdateRequest request,
-            @RequestHeader(value = "X-Consumer-Username", required = false) String consumer) {
+            @RequestHeader(value = "X-Consumer-Username", required = false) String consumer,
+            @RequestHeader(value = "X-Tenant-Id", required = false) String tenantId) {
         String consumerName = requireConsumer(consumer);
-        logAudit(consumerName, "updateLastLogin", String.valueOf(userId));
-        userService.updateLastLogin(userId, request);
+        String resolvedTenantId = resolveTenantId(tenantId);
+        logAudit(consumerName, resolvedTenantId, "updateLastLogin", String.valueOf(userId));
+        userService.updateLastLogin(resolvedTenantId, userId, request);
         return ResponseEntity.ok().build();
     }
 
     @GetMapping("/users/{userId}/roles")
     public ResponseEntity<List<String>> getUserRoles(
             @PathVariable Long userId,
-            @RequestHeader(value = "X-Consumer-Username", required = false) String consumer) {
+            @RequestHeader(value = "X-Consumer-Username", required = false) String consumer,
+            @RequestHeader(value = "X-Tenant-Id", required = false) String tenantId) {
         String consumerName = requireConsumer(consumer);
-        logAudit(consumerName, "getUserRoles", String.valueOf(userId));
-        return ResponseEntity.ok(userService.getUserRoles(userId));
+        String resolvedTenantId = resolveTenantId(tenantId);
+        logAudit(consumerName, resolvedTenantId, "getUserRoles", String.valueOf(userId));
+        return ResponseEntity.ok(userService.getUserRoles(resolvedTenantId, userId));
     }
 
     @GetMapping("/users/{userId}/permissions")
     public ResponseEntity<List<String>> getUserPermissions(
             @PathVariable Long userId,
-            @RequestHeader(value = "X-Consumer-Username", required = false) String consumer) {
+            @RequestHeader(value = "X-Consumer-Username", required = false) String consumer,
+            @RequestHeader(value = "X-Tenant-Id", required = false) String tenantId) {
         String consumerName = requireConsumer(consumer);
-        logAudit(consumerName, "getUserPermissions", String.valueOf(userId));
-        return ResponseEntity.ok(userService.getUserPermissions(userId));
+        String resolvedTenantId = resolveTenantId(tenantId);
+        logAudit(consumerName, resolvedTenantId, "getUserPermissions", String.valueOf(userId));
+        return ResponseEntity.ok(userService.getUserPermissions(resolvedTenantId, userId));
     }
 
     private String requireConsumer(String consumer) {
@@ -101,8 +114,12 @@ public class InternalUserController {
         return consumer;
     }
 
-    private void logAudit(String consumer, String action, String target) {
+    private String resolveTenantId(String tenantId) {
+        return (tenantId == null || tenantId.isBlank()) ? DEFAULT_TENANT_ID : tenantId;
+    }
+
+    private void logAudit(String consumer, String tenantId, String action, String target) {
         String consumerName = (consumer == null || consumer.isBlank()) ? "unknown" : consumer;
-        log.info("internal-api action={} target={} consumer={}", action, target, consumerName);
+        log.info("internal-api action={} target={} consumer={} tenantId={}", action, target, consumerName, tenantId);
     }
 }

--- a/koduck-user/src/main/java/com/koduck/service/UserService.java
+++ b/koduck-user/src/main/java/com/koduck/service/UserService.java
@@ -47,15 +47,15 @@ public interface UserService {
 
     // === 内部 API ===
 
-    Optional<UserDetailsResponse> findByUsername(String username);
+    Optional<UserDetailsResponse> findByUsername(String tenantId, String username);
 
-    Optional<UserDetailsResponse> findByEmail(String email);
+    Optional<UserDetailsResponse> findByEmail(String tenantId, String email);
 
-    UserDetailsResponse createUser(CreateUserRequest request);
+    UserDetailsResponse createUser(String tenantId, CreateUserRequest request);
 
-    void updateLastLogin(Long userId, LastLoginUpdateRequest request);
+    void updateLastLogin(String tenantId, Long userId, LastLoginUpdateRequest request);
 
-    List<String> getUserRoles(Long userId);
+    List<String> getUserRoles(String tenantId, Long userId);
 
-    List<String> getUserPermissions(Long userId);
+    List<String> getUserPermissions(String tenantId, Long userId);
 }

--- a/koduck-user/src/main/java/com/koduck/service/impl/UserServiceImpl.java
+++ b/koduck-user/src/main/java/com/koduck/service/impl/UserServiceImpl.java
@@ -207,26 +207,28 @@ public class UserServiceImpl implements UserService {
 
     @Override
     @Transactional(readOnly = true)
-    public Optional<UserDetailsResponse> findByUsername(String username) {
-        return userRepository.findByTenantIdAndUsername(DEFAULT_TENANT_ID, username)
+    public Optional<UserDetailsResponse> findByUsername(String tenantId, String username) {
+        return userRepository.findByTenantIdAndUsername(resolveTenantId(tenantId), username)
                 .map(this::buildUserDetailsResponse);
     }
 
     @Override
     @Transactional(readOnly = true)
-    public Optional<UserDetailsResponse> findByEmail(String email) {
-        return userRepository.findByTenantIdAndEmail(DEFAULT_TENANT_ID, email)
+    public Optional<UserDetailsResponse> findByEmail(String tenantId, String email) {
+        return userRepository.findByTenantIdAndEmail(resolveTenantId(tenantId), email)
                 .map(this::buildUserDetailsResponse);
     }
 
     @Override
     @Transactional
-    public UserDetailsResponse createUser(CreateUserRequest request) {
-        if (userRepository.existsByTenantIdAndUsername(DEFAULT_TENANT_ID, request.getUsername())) {
+    public UserDetailsResponse createUser(String tenantId, CreateUserRequest request) {
+        String resolvedTenantId = resolveTenantId(tenantId);
+
+        if (userRepository.existsByTenantIdAndUsername(resolvedTenantId, request.getUsername())) {
             throw new UsernameAlreadyExistsException(request.getUsername());
         }
 
-        if (userRepository.existsByTenantIdAndEmail(DEFAULT_TENANT_ID, request.getEmail())) {
+        if (userRepository.existsByTenantIdAndEmail(resolvedTenantId, request.getEmail())) {
             throw new EmailAlreadyExistsException(request.getEmail());
         }
 
@@ -236,7 +238,7 @@ public class UserServiceImpl implements UserService {
         }
 
         User user = User.builder()
-                .tenantId(DEFAULT_TENANT_ID)
+                .tenantId(resolvedTenantId)
                 .username(request.getUsername())
                 .email(request.getEmail())
                 .passwordHash(request.getPasswordHash())
@@ -245,11 +247,11 @@ public class UserServiceImpl implements UserService {
                 .build();
 
         User saved = userRepository.save(user);
-        Role defaultRole = roleRepository.findByTenantIdAndName(DEFAULT_TENANT_ID, "ROLE_USER")
+        Role defaultRole = roleRepository.findByTenantIdAndName(resolvedTenantId, "ROLE_USER")
                 .orElseThrow(() -> new RoleNotFoundException("ROLE_USER"));
-        if (!userRoleRepository.existsByTenantIdAndUserIdAndRoleId(DEFAULT_TENANT_ID, saved.getId(), defaultRole.getId())) {
+        if (!userRoleRepository.existsByTenantIdAndUserIdAndRoleId(resolvedTenantId, saved.getId(), defaultRole.getId())) {
             userRoleRepository.save(UserRole.builder()
-                    .tenantId(DEFAULT_TENANT_ID)
+                    .tenantId(resolvedTenantId)
                     .userId(saved.getId())
                     .roleId(defaultRole.getId())
                     .build());
@@ -259,18 +261,20 @@ public class UserServiceImpl implements UserService {
 
     @Override
     @Transactional
-    public void updateLastLogin(Long userId, LastLoginUpdateRequest request) {
-        findUserOrThrow(userId);
-        userRepository.updateLastLogin(DEFAULT_TENANT_ID, userId, request.getLoginTime(), request.getIpAddress());
+    public void updateLastLogin(String tenantId, Long userId, LastLoginUpdateRequest request) {
+        String resolvedTenantId = resolveTenantId(tenantId);
+        findUserOrThrow(resolvedTenantId, userId);
+        userRepository.updateLastLogin(resolvedTenantId, userId, request.getLoginTime(), request.getIpAddress());
     }
 
     @Override
     @Transactional(readOnly = true)
-    public List<String> getUserRoles(Long userId) {
-        findUserOrThrow(userId);
-        List<Integer> roleIds = userRoleRepository.findRoleIdsByTenantIdAndUserId(DEFAULT_TENANT_ID, userId);
+    public List<String> getUserRoles(String tenantId, Long userId) {
+        String resolvedTenantId = resolveTenantId(tenantId);
+        findUserOrThrow(resolvedTenantId, userId);
+        List<Integer> roleIds = userRoleRepository.findRoleIdsByTenantIdAndUserId(resolvedTenantId, userId);
         return roleIds.stream()
-                .map(roleId -> roleRepository.findByIdAndTenantId(roleId, DEFAULT_TENANT_ID))
+                .map(roleId -> roleRepository.findByIdAndTenantId(roleId, resolvedTenantId))
                 .filter(Optional::isPresent)
                 .map(Optional::get)
                 .map(Role::getName)
@@ -279,16 +283,25 @@ public class UserServiceImpl implements UserService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<String> getUserPermissions(Long userId) {
-        findUserOrThrow(userId);
-        return userRoleRepository.findPermissionsByTenantIdAndUserId(DEFAULT_TENANT_ID, userId);
+    public List<String> getUserPermissions(String tenantId, Long userId) {
+        String resolvedTenantId = resolveTenantId(tenantId);
+        findUserOrThrow(resolvedTenantId, userId);
+        return userRoleRepository.findPermissionsByTenantIdAndUserId(resolvedTenantId, userId);
     }
 
     // === 私有辅助方法 ===
 
     private User findUserOrThrow(Long userId) {
-        return userRepository.findByIdAndTenantId(userId, DEFAULT_TENANT_ID)
+        return findUserOrThrow(DEFAULT_TENANT_ID, userId);
+    }
+
+    private User findUserOrThrow(String tenantId, Long userId) {
+        return userRepository.findByIdAndTenantId(userId, tenantId)
                 .orElseThrow(() -> new UserNotFoundException(userId));
+    }
+
+    private String resolveTenantId(String tenantId) {
+        return StringUtils.hasText(tenantId) ? tenantId : DEFAULT_TENANT_ID;
     }
 
     private UserProfileResponse buildUserProfileResponse(User user, List<RoleInfo> roles) {

--- a/koduck-user/src/test/java/com/koduck/controller/user/InternalUserControllerTest.java
+++ b/koduck-user/src/test/java/com/koduck/controller/user/InternalUserControllerTest.java
@@ -36,6 +36,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 class InternalUserControllerTest {
 
+    private static final String DEFAULT_TENANT_ID = "default";
+    private static final String TENANT_ID = "tenant-a";
+
     private MockMvc mockMvc;
     private ObjectMapper objectMapper;
     private StubUserService userService;
@@ -62,10 +65,12 @@ class InternalUserControllerTest {
                 .build());
 
         mockMvc.perform(get("/internal/users/by-username/alice")
-                        .header("X-Consumer-Username", "koduck-auth"))
+                        .header("X-Consumer-Username", "koduck-auth")
+                        .header("X-Tenant-Id", TENANT_ID))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").value(1001))
                 .andExpect(jsonPath("$.username").value("alice"));
+        org.junit.jupiter.api.Assertions.assertEquals(TENANT_ID, userService.lastTenantId);
     }
 
     @Test
@@ -73,8 +78,26 @@ class InternalUserControllerTest {
         userService.userByUsername = Optional.empty();
 
         mockMvc.perform(get("/internal/users/by-username/missing")
-                        .header("X-Consumer-Username", "koduck-auth"))
+                        .header("X-Consumer-Username", "koduck-auth")
+                        .header("X-Tenant-Id", TENANT_ID))
                 .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void shouldFallbackToDefaultTenantWhenTenantHeaderMissing() throws Exception {
+        userService.userByUsername = Optional.of(UserDetailsResponse.builder()
+                .id(1001L)
+                .username("alice")
+                .email("alice@koduck.com")
+                .passwordHash("hash")
+                .status("ACTIVE")
+                .build());
+
+        mockMvc.perform(get("/internal/users/by-username/alice")
+                        .header("X-Consumer-Username", "koduck-auth"))
+                .andExpect(status().isOk());
+
+        org.junit.jupiter.api.Assertions.assertEquals(DEFAULT_TENANT_ID, userService.lastTenantId);
     }
 
     @Test
@@ -96,7 +119,8 @@ class InternalUserControllerTest {
                 .build());
 
         mockMvc.perform(get("/internal/users/by-email/bob@koduck.com")
-                        .header("X-Consumer-Username", "koduck-auth"))
+                        .header("X-Consumer-Username", "koduck-auth")
+                        .header("X-Tenant-Id", TENANT_ID))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").value(1002))
                 .andExpect(jsonPath("$.email").value("bob@koduck.com"));
@@ -107,7 +131,8 @@ class InternalUserControllerTest {
         userService.userByEmail = Optional.empty();
 
         mockMvc.perform(get("/internal/users/by-email/missing@koduck.com")
-                        .header("X-Consumer-Username", "koduck-auth"))
+                        .header("X-Consumer-Username", "koduck-auth")
+                        .header("X-Tenant-Id", TENANT_ID))
                 .andExpect(status().isNotFound());
     }
 
@@ -131,6 +156,7 @@ class InternalUserControllerTest {
 
         mockMvc.perform(post("/internal/users")
                         .header("X-Consumer-Username", "koduck-auth")
+                        .header("X-Tenant-Id", TENANT_ID)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
@@ -148,6 +174,7 @@ class InternalUserControllerTest {
 
         mockMvc.perform(post("/internal/users")
                         .header("X-Consumer-Username", "koduck-auth")
+                        .header("X-Tenant-Id", TENANT_ID)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest());
@@ -164,6 +191,7 @@ class InternalUserControllerTest {
 
         mockMvc.perform(post("/internal/users")
                         .header("X-Consumer-Username", "koduck-auth")
+                        .header("X-Tenant-Id", TENANT_ID)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isConflict())
@@ -183,6 +211,7 @@ class InternalUserControllerTest {
 
         mockMvc.perform(post("/internal/users")
                         .header("X-Consumer-Username", "koduck-auth")
+                        .header("X-Tenant-Id", TENANT_ID)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isConflict())
@@ -200,6 +229,7 @@ class InternalUserControllerTest {
 
         mockMvc.perform(put("/internal/users/1001/last-login")
                         .header("X-Consumer-Username", "koduck-auth")
+                        .header("X-Tenant-Id", TENANT_ID)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk());
@@ -215,6 +245,7 @@ class InternalUserControllerTest {
 
         mockMvc.perform(put("/internal/users/9999/last-login")
                         .header("X-Consumer-Username", "koduck-auth")
+                        .header("X-Tenant-Id", TENANT_ID)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isNotFound())
@@ -228,7 +259,8 @@ class InternalUserControllerTest {
         userService.roles = List.of("ROLE_USER", "ROLE_ADMIN");
 
         mockMvc.perform(get("/internal/users/1001/roles")
-                        .header("X-Consumer-Username", "koduck-auth"))
+                        .header("X-Consumer-Username", "koduck-auth")
+                        .header("X-Tenant-Id", TENANT_ID))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0]").value("ROLE_USER"))
                 .andExpect(jsonPath("$[1]").value("ROLE_ADMIN"));
@@ -239,7 +271,8 @@ class InternalUserControllerTest {
         userService.notFoundUserIds = Set.of(9999L);
 
         mockMvc.perform(get("/internal/users/9999/roles")
-                        .header("X-Consumer-Username", "koduck-auth"))
+                        .header("X-Consumer-Username", "koduck-auth")
+                        .header("X-Tenant-Id", TENANT_ID))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.code").value(404))
                 .andExpect(jsonPath("$.message").value("用户不存在: id=9999"))
@@ -251,7 +284,8 @@ class InternalUserControllerTest {
         userService.permissions = List.of("user:read", "user:write");
 
         mockMvc.perform(get("/internal/users/1001/permissions")
-                        .header("X-Consumer-Username", "koduck-auth"))
+                        .header("X-Consumer-Username", "koduck-auth")
+                        .header("X-Tenant-Id", TENANT_ID))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0]").value("user:read"))
                 .andExpect(jsonPath("$[1]").value("user:write"));
@@ -262,7 +296,8 @@ class InternalUserControllerTest {
         userService.notFoundUserIds = Set.of(9999L);
 
         mockMvc.perform(get("/internal/users/9999/permissions")
-                        .header("X-Consumer-Username", "koduck-auth"))
+                        .header("X-Consumer-Username", "koduck-auth")
+                        .header("X-Tenant-Id", TENANT_ID))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.code").value(404))
                 .andExpect(jsonPath("$.message").value("用户不存在: id=9999"))
@@ -273,6 +308,7 @@ class InternalUserControllerTest {
 
         private Optional<UserDetailsResponse> userByUsername = Optional.empty();
         private Optional<UserDetailsResponse> userByEmail = Optional.empty();
+        private String lastTenantId;
         private UserDetailsResponse createdUser;
         private List<String> roles = List.of();
         private List<String> permissions = List.of();
@@ -331,17 +367,20 @@ class InternalUserControllerTest {
         }
 
         @Override
-        public Optional<UserDetailsResponse> findByUsername(String username) {
+        public Optional<UserDetailsResponse> findByUsername(String tenantId, String username) {
+            this.lastTenantId = tenantId;
             return userByUsername;
         }
 
         @Override
-        public Optional<UserDetailsResponse> findByEmail(String email) {
+        public Optional<UserDetailsResponse> findByEmail(String tenantId, String email) {
+            this.lastTenantId = tenantId;
             return userByEmail;
         }
 
         @Override
-        public UserDetailsResponse createUser(CreateUserRequest request) {
+        public UserDetailsResponse createUser(String tenantId, CreateUserRequest request) {
+            this.lastTenantId = tenantId;
             if (request.getUsername() != null && request.getUsername().equals(conflictUsername)) {
                 throw new UsernameAlreadyExistsException(request.getUsername());
             }
@@ -352,14 +391,16 @@ class InternalUserControllerTest {
         }
 
         @Override
-        public void updateLastLogin(Long userId, LastLoginUpdateRequest request) {
+        public void updateLastLogin(String tenantId, Long userId, LastLoginUpdateRequest request) {
+            this.lastTenantId = tenantId;
             if (notFoundUserIds.contains(userId)) {
                 throw new UserNotFoundException(userId);
             }
         }
 
         @Override
-        public List<String> getUserRoles(Long userId) {
+        public List<String> getUserRoles(String tenantId, Long userId) {
+            this.lastTenantId = tenantId;
             if (notFoundUserIds.contains(userId)) {
                 throw new UserNotFoundException(userId);
             }
@@ -367,7 +408,8 @@ class InternalUserControllerTest {
         }
 
         @Override
-        public List<String> getUserPermissions(Long userId) {
+        public List<String> getUserPermissions(String tenantId, Long userId) {
+            this.lastTenantId = tenantId;
             if (notFoundUserIds.contains(userId)) {
                 throw new UserNotFoundException(userId);
             }

--- a/koduck-user/src/test/java/com/koduck/controller/user/UserControllerAuthBoundaryTest.java
+++ b/koduck-user/src/test/java/com/koduck/controller/user/UserControllerAuthBoundaryTest.java
@@ -119,32 +119,32 @@ class UserControllerAuthBoundaryTest {
         }
 
         @Override
-        public Optional<UserDetailsResponse> findByUsername(String username) {
+        public Optional<UserDetailsResponse> findByUsername(String tenantId, String username) {
             throw new UnsupportedOperationException("Not used in this test");
         }
 
         @Override
-        public Optional<UserDetailsResponse> findByEmail(String email) {
+        public Optional<UserDetailsResponse> findByEmail(String tenantId, String email) {
             throw new UnsupportedOperationException("Not used in this test");
         }
 
         @Override
-        public UserDetailsResponse createUser(CreateUserRequest request) {
+        public UserDetailsResponse createUser(String tenantId, CreateUserRequest request) {
             throw new UnsupportedOperationException("Not used in this test");
         }
 
         @Override
-        public void updateLastLogin(Long userId, LastLoginUpdateRequest request) {
+        public void updateLastLogin(String tenantId, Long userId, LastLoginUpdateRequest request) {
             throw new UnsupportedOperationException("Not used in this test");
         }
 
         @Override
-        public List<String> getUserRoles(Long userId) {
+        public List<String> getUserRoles(String tenantId, Long userId) {
             throw new UnsupportedOperationException("Not used in this test");
         }
 
         @Override
-        public List<String> getUserPermissions(Long userId) {
+        public List<String> getUserPermissions(String tenantId, Long userId) {
             throw new UnsupportedOperationException("Not used in this test");
         }
     }

--- a/koduck-user/src/test/java/com/koduck/integration/InternalUserControllerIntegrationTest.java
+++ b/koduck-user/src/test/java/com/koduck/integration/InternalUserControllerIntegrationTest.java
@@ -36,6 +36,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class InternalUserControllerIntegrationTest {
 
     private static final String DEFAULT_TENANT_ID = "default";
+    private static final String TENANT_B = "tenant-b";
 
     @Container
     static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:15-alpine")
@@ -64,8 +65,20 @@ class InternalUserControllerIntegrationTest {
 
     @BeforeEach
     void setUp() {
+        jdbcTemplate.update("DELETE FROM roles WHERE tenant_id <> ?", DEFAULT_TENANT_ID);
+        jdbcTemplate.update("DELETE FROM tenants WHERE id <> 'default'");
         jdbcTemplate.update("DELETE FROM user_roles");
         jdbcTemplate.update("DELETE FROM users");
+        jdbcTemplate.update(
+                "INSERT INTO tenants (id, name, status) VALUES (?, ?, ?) ON CONFLICT (id) DO NOTHING",
+                TENANT_B,
+                "Tenant B",
+                "ACTIVE");
+        jdbcTemplate.update(
+                "INSERT INTO roles (tenant_id, name, description) VALUES (?, ?, ?) ON CONFLICT DO NOTHING",
+                TENANT_B,
+                "ROLE_USER",
+                "tenant default role");
     }
 
     @Test
@@ -81,19 +94,21 @@ class InternalUserControllerIntegrationTest {
 
         mockMvc.perform(post("/internal/users")
                         .header("X-Consumer-Username", "koduck-auth")
+                        .header("X-Tenant-Id", TENANT_B)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.username").value(request.getUsername()))
                 .andExpect(jsonPath("$.email").value(request.getEmail()));
 
-        User created = userRepository.findByTenantIdAndUsername(DEFAULT_TENANT_ID, request.getUsername()).orElseThrow();
+        User created = userRepository.findByTenantIdAndUsername(TENANT_B, request.getUsername()).orElseThrow();
         assertNotNull(created.getId());
-        assertEquals(1, userRoleRepository.findByTenantIdAndUserId(DEFAULT_TENANT_ID, created.getId()).size(),
+        assertEquals(1, userRoleRepository.findByTenantIdAndUserId(TENANT_B, created.getId()).size(),
                 "new user should have default role");
 
         mockMvc.perform(get("/internal/users/by-username/{username}", request.getUsername())
-                        .header("X-Consumer-Username", "koduck-auth"))
+                        .header("X-Consumer-Username", "koduck-auth")
+                        .header("X-Tenant-Id", TENANT_B))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").value(created.getId()))
                 .andExpect(jsonPath("$.username").value(request.getUsername()));
@@ -116,6 +131,7 @@ class InternalUserControllerIntegrationTest {
 
         mockMvc.perform(put("/internal/users/{userId}/last-login", user.getId())
                         .header("X-Consumer-Username", "koduck-auth")
+                        .header("X-Tenant-Id", DEFAULT_TENANT_ID)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk());
@@ -123,5 +139,22 @@ class InternalUserControllerIntegrationTest {
         User reloaded = userRepository.findById(user.getId()).orElseThrow();
         assertEquals(request.getLoginTime(), reloaded.getLastLoginAt());
         assertEquals(request.getIpAddress(), reloaded.getLastLoginIp());
+    }
+
+    @Test
+    void shouldFallbackToDefaultTenantWhenTenantHeaderMissing() throws Exception {
+        String unique = String.valueOf(System.nanoTime());
+        User user = userRepository.save(User.builder()
+                .tenantId(DEFAULT_TENANT_ID)
+                .username("fallback-user-" + unique)
+                .email("fallback-" + unique + "@koduck.local")
+                .passwordHash("hash")
+                .build());
+
+        mockMvc.perform(get("/internal/users/by-username/{username}", user.getUsername())
+                        .header("X-Consumer-Username", "koduck-auth"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(user.getId()))
+                .andExpect(jsonPath("$.username").value(user.getUsername()));
     }
 }


### PR DESCRIPTION
## Summary
- add X-Tenant-Id support to the internal user API and keep missing-header calls compatible via the default tenant
- pass tenantId through UserService internal methods so user, role, and permission lookups execute in tenant scope
- add ADR 0021 and mark Task 3.2 as complete in the tenant semantics task list

## Validation
- mvn -f koduck-user/pom.xml test
- docker build -t koduck-user:dev ./koduck-user
- kubectl rollout restart deployment/dev-koduck-user -n koduck-dev
- kubectl rollout status deployment/dev-koduck-user -n koduck-dev --timeout=180s

Closes #772