### PR TITLE
feat(user): extend user context with tenant id

### DIFF
--- a/docs/implementation/koduck-auth-user-tenant-semantics-tasks.md
+++ b/docs/implementation/koduck-auth-user-tenant-semantics-tasks.md
@@ -149,8 +149,14 @@
 1. 新增 `X-Tenant-Id`
 2. 增加 `getTenantId()`
 
+**执行结果（2026-04-11）:**
+- `UserContext` 已新增 `X-Tenant-Id` 支持和 `getTenantId()`，缺失 header 时兼容回退到 `default`
+- `UserController`、`RoleController`、`PermissionController` 均已通过 `UserContext` 读取 tenantId，并显式传入 service 层
+- `UserService`、`RoleService`、`PermissionService` 的公开 API 相关方法均增加 tenantId 参数，服务层不再只能依赖内置默认租户
+- 新增 ADR `0022-extend-user-context-with-tenant-id.md`，明确上下文统一入口和兼容策略
+
 **验收标准:**
-- [ ] 控制器和服务层可读取租户上下文
+- [x] 控制器和服务层可读取租户上下文
 
 ---
 

--- a/koduck-user/docs/adr/0022-extend-user-context-with-tenant-id.md
+++ b/koduck-user/docs/adr/0022-extend-user-context-with-tenant-id.md
@@ -1,0 +1,132 @@
+# ADR-0022: Task 3.3 为 UserContext 增加 tenant_id
+
+## 元数据
+
+- **状态**: 已接受
+- **日期**: 2026-04-11
+- **作者**: @hailingu
+- **相关**: #774, docs/implementation/koduck-auth-user-tenant-semantics-tasks.md Task 3.3, ADR-0021
+
+---
+
+## 背景与问题陈述
+
+Task 3.2 已经让 internal API 显式支持 `X-Tenant-Id`，但公开 API 与通用权限校验链路仍然缺少统一的租户上下文入口：
+
+1. `UserContext` 只能读取 `X-User-Id`、`X-Username`、`X-Roles`
+2. `UserController`、`RoleController`、`PermissionController` 还不能统一从上下文获取 tenant
+3. 服务层公开 API 仍大量依赖默认 tenant，而不是从控制器显式传入
+
+如果不先解决这一层，后续 `koduck-auth` 写入租户 claim 后，公开 API 仍然无法稳定消费租户上下文。
+
+---
+
+## 决策驱动因素
+
+1. **统一入口**: 租户上下文应与用户身份上下文一样，通过 `UserContext` 统一读取。
+2. **控制器可见性**: 公开 API 控制器需要显式拿到 tenantId，而不是依赖服务层内置默认值。
+3. **服务层透传**: 服务层公开 API 方法应能直接接收 tenantId。
+4. **兼容过渡**: 缺失 `X-Tenant-Id` 时仍需兼容回退到 `default` tenant。
+
+---
+
+## 考虑的选项
+
+### 选项 1：只给 `UserContext` 增加 `getTenantId()`，其他层不动
+
+**优点**:
+- 改动较小
+
+**缺点**:
+- 控制器和服务层仍未真正消费租户上下文
+- 无法满足验收标准
+
+### 选项 2：扩展 `UserContext`，并让公开 API 控制器和服务层显式透传 tenantId（选定）
+
+**优点**:
+- 控制器与服务层都能读取租户上下文
+- 与 Task 3.2 的 internal API header 语义保持一致
+- 为后续 auth claim 接入打好统一入口
+
+**缺点**:
+- 需要同步调整多个 service 接口和测试桩
+
+### 选项 3：等待 Task 4 再一起处理租户上下文
+
+**优点**:
+- 当前任务改动更少
+
+**缺点**:
+- `koduck-user` 侧上下文链路仍不完整
+- 不符合任务拆分顺序
+
+---
+
+## 决策结果
+
+采用 **选项 2**：
+
+1. 在 `UserContext` 中新增 `X-Tenant-Id` 读取与 `getTenantId()`
+2. 缺失 tenant header 时兼容回退到 `default`
+3. `UserController`、`RoleController`、`PermissionController` 通过 `UserContext.getTenantId()` 获取租户上下文
+4. 公开 API 相关的 `UserService`、`RoleService`、`PermissionService` 方法显式增加 tenantId 参数
+5. `AccessControl` 在权限校验前同步读取 tenant 上下文，确保统一上下文已存在
+
+---
+
+## 实施细节
+
+### 变更文件
+
+| 文件 | 变更说明 |
+|------|------|
+| `koduck-user/src/main/java/com/koduck/context/UserContext.java` | 新增 `X-Tenant-Id` 和 `getTenantId()` |
+| `koduck-user/src/main/java/com/koduck/context/AccessControl.java` | 权限校验前同步读取 tenant 上下文 |
+| `koduck-user/src/main/java/com/koduck/controller/user/*.java` | 公开 API 控制器通过 `UserContext` 读取 tenantId |
+| `koduck-user/src/main/java/com/koduck/service/*.java` | 公开 API 相关 service 方法显式增加 tenantId 参数 |
+| `koduck-user/src/test/java/...` | 补充 `UserContext` 行为测试并更新测试桩 |
+| `docs/implementation/koduck-auth-user-tenant-semantics-tasks.md` | 回填 Task 3.3 执行结果与 checklist |
+
+---
+
+## 权衡与影响
+
+### 正向影响
+
+- 公开 API 和 internal API 统一拥有租户上下文读取入口。
+- 控制器和服务层都能显式消费 tenantId。
+- 后续 JWT claim 注入 `tenant_id` 后，`koduck-user` 可以直接消费。
+
+### 负向影响
+
+- service 接口签名变化较多，需要同步测试和调用点。
+- 过渡阶段仍保留 `default` tenant 回退路径。
+
+### 缓解措施
+
+- 用单元测试覆盖 `UserContext.getTenantId()` 的显式值与默认回退行为。
+- 在 ADR 中明确 default tenant 的兼容策略。
+
+---
+
+## 兼容性影响
+
+1. **运行时兼容性**: 缺失 `X-Tenant-Id` 的公开 API 请求仍会回退到 `default` tenant。
+2. **调用方兼容性**: 已传租户 header 的调用链可立即获得租户作用域行为。
+3. **接口兼容性**: HTTP API 只新增可选 header，不改变路径与 body。
+
+---
+
+## 相关文档
+
+- [koduck-auth-user-tenant-semantics.md](../../../docs/design/koduck-auth-user-tenant-semantics.md)
+- [koduck-auth-user-tenant-semantics-tasks.md](../../../docs/implementation/koduck-auth-user-tenant-semantics-tasks.md)
+- [ADR-0021](./0021-add-tenant-context-to-internal-user-api.md)
+
+---
+
+## 变更日志
+
+| 日期 | 变更 | 作者 |
+|------|------|------|
+| 2026-04-11 | 初始版本 | @hailingu |

--- a/koduck-user/src/main/java/com/koduck/context/AccessControl.java
+++ b/koduck-user/src/main/java/com/koduck/context/AccessControl.java
@@ -46,6 +46,7 @@ public final class AccessControl {
     public static void requirePermission(HttpServletRequest request, String permission) {
         // 权限校验前必须具备已认证用户上下文（X-User-Id）。
         UserContext.getUserId(request);
+        UserContext.getTenantId(request);
 
         if (UserContext.hasRole(request, ROLE_SUPER_ADMIN)) {
             return;

--- a/koduck-user/src/main/java/com/koduck/context/UserContext.java
+++ b/koduck-user/src/main/java/com/koduck/context/UserContext.java
@@ -12,13 +12,16 @@ import java.util.List;
  *   <li>{@code X-User-Id} - 用户ID</li>
  *   <li>{@code X-Username} - 用户名</li>
  *   <li>{@code X-Roles} - 角色列表（逗号分隔）</li>
+ *   <li>{@code X-Tenant-Id} - 租户ID</li>
  * </ul>
  */
 public final class UserContext {
 
+    private static final String DEFAULT_TENANT_ID = "default";
     private static final String HEADER_USER_ID = "X-User-Id";
     private static final String HEADER_USERNAME = "X-Username";
     private static final String HEADER_ROLES = "X-Roles";
+    private static final String HEADER_TENANT_ID = "X-Tenant-Id";
 
     private UserContext() {
     }
@@ -37,6 +40,14 @@ public final class UserContext {
 
     public static String getUsername(HttpServletRequest request) {
         return request.getHeader(HEADER_USERNAME);
+    }
+
+    public static String getTenantId(HttpServletRequest request) {
+        String tenantId = request.getHeader(HEADER_TENANT_ID);
+        if (tenantId == null || tenantId.isBlank()) {
+            return DEFAULT_TENANT_ID;
+        }
+        return tenantId;
     }
 
     public static List<String> getRoles(HttpServletRequest request) {

--- a/koduck-user/src/main/java/com/koduck/controller/user/PermissionController.java
+++ b/koduck-user/src/main/java/com/koduck/controller/user/PermissionController.java
@@ -40,6 +40,6 @@ public class PermissionController {
             HttpServletRequest request,
             @PathVariable Long userId) {
         UserContext.getUserId(request);
-        return ApiResponse.ok(permissionService.getUserPermissions(userId));
+        return ApiResponse.ok(permissionService.getUserPermissions(UserContext.getTenantId(request), userId));
     }
 }

--- a/koduck-user/src/main/java/com/koduck/controller/user/RoleController.java
+++ b/koduck-user/src/main/java/com/koduck/controller/user/RoleController.java
@@ -1,6 +1,7 @@
 package com.koduck.controller.user;
 
 import com.koduck.context.AccessControl;
+import com.koduck.context.UserContext;
 import com.koduck.dto.user.common.ApiResponse;
 import com.koduck.dto.user.permission.PermissionInfo;
 import com.koduck.dto.user.role.CreateRoleRequest;
@@ -48,7 +49,7 @@ public class RoleController {
     @GetMapping
     public ApiResponse<List<RoleInfo>> listRoles(HttpServletRequest request) {
         AccessControl.requirePermission(request, "role:read");
-        return ApiResponse.ok(roleService.listRoles());
+        return ApiResponse.ok(roleService.listRoles(UserContext.getTenantId(request)));
     }
 
     @GetMapping("/{roleId}")
@@ -56,7 +57,7 @@ public class RoleController {
             HttpServletRequest request,
             @PathVariable Integer roleId) {
         AccessControl.requirePermission(request, "role:read");
-        return ApiResponse.ok(roleService.getRoleById(roleId));
+        return ApiResponse.ok(roleService.getRoleById(UserContext.getTenantId(request), roleId));
     }
 
     @PostMapping
@@ -64,7 +65,7 @@ public class RoleController {
             HttpServletRequest request,
             @RequestBody @Valid CreateRoleRequest createRequest) {
         AccessControl.requirePermission(request, "role:write");
-        return ApiResponse.ok(roleService.createRole(createRequest));
+        return ApiResponse.ok(roleService.createRole(UserContext.getTenantId(request), createRequest));
     }
 
     @PutMapping("/{roleId}")
@@ -73,7 +74,7 @@ public class RoleController {
             @PathVariable Integer roleId,
             @RequestBody @Valid UpdateRoleRequest updateRequest) {
         AccessControl.requirePermission(request, "role:write");
-        return ApiResponse.ok(roleService.updateRole(roleId, updateRequest));
+        return ApiResponse.ok(roleService.updateRole(UserContext.getTenantId(request), roleId, updateRequest));
     }
 
     @DeleteMapping("/{roleId}")
@@ -81,7 +82,7 @@ public class RoleController {
             HttpServletRequest request,
             @PathVariable Integer roleId) {
         AccessControl.requirePermission(request, "role:delete");
-        roleService.deleteRole(roleId);
+        roleService.deleteRole(UserContext.getTenantId(request), roleId);
         return ApiResponse.ok();
     }
 
@@ -90,7 +91,7 @@ public class RoleController {
             HttpServletRequest request,
             @PathVariable Integer roleId) {
         AccessControl.requirePermission(request, "role:read");
-        return ApiResponse.ok(roleService.getRolePermissions(roleId));
+        return ApiResponse.ok(roleService.getRolePermissions(UserContext.getTenantId(request), roleId));
     }
 
     @PutMapping("/{roleId}/permissions")
@@ -99,7 +100,7 @@ public class RoleController {
             @PathVariable Integer roleId,
             @RequestBody @Valid SetRolePermissionsRequest permissionsRequest) {
         AccessControl.requirePermission(request, "role:write");
-        roleService.setRolePermissions(roleId, permissionsRequest);
+        roleService.setRolePermissions(UserContext.getTenantId(request), roleId, permissionsRequest);
         return ApiResponse.ok();
     }
 }

--- a/koduck-user/src/main/java/com/koduck/controller/user/UserController.java
+++ b/koduck-user/src/main/java/com/koduck/controller/user/UserController.java
@@ -40,6 +40,7 @@ import java.util.List;
  *   <li>{@code X-User-Id} - 用户ID</li>
  *   <li>{@code X-Username} - 用户名</li>
  *   <li>{@code X-Roles} - 角色列表</li>
+ *   <li>{@code X-Tenant-Id} - 租户ID</li>
  * </ul>
  *
  * @see com.koduck.context.UserContext
@@ -60,8 +61,9 @@ public class UserController {
 
     @GetMapping("/users/me")
     public ApiResponse<UserProfileResponse> getCurrentUser(HttpServletRequest request) {
+        String tenantId = UserContext.getTenantId(request);
         Long userId = UserContext.getUserId(request);
-        UserProfileResponse profile = userService.getCurrentUser(userId);
+        UserProfileResponse profile = userService.getCurrentUser(tenantId, userId);
         return ApiResponse.ok(profile);
     }
 
@@ -69,8 +71,9 @@ public class UserController {
     public ApiResponse<UserProfileResponse> updateCurrentUser(
             HttpServletRequest request,
             @RequestBody @Valid UpdateProfileRequest updateRequest) {
+        String tenantId = UserContext.getTenantId(request);
         Long userId = UserContext.getUserId(request);
-        UserProfileResponse profile = userService.updateProfile(userId, updateRequest);
+        UserProfileResponse profile = userService.updateProfile(tenantId, userId, updateRequest);
         return ApiResponse.ok(profile);
     }
 
@@ -90,15 +93,17 @@ public class UserController {
 
     @DeleteMapping("/users/me")
     public ApiResponse<Void> deleteCurrentUser(HttpServletRequest request) {
+        String tenantId = UserContext.getTenantId(request);
         Long userId = UserContext.getUserId(request);
-        userService.deleteUser(userId);
+        userService.deleteUser(tenantId, userId);
         return ApiResponse.ok();
     }
 
     @GetMapping("/users/me/permissions")
     public ApiResponse<List<PermissionInfo>> getCurrentUserPermissions(HttpServletRequest request) {
+        String tenantId = UserContext.getTenantId(request);
         Long userId = UserContext.getUserId(request);
-        List<String> userPermissionCodes = userService.getCurrentUserPermissions(userId);
+        List<String> userPermissionCodes = userService.getCurrentUserPermissions(tenantId, userId);
         List<PermissionInfo> allPermissions = permissionService.listPermissions();
         List<PermissionInfo> userPermissions = allPermissions.stream()
                 .filter(p -> userPermissionCodes.contains(p.getCode()))
@@ -113,7 +118,7 @@ public class UserController {
             HttpServletRequest request,
             @PathVariable Long userId) {
         AccessControl.requirePermission(request, "user:read");
-        UserProfileResponse profile = userService.getUserById(userId);
+        UserProfileResponse profile = userService.getUserById(UserContext.getTenantId(request), userId);
         return ApiResponse.ok(profile);
     }
 
@@ -126,10 +131,11 @@ public class UserController {
             @RequestParam(defaultValue = "20") int size,
             @RequestParam(defaultValue = "createdAt,desc") String sort) {
         AccessControl.requirePermission(request, "user:read");
+        String tenantId = UserContext.getTenantId(request);
         Sort sortObj = parseSort(sort);
         PageRequest pageable = PageRequest.of(page, size, sortObj);
         com.koduck.dto.user.common.PageResponse<UserSummaryResponse> result =
-                userService.searchUsers(keyword, status, pageable);
+                userService.searchUsers(tenantId, keyword, status, pageable);
         return ApiResponse.ok(result);
     }
 
@@ -139,7 +145,7 @@ public class UserController {
             @PathVariable Long userId,
             @RequestBody @Valid UpdateUserRequest updateRequest) {
         AccessControl.requirePermission(request, "user:write");
-        UserProfileResponse profile = userService.updateUser(userId, updateRequest);
+        UserProfileResponse profile = userService.updateUser(UserContext.getTenantId(request), userId, updateRequest);
         return ApiResponse.ok(profile);
     }
 
@@ -148,7 +154,7 @@ public class UserController {
             HttpServletRequest request,
             @PathVariable Long userId) {
         AccessControl.requirePermission(request, "user:delete");
-        userService.deleteUser(userId);
+        userService.deleteUser(UserContext.getTenantId(request), userId);
         return ApiResponse.ok();
     }
 
@@ -161,7 +167,7 @@ public class UserController {
         UpdateUserRequest updateRequest = UpdateUserRequest.builder()
                 .status(statusRequest.getStatus())
                 .build();
-        UserProfileResponse profile = userService.updateUser(userId, updateRequest);
+        UserProfileResponse profile = userService.updateUser(UserContext.getTenantId(request), userId, updateRequest);
         return ApiResponse.ok(profile);
     }
 
@@ -172,7 +178,7 @@ public class UserController {
             HttpServletRequest request,
             @PathVariable Long userId) {
         AccessControl.requirePermission(request, "role:read");
-        List<RoleInfo> roles = userService.getUserRolesInfo(userId);
+        List<RoleInfo> roles = userService.getUserRolesInfo(UserContext.getTenantId(request), userId);
         return ApiResponse.ok(roles);
     }
 
@@ -182,7 +188,7 @@ public class UserController {
             @PathVariable Long userId,
             @RequestBody @Valid AssignRoleRequest assignRequest) {
         AccessControl.requirePermission(request, "role:write");
-        userService.assignRole(userId, assignRequest.getRoleId());
+        userService.assignRole(UserContext.getTenantId(request), userId, assignRequest.getRoleId());
         return ApiResponse.ok();
     }
 
@@ -192,7 +198,7 @@ public class UserController {
             @PathVariable Long userId,
             @PathVariable Integer roleId) {
         AccessControl.requirePermission(request, "role:write");
-        userService.removeRole(userId, roleId);
+        userService.removeRole(UserContext.getTenantId(request), userId, roleId);
         return ApiResponse.ok();
     }
 

--- a/koduck-user/src/main/java/com/koduck/service/PermissionService.java
+++ b/koduck-user/src/main/java/com/koduck/service/PermissionService.java
@@ -13,5 +13,5 @@ public interface PermissionService {
 
     List<PermissionInfo> listPermissions();
 
-    List<String> getUserPermissions(Long userId);
+    List<String> getUserPermissions(String tenantId, Long userId);
 }

--- a/koduck-user/src/main/java/com/koduck/service/RoleService.java
+++ b/koduck-user/src/main/java/com/koduck/service/RoleService.java
@@ -17,17 +17,17 @@ import java.util.List;
  */
 public interface RoleService {
 
-    List<RoleInfo> listRoles();
+    List<RoleInfo> listRoles(String tenantId);
 
-    RoleDetailResponse getRoleById(Integer roleId);
+    RoleDetailResponse getRoleById(String tenantId, Integer roleId);
 
-    RoleResponse createRole(CreateRoleRequest request);
+    RoleResponse createRole(String tenantId, CreateRoleRequest request);
 
-    RoleResponse updateRole(Integer roleId, UpdateRoleRequest request);
+    RoleResponse updateRole(String tenantId, Integer roleId, UpdateRoleRequest request);
 
-    void deleteRole(Integer roleId);
+    void deleteRole(String tenantId, Integer roleId);
 
-    void setRolePermissions(Integer roleId, SetRolePermissionsRequest request);
+    void setRolePermissions(String tenantId, Integer roleId, SetRolePermissionsRequest request);
 
-    List<PermissionInfo> getRolePermissions(Integer roleId);
+    List<PermissionInfo> getRolePermissions(String tenantId, Integer roleId);
 }

--- a/koduck-user/src/main/java/com/koduck/service/UserService.java
+++ b/koduck-user/src/main/java/com/koduck/service/UserService.java
@@ -23,27 +23,27 @@ public interface UserService {
 
     // === 公开 API: 当前用户 ===
 
-    UserProfileResponse getCurrentUser(Long currentUserId);
+    UserProfileResponse getCurrentUser(String tenantId, Long currentUserId);
 
-    UserProfileResponse updateProfile(Long currentUserId, UpdateProfileRequest request);
+    UserProfileResponse updateProfile(String tenantId, Long currentUserId, UpdateProfileRequest request);
 
-    List<String> getCurrentUserPermissions(Long currentUserId);
+    List<String> getCurrentUserPermissions(String tenantId, Long currentUserId);
 
     // === 公开 API: 管理员 ===
 
-    PageResponse<UserSummaryResponse> searchUsers(String keyword, String status, Pageable pageable);
+    PageResponse<UserSummaryResponse> searchUsers(String tenantId, String keyword, String status, Pageable pageable);
 
-    UserProfileResponse getUserById(Long userId);
+    UserProfileResponse getUserById(String tenantId, Long userId);
 
-    UserProfileResponse updateUser(Long userId, UpdateUserRequest request);
+    UserProfileResponse updateUser(String tenantId, Long userId, UpdateUserRequest request);
 
-    void deleteUser(Long userId);
+    void deleteUser(String tenantId, Long userId);
 
-    void assignRole(Long userId, Integer roleId);
+    void assignRole(String tenantId, Long userId, Integer roleId);
 
-    void removeRole(Long userId, Integer roleId);
+    void removeRole(String tenantId, Long userId, Integer roleId);
 
-    List<RoleInfo> getUserRolesInfo(Long userId);
+    List<RoleInfo> getUserRolesInfo(String tenantId, Long userId);
 
     // === 内部 API ===
 

--- a/koduck-user/src/main/java/com/koduck/service/impl/PermissionServiceImpl.java
+++ b/koduck-user/src/main/java/com/koduck/service/impl/PermissionServiceImpl.java
@@ -34,8 +34,9 @@ public class PermissionServiceImpl implements PermissionService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<String> getUserPermissions(Long userId) {
-        return userRoleRepository.findPermissionsByTenantIdAndUserId(DEFAULT_TENANT_ID, userId);
+    public List<String> getUserPermissions(String tenantId, Long userId) {
+        String resolvedTenantId = (tenantId == null || tenantId.isBlank()) ? DEFAULT_TENANT_ID : tenantId;
+        return userRoleRepository.findPermissionsByTenantIdAndUserId(resolvedTenantId, userId);
     }
 
     private PermissionInfo buildPermissionInfo(Permission permission) {

--- a/koduck-user/src/main/java/com/koduck/service/impl/RoleServiceImpl.java
+++ b/koduck-user/src/main/java/com/koduck/service/impl/RoleServiceImpl.java
@@ -57,29 +57,32 @@ public class RoleServiceImpl implements RoleService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<RoleInfo> listRoles() {
-        return roleRepository.findAllByTenantId(DEFAULT_TENANT_ID).stream()
+    public List<RoleInfo> listRoles(String tenantId) {
+        String resolvedTenantId = resolveTenantId(tenantId);
+        return roleRepository.findAllByTenantId(resolvedTenantId).stream()
                 .map(this::buildRoleInfo)
                 .toList();
     }
 
     @Override
     @Transactional(readOnly = true)
-    public RoleDetailResponse getRoleById(Integer roleId) {
-        Role role = findRoleOrThrow(roleId);
-        List<PermissionInfo> permissions = getRolePermissions(roleId);
+    public RoleDetailResponse getRoleById(String tenantId, Integer roleId) {
+        String resolvedTenantId = resolveTenantId(tenantId);
+        Role role = findRoleOrThrow(resolvedTenantId, roleId);
+        List<PermissionInfo> permissions = getRolePermissions(resolvedTenantId, roleId);
         return buildRoleDetailResponse(role, permissions);
     }
 
     @Override
     @Transactional
-    public RoleResponse createRole(CreateRoleRequest request) {
-        if (roleRepository.existsByTenantIdAndName(DEFAULT_TENANT_ID, request.getName())) {
+    public RoleResponse createRole(String tenantId, CreateRoleRequest request) {
+        String resolvedTenantId = resolveTenantId(tenantId);
+        if (roleRepository.existsByTenantIdAndName(resolvedTenantId, request.getName())) {
             throw new RoleAlreadyExistsException(request.getName());
         }
 
         Role role = Role.builder()
-                .tenantId(DEFAULT_TENANT_ID)
+                .tenantId(resolvedTenantId)
                 .name(request.getName())
                 .description(request.getDescription())
                 .build();
@@ -90,11 +93,12 @@ public class RoleServiceImpl implements RoleService {
 
     @Override
     @Transactional
-    public RoleResponse updateRole(Integer roleId, UpdateRoleRequest request) {
-        Role role = findRoleOrThrow(roleId);
+    public RoleResponse updateRole(String tenantId, Integer roleId, UpdateRoleRequest request) {
+        String resolvedTenantId = resolveTenantId(tenantId);
+        Role role = findRoleOrThrow(resolvedTenantId, roleId);
 
         if (request.getName() != null && !request.getName().equals(role.getName())) {
-            if (roleRepository.existsByTenantIdAndName(DEFAULT_TENANT_ID, request.getName())) {
+            if (roleRepository.existsByTenantIdAndName(resolvedTenantId, request.getName())) {
                 throw new RoleAlreadyExistsException(request.getName());
             }
             role.setName(request.getName());
@@ -110,25 +114,27 @@ public class RoleServiceImpl implements RoleService {
 
     @Override
     @Transactional
-    public void deleteRole(Integer roleId) {
-        Role role = findRoleOrThrow(roleId);
+    public void deleteRole(String tenantId, Integer roleId) {
+        String resolvedTenantId = resolveTenantId(tenantId);
+        Role role = findRoleOrThrow(resolvedTenantId, roleId);
 
         if (PROTECTED_ROLES.contains(role.getName())) {
             throw new ProtectedRoleException(role.getName());
         }
 
-        if (hasAssociatedUsers(roleId)) {
+        if (hasAssociatedUsers(resolvedTenantId, roleId)) {
             throw new RoleHasUsersException(roleId);
         }
 
-        rolePermissionRepository.deleteByTenantIdAndRoleId(DEFAULT_TENANT_ID, roleId);
+        rolePermissionRepository.deleteByTenantIdAndRoleId(resolvedTenantId, roleId);
         roleRepository.delete(role);
     }
 
     @Override
     @Transactional
-    public void setRolePermissions(Integer roleId, SetRolePermissionsRequest request) {
-        findRoleOrThrow(roleId);
+    public void setRolePermissions(String tenantId, Integer roleId, SetRolePermissionsRequest request) {
+        String resolvedTenantId = resolveTenantId(tenantId);
+        findRoleOrThrow(resolvedTenantId, roleId);
 
         // 验证所有权限 ID 存在
         List<Permission> permissions = permissionRepository.findAllById(request.getPermissionIds());
@@ -142,11 +148,11 @@ public class RoleServiceImpl implements RoleService {
         }
 
         // 全量替换：先删除再插入
-        rolePermissionRepository.deleteByTenantIdAndRoleId(DEFAULT_TENANT_ID, roleId);
+        rolePermissionRepository.deleteByTenantIdAndRoleId(resolvedTenantId, roleId);
 
         List<RolePermission> rolePermissions = permissions.stream()
                 .map(p -> RolePermission.builder()
-                        .tenantId(DEFAULT_TENANT_ID)
+                        .tenantId(resolvedTenantId)
                         .roleId(roleId)
                         .permissionId(p.getId())
                         .build())
@@ -157,10 +163,11 @@ public class RoleServiceImpl implements RoleService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<PermissionInfo> getRolePermissions(Integer roleId) {
-        findRoleOrThrow(roleId);
+    public List<PermissionInfo> getRolePermissions(String tenantId, Integer roleId) {
+        String resolvedTenantId = resolveTenantId(tenantId);
+        findRoleOrThrow(resolvedTenantId, roleId);
 
-        return rolePermissionRepository.findByTenantIdAndRoleId(DEFAULT_TENANT_ID, roleId).stream()
+        return rolePermissionRepository.findByTenantIdAndRoleId(resolvedTenantId, roleId).stream()
                 .map(rp -> permissionRepository.findById(rp.getPermissionId()))
                 .filter(java.util.Optional::isPresent)
                 .map(java.util.Optional::get)
@@ -170,13 +177,17 @@ public class RoleServiceImpl implements RoleService {
 
     // === 私有辅助方法 ===
 
-    private Role findRoleOrThrow(Integer roleId) {
-        return roleRepository.findByIdAndTenantId(roleId, DEFAULT_TENANT_ID)
+    private Role findRoleOrThrow(String tenantId, Integer roleId) {
+        return roleRepository.findByIdAndTenantId(roleId, tenantId)
                 .orElseThrow(() -> new RoleNotFoundException(roleId));
     }
 
-    private boolean hasAssociatedUsers(Integer roleId) {
-        return userRoleRepository.countByTenantIdAndRoleId(DEFAULT_TENANT_ID, roleId) > 0;
+    private boolean hasAssociatedUsers(String tenantId, Integer roleId) {
+        return userRoleRepository.countByTenantIdAndRoleId(tenantId, roleId) > 0;
+    }
+
+    private String resolveTenantId(String tenantId) {
+        return (tenantId == null || tenantId.isBlank()) ? DEFAULT_TENANT_ID : tenantId;
     }
 
     private RoleInfo buildRoleInfo(Role role) {

--- a/koduck-user/src/main/java/com/koduck/service/impl/UserServiceImpl.java
+++ b/koduck-user/src/main/java/com/koduck/service/impl/UserServiceImpl.java
@@ -51,19 +51,21 @@ public class UserServiceImpl implements UserService {
 
     @Override
     @Transactional(readOnly = true)
-    public UserProfileResponse getCurrentUser(Long currentUserId) {
-        User user = findUserOrThrow(currentUserId);
-        List<RoleInfo> roles = getUserRolesInfo(currentUserId);
+    public UserProfileResponse getCurrentUser(String tenantId, Long currentUserId) {
+        String resolvedTenantId = resolveTenantId(tenantId);
+        User user = findUserOrThrow(resolvedTenantId, currentUserId);
+        List<RoleInfo> roles = getUserRolesInfo(resolvedTenantId, currentUserId);
         return buildUserProfileResponse(user, roles);
     }
 
     @Override
     @Transactional
-    public UserProfileResponse updateProfile(Long currentUserId, UpdateProfileRequest request) {
-        User user = findUserOrThrow(currentUserId);
+    public UserProfileResponse updateProfile(String tenantId, Long currentUserId, UpdateProfileRequest request) {
+        String resolvedTenantId = resolveTenantId(tenantId);
+        User user = findUserOrThrow(resolvedTenantId, currentUserId);
 
         if (request.getEmail() != null && !request.getEmail().equals(user.getEmail())) {
-            if (userRepository.existsByTenantIdAndEmail(DEFAULT_TENANT_ID, request.getEmail())) {
+            if (userRepository.existsByTenantIdAndEmail(resolvedTenantId, request.getEmail())) {
                 throw new EmailAlreadyExistsException(request.getEmail());
             }
             user.setEmail(request.getEmail());
@@ -75,29 +77,30 @@ public class UserServiceImpl implements UserService {
         }
 
         User saved = userRepository.save(user);
-        List<RoleInfo> roles = getUserRolesInfo(saved.getId());
+        List<RoleInfo> roles = getUserRolesInfo(resolvedTenantId, saved.getId());
         return buildUserProfileResponse(saved, roles);
     }
 
     @Override
     @Transactional(readOnly = true)
-    public List<String> getCurrentUserPermissions(Long currentUserId) {
-        return userRoleRepository.findPermissionsByTenantIdAndUserId(DEFAULT_TENANT_ID, currentUserId);
+    public List<String> getCurrentUserPermissions(String tenantId, Long currentUserId) {
+        return userRoleRepository.findPermissionsByTenantIdAndUserId(resolveTenantId(tenantId), currentUserId);
     }
 
     // === 公开 API: 管理员 ===
 
     @Override
     @Transactional(readOnly = true)
-    public PageResponse<UserSummaryResponse> searchUsers(String keyword, String status, Pageable pageable) {
+    public PageResponse<UserSummaryResponse> searchUsers(String tenantId, String keyword, String status, Pageable pageable) {
+        String resolvedTenantId = resolveTenantId(tenantId);
         Page<User> users;
 
         if (StringUtils.hasText(keyword)) {
-            users = userRepository.searchByTenantIdAndKeyword(DEFAULT_TENANT_ID, keyword, pageable);
+            users = userRepository.searchByTenantIdAndKeyword(resolvedTenantId, keyword, pageable);
         } else if (StringUtils.hasText(status)) {
-            users = userRepository.findByTenantIdAndStatus(DEFAULT_TENANT_ID, UserStatus.valueOf(status), pageable);
+            users = userRepository.findByTenantIdAndStatus(resolvedTenantId, UserStatus.valueOf(status), pageable);
         } else {
-            users = userRepository.findByTenantId(DEFAULT_TENANT_ID, pageable);
+            users = userRepository.findByTenantId(resolvedTenantId, pageable);
         }
 
         Page<UserSummaryResponse> mapped = users.map(this::buildUserSummaryResponse);
@@ -116,19 +119,21 @@ public class UserServiceImpl implements UserService {
 
     @Override
     @Transactional(readOnly = true)
-    public UserProfileResponse getUserById(Long userId) {
-        User user = findUserOrThrow(userId);
-        List<RoleInfo> roles = getUserRolesInfo(userId);
+    public UserProfileResponse getUserById(String tenantId, Long userId) {
+        String resolvedTenantId = resolveTenantId(tenantId);
+        User user = findUserOrThrow(resolvedTenantId, userId);
+        List<RoleInfo> roles = getUserRolesInfo(resolvedTenantId, userId);
         return buildUserProfileResponse(user, roles);
     }
 
     @Override
     @Transactional
-    public UserProfileResponse updateUser(Long userId, UpdateUserRequest request) {
-        User user = findUserOrThrow(userId);
+    public UserProfileResponse updateUser(String tenantId, Long userId, UpdateUserRequest request) {
+        String resolvedTenantId = resolveTenantId(tenantId);
+        User user = findUserOrThrow(resolvedTenantId, userId);
 
         if (request.getEmail() != null && !request.getEmail().equals(user.getEmail())) {
-            if (userRepository.existsByTenantIdAndEmail(DEFAULT_TENANT_ID, request.getEmail())) {
+            if (userRepository.existsByTenantIdAndEmail(resolvedTenantId, request.getEmail())) {
                 throw new EmailAlreadyExistsException(request.getEmail());
             }
             user.setEmail(request.getEmail());
@@ -144,14 +149,15 @@ public class UserServiceImpl implements UserService {
         }
 
         User saved = userRepository.save(user);
-        List<RoleInfo> roles = getUserRolesInfo(saved.getId());
+        List<RoleInfo> roles = getUserRolesInfo(resolvedTenantId, saved.getId());
         return buildUserProfileResponse(saved, roles);
     }
 
     @Override
     @Transactional
-    public void deleteUser(Long userId) {
-        if (userRepository.findByIdAndTenantId(userId, DEFAULT_TENANT_ID).isEmpty()) {
+    public void deleteUser(String tenantId, Long userId) {
+        String resolvedTenantId = resolveTenantId(tenantId);
+        if (userRepository.findByIdAndTenantId(userId, resolvedTenantId).isEmpty()) {
             throw new UserNotFoundException(userId);
         }
         userRepository.deleteById(userId);
@@ -159,19 +165,20 @@ public class UserServiceImpl implements UserService {
 
     @Override
     @Transactional
-    public void assignRole(Long userId, Integer roleId) {
-        findUserOrThrow(userId);
+    public void assignRole(String tenantId, Long userId, Integer roleId) {
+        String resolvedTenantId = resolveTenantId(tenantId);
+        findUserOrThrow(resolvedTenantId, userId);
 
-        if (roleRepository.findByIdAndTenantId(roleId, DEFAULT_TENANT_ID).isEmpty()) {
+        if (roleRepository.findByIdAndTenantId(roleId, resolvedTenantId).isEmpty()) {
             throw new RoleNotFoundException(roleId);
         }
 
-        if (userRoleRepository.existsByTenantIdAndUserIdAndRoleId(DEFAULT_TENANT_ID, userId, roleId)) {
+        if (userRoleRepository.existsByTenantIdAndUserIdAndRoleId(resolvedTenantId, userId, roleId)) {
             return;
         }
 
         UserRole userRole = UserRole.builder()
-                .tenantId(DEFAULT_TENANT_ID)
+                .tenantId(resolvedTenantId)
                 .userId(userId)
                 .roleId(roleId)
                 .build();
@@ -181,22 +188,24 @@ public class UserServiceImpl implements UserService {
 
     @Override
     @Transactional
-    public void removeRole(Long userId, Integer roleId) {
-        findUserOrThrow(userId);
+    public void removeRole(String tenantId, Long userId, Integer roleId) {
+        String resolvedTenantId = resolveTenantId(tenantId);
+        findUserOrThrow(resolvedTenantId, userId);
 
-        if (roleRepository.findByIdAndTenantId(roleId, DEFAULT_TENANT_ID).isEmpty()) {
+        if (roleRepository.findByIdAndTenantId(roleId, resolvedTenantId).isEmpty()) {
             throw new RoleNotFoundException(roleId);
         }
 
-        userRoleRepository.deleteByTenantIdAndUserIdAndRoleId(DEFAULT_TENANT_ID, userId, roleId);
+        userRoleRepository.deleteByTenantIdAndUserIdAndRoleId(resolvedTenantId, userId, roleId);
     }
 
     @Override
     @Transactional(readOnly = true)
-    public List<RoleInfo> getUserRolesInfo(Long userId) {
-        List<Integer> roleIds = userRoleRepository.findRoleIdsByTenantIdAndUserId(DEFAULT_TENANT_ID, userId);
+    public List<RoleInfo> getUserRolesInfo(String tenantId, Long userId) {
+        String resolvedTenantId = resolveTenantId(tenantId);
+        List<Integer> roleIds = userRoleRepository.findRoleIdsByTenantIdAndUserId(resolvedTenantId, userId);
         return roleIds.stream()
-                .map(roleId -> roleRepository.findByIdAndTenantId(roleId, DEFAULT_TENANT_ID))
+                .map(roleId -> roleRepository.findByIdAndTenantId(roleId, resolvedTenantId))
                 .filter(Optional::isPresent)
                 .map(Optional::get)
                 .map(this::buildRoleInfo)

--- a/koduck-user/src/test/java/com/koduck/context/UserContextTest.java
+++ b/koduck-user/src/test/java/com/koduck/context/UserContextTest.java
@@ -1,0 +1,32 @@
+package com.koduck.context;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class UserContextTest {
+
+    @Test
+    void shouldReturnTenantIdFromHeader() {
+        HttpServletRequest request = buildRequestWithTenant("tenant-a");
+
+        assertEquals("tenant-a", UserContext.getTenantId(request));
+    }
+
+    @Test
+    void shouldFallbackToDefaultTenantWhenHeaderMissing() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("X-User-Id", "1001");
+
+        assertEquals("default", UserContext.getTenantId(request));
+    }
+
+    private HttpServletRequest buildRequestWithTenant(String tenantId) {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("X-User-Id", "1001");
+        request.addHeader("X-Tenant-Id", tenantId);
+        return request;
+    }
+}

--- a/koduck-user/src/test/java/com/koduck/controller/user/InternalUserControllerTest.java
+++ b/koduck-user/src/test/java/com/koduck/controller/user/InternalUserControllerTest.java
@@ -317,52 +317,52 @@ class InternalUserControllerTest {
         private Set<Long> notFoundUserIds = Set.of();
 
         @Override
-        public UserProfileResponse getCurrentUser(Long currentUserId) {
+        public UserProfileResponse getCurrentUser(String tenantId, Long currentUserId) {
             throw new UnsupportedOperationException("Not used in this test");
         }
 
         @Override
-        public UserProfileResponse updateProfile(Long currentUserId, UpdateProfileRequest request) {
+        public UserProfileResponse updateProfile(String tenantId, Long currentUserId, UpdateProfileRequest request) {
             throw new UnsupportedOperationException("Not used in this test");
         }
 
         @Override
-        public List<String> getCurrentUserPermissions(Long currentUserId) {
+        public List<String> getCurrentUserPermissions(String tenantId, Long currentUserId) {
             throw new UnsupportedOperationException("Not used in this test");
         }
 
         @Override
-        public PageResponse<UserSummaryResponse> searchUsers(String keyword, String status, Pageable pageable) {
+        public PageResponse<UserSummaryResponse> searchUsers(String tenantId, String keyword, String status, Pageable pageable) {
             throw new UnsupportedOperationException("Not used in this test");
         }
 
         @Override
-        public UserProfileResponse getUserById(Long userId) {
+        public UserProfileResponse getUserById(String tenantId, Long userId) {
             throw new UnsupportedOperationException("Not used in this test");
         }
 
         @Override
-        public UserProfileResponse updateUser(Long userId, UpdateUserRequest request) {
+        public UserProfileResponse updateUser(String tenantId, Long userId, UpdateUserRequest request) {
             throw new UnsupportedOperationException("Not used in this test");
         }
 
         @Override
-        public void deleteUser(Long userId) {
+        public void deleteUser(String tenantId, Long userId) {
             throw new UnsupportedOperationException("Not used in this test");
         }
 
         @Override
-        public void assignRole(Long userId, Integer roleId) {
+        public void assignRole(String tenantId, Long userId, Integer roleId) {
             throw new UnsupportedOperationException("Not used in this test");
         }
 
         @Override
-        public void removeRole(Long userId, Integer roleId) {
+        public void removeRole(String tenantId, Long userId, Integer roleId) {
             throw new UnsupportedOperationException("Not used in this test");
         }
 
         @Override
-        public List<RoleInfo> getUserRolesInfo(Long userId) {
+        public List<RoleInfo> getUserRolesInfo(String tenantId, Long userId) {
             throw new UnsupportedOperationException("Not used in this test");
         }
 

--- a/koduck-user/src/test/java/com/koduck/controller/user/UserControllerAuthBoundaryTest.java
+++ b/koduck-user/src/test/java/com/koduck/controller/user/UserControllerAuthBoundaryTest.java
@@ -27,6 +27,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 class UserControllerAuthBoundaryTest {
 
+    private static final String TENANT_ID = "tenant-a";
+
     private MockMvc mockMvc;
 
     @BeforeEach
@@ -51,6 +53,7 @@ class UserControllerAuthBoundaryTest {
     void shouldReturn403WhenPermissionInsufficientOnManagedApi() throws Exception {
         mockMvc.perform(get("/api/v1/users")
                         .header("X-User-Id", "1001")
+                        .header("X-Tenant-Id", TENANT_ID)
                         .header("X-Username", "demo")
                         .header("X-Roles", "ROLE_USER"))
                 .andExpect(status().isForbidden())
@@ -61,22 +64,22 @@ class UserControllerAuthBoundaryTest {
     private static class StubUserService implements UserService {
 
         @Override
-        public UserProfileResponse getCurrentUser(Long currentUserId) {
+        public UserProfileResponse getCurrentUser(String tenantId, Long currentUserId) {
             return UserProfileResponse.builder().id(currentUserId).username("demo").build();
         }
 
         @Override
-        public UserProfileResponse updateProfile(Long currentUserId, UpdateProfileRequest request) {
+        public UserProfileResponse updateProfile(String tenantId, Long currentUserId, UpdateProfileRequest request) {
             throw new UnsupportedOperationException("Not used in this test");
         }
 
         @Override
-        public List<String> getCurrentUserPermissions(Long currentUserId) {
+        public List<String> getCurrentUserPermissions(String tenantId, Long currentUserId) {
             return List.of();
         }
 
         @Override
-        public PageResponse<UserSummaryResponse> searchUsers(String keyword, String status, Pageable pageable) {
+        public PageResponse<UserSummaryResponse> searchUsers(String tenantId, String keyword, String status, Pageable pageable) {
             return PageResponse.<UserSummaryResponse>builder()
                     .content(List.of())
                     .pageNumber(0)
@@ -89,32 +92,32 @@ class UserControllerAuthBoundaryTest {
         }
 
         @Override
-        public UserProfileResponse getUserById(Long userId) {
+        public UserProfileResponse getUserById(String tenantId, Long userId) {
             throw new UnsupportedOperationException("Not used in this test");
         }
 
         @Override
-        public UserProfileResponse updateUser(Long userId, UpdateUserRequest request) {
+        public UserProfileResponse updateUser(String tenantId, Long userId, UpdateUserRequest request) {
             throw new UnsupportedOperationException("Not used in this test");
         }
 
         @Override
-        public void deleteUser(Long userId) {
+        public void deleteUser(String tenantId, Long userId) {
             throw new UnsupportedOperationException("Not used in this test");
         }
 
         @Override
-        public void assignRole(Long userId, Integer roleId) {
+        public void assignRole(String tenantId, Long userId, Integer roleId) {
             throw new UnsupportedOperationException("Not used in this test");
         }
 
         @Override
-        public void removeRole(Long userId, Integer roleId) {
+        public void removeRole(String tenantId, Long userId, Integer roleId) {
             throw new UnsupportedOperationException("Not used in this test");
         }
 
         @Override
-        public List<RoleInfo> getUserRolesInfo(Long userId) {
+        public List<RoleInfo> getUserRolesInfo(String tenantId, Long userId) {
             throw new UnsupportedOperationException("Not used in this test");
         }
 
@@ -157,7 +160,7 @@ class UserControllerAuthBoundaryTest {
         }
 
         @Override
-        public List<String> getUserPermissions(Long userId) {
+        public List<String> getUserPermissions(String tenantId, Long userId) {
             return List.of();
         }
     }

--- a/koduck-user/src/test/java/com/koduck/service/impl/UserServiceImplTest.java
+++ b/koduck-user/src/test/java/com/koduck/service/impl/UserServiceImplTest.java
@@ -74,7 +74,7 @@ class UserServiceImplTest {
                 .description("default")
                 .build()));
 
-        UserProfileResponse response = userService.updateProfile(userId, request);
+        UserProfileResponse response = userService.updateProfile(DEFAULT_TENANT_ID, userId, request);
 
         ArgumentCaptor<User> savedCaptor = ArgumentCaptor.forClass(User.class);
         verify(userRepository).save(savedCaptor.capture());
@@ -103,7 +103,7 @@ class UserServiceImplTest {
                 .thenReturn(Optional.of(Role.builder().id(roleId).tenantId(DEFAULT_TENANT_ID).name("ROLE_ADMIN").build()));
         when(userRoleRepository.existsByTenantIdAndUserIdAndRoleId(DEFAULT_TENANT_ID, userId, roleId)).thenReturn(true);
 
-        userService.assignRole(userId, roleId);
+        userService.assignRole(DEFAULT_TENANT_ID, userId, roleId);
 
         verify(userRoleRepository, never()).save(any());
     }
@@ -115,7 +115,7 @@ class UserServiceImplTest {
 
         when(userRoleRepository.findPermissionsByTenantIdAndUserId(DEFAULT_TENANT_ID, userId)).thenReturn(aggregatedPermissions);
 
-        List<String> result = userService.getCurrentUserPermissions(userId);
+        List<String> result = userService.getCurrentUserPermissions(DEFAULT_TENANT_ID, userId);
 
         assertEquals(2, result.size());
         assertTrue(result.contains("user:read"));


### PR DESCRIPTION
## Summary
- extend UserContext with X-Tenant-Id and a getTenantId() helper that defaults to the default tenant
- pass tenant context from public controllers into user, role, and permission services so both controller and service layers can read tenant scope
- add ADR 0022 and mark Task 3.3 as complete in the tenant semantics task list

## Validation
- mvn -f koduck-user/pom.xml test
- docker build -t koduck-user:dev ./koduck-user
- kubectl rollout restart deployment/dev-koduck-user -n koduck-dev
- kubectl rollout status deployment/dev-koduck-user -n koduck-dev --timeout=180s

Closes #774