### PR TITLE
feat(auth): thread tenant through jwt refresh chain

### DIFF
--- a/docs/implementation/koduck-auth-user-tenant-semantics-tasks.md
+++ b/docs/implementation/koduck-auth-user-tenant-semantics-tasks.md
@@ -169,8 +169,8 @@
 3. token 校验时解析 `tenant_id`
 
 **验收标准:**
-- [ ] access token 带 `tenant_id`
-- [ ] refresh / validate 链路不丢失 tenant
+- [x] access token 带 `tenant_id`
+- [x] refresh / validate 链路不丢失 tenant
 
 ### Task 4.2: gRPC / introspection 增加 `tenant_id`
 **详细要求:**

--- a/koduck-auth/docs/adr/0024-thread-tenant-through-jwt-refresh-chain.md
+++ b/koduck-auth/docs/adr/0024-thread-tenant-through-jwt-refresh-chain.md
@@ -1,0 +1,152 @@
+# ADR-0024: Task 4.1 在线程化 JWT claims 时保留 tenant 上下文
+
+## 元数据
+
+- **状态**: 已接受
+- **日期**: 2026-04-11
+- **作者**: @hailingu
+- **相关**: #776, docs/implementation/koduck-auth-user-tenant-semantics-tasks.md Task 4.1, ADR-0022, ADR-0023
+
+---
+
+## 背景与问题陈述
+
+Task 2.2 已经让 `koduck-auth` 的安全域表具备 `tenant_id`，但 Task 4.1 开始前，认证链路里仍有两个关键缺口：
+
+1. JWT `Claims` 不包含 `tenant_id`
+2. refresh token 刷新时仍通过默认租户包装方法查找与吊销 token
+
+这意味着即使数据库已经具备租户字段，`access token -> refresh token -> validate` 这条主链路仍无法稳定传播租户上下文。
+
+另外，`koduck-auth` 本地遗留的 `users / roles` 表仍是旧单租户 schema，refresh 链路如果继续依赖本地表，就无法用 `(tenant_id, user_id)` 作为完整身份语义。
+
+---
+
+## 决策驱动因素
+
+1. **身份语义一致性**: JWT 必须显式携带 `tenant_id`，与根设计文档冻结的 `(tenant_id, user_id)` 语义保持一致。
+2. **refresh 链路正确性**: 刷新 token 时，查找、吊销与重签发都必须在租户作用域内完成。
+3. **避免错误真值**: `koduck-auth` 不能根据邮箱、角色或本地遗留表推断租户，仍应回到 `koduck-user` 的用户真值。
+4. **任务边界控制**: 本任务聚焦 claims 与 refresh / validate 内部链路，不提前扩散到 Task 4.2 的 gRPC / introspection 对外契约变更。
+
+---
+
+## 考虑的选项
+
+### 选项 1：只给 JWT claims 增加 `tenant_id`，其余逻辑继续使用 default tenant
+
+**优点**:
+- 改动最小
+
+**缺点**:
+- refresh token 查询与吊销仍可能串租户
+- 不能满足“refresh / validate 链路不丢失 tenant”的验收标准
+
+### 选项 2：claims 写入 `tenant_id`，refresh 链路按租户查询 token，并通过 `koduck-user` internal API 取用户真值（选定）
+
+**优点**:
+- `tenant_id` 从签发到刷新都可贯通
+- 不需要在本任务里补 `koduck-auth` 遗留用户表的 schema
+- 真值仍来自 `koduck-user`
+
+**缺点**:
+- 需要在 `koduck-user` internal API 追加按 `userId` 查询用户详情的最小入口
+
+### 选项 3：直接在本任务中把 gRPC / introspection 返回结构一起改掉
+
+**优点**:
+- 一次性对外暴露完整 tenant 信息
+
+**缺点**:
+- 会与 Task 4.2 职责重叠
+- 契约面扩张过大，不利于拆分验收
+
+---
+
+## 决策结果
+
+采用 **选项 2**：
+
+1. `Claims` 增加 `tenant_id`
+2. access token 和 refresh token 在签发时都写入 `tenant_id`
+3. refresh token 刷新时先从 token payload 中解析 `tenant_id`
+4. `refresh_tokens` 的查找与吊销统一切到 tenant-aware 仓储方法
+5. `koduck-auth` 在 refresh 时不再依赖本地遗留 `users` 表取用户真值，而是通过 `koduck-user` internal API 按 `(tenant_id, user_id)` 获取用户详情与角色
+6. `koduck-user` internal API 的 `UserDetailsResponse` 增加 `tenantId`，并补充 `GET /internal/users/{userId}` 供 refresh 链路使用
+7. `TokenIntrospectionResult`、gRPC `ValidateTokenResponse`、`GetUserResponse` 等对外契约字段仍留到 Task 4.2 再统一暴露
+
+---
+
+## 实施细节
+
+### 变更文件
+
+| 文件 | 变更说明 |
+|------|------|
+| `koduck-auth/src/model/token.rs` | 为 JWT claims 增加 `tenant_id` |
+| `koduck-auth/src/jwt/generator.rs` | access / refresh token 签发时写入 `tenant_id` |
+| `koduck-auth/src/service/auth_service.rs` | refresh / logout / internal user-service 调用全部切换到 tenant-aware 链路 |
+| `koduck-auth/src/grpc/token_service.rs` | 适配新的 JWT 生成函数签名，仍保留 default tenant 兼容 |
+| `koduck-user/src/main/java/com/koduck/dto/user/user/UserDetailsResponse.java` | internal API 响应回传 `tenantId` |
+| `koduck-user/src/main/java/com/koduck/controller/user/InternalUserController.java` | 新增 `GET /internal/users/{userId}` |
+| `koduck-user/src/main/java/com/koduck/service/UserService.java` | 增加 `findById` internal 方法 |
+| `koduck-user/src/main/java/com/koduck/service/impl/UserServiceImpl.java` | 以租户作用域实现 `findById` 并回填 `tenantId` |
+
+### validate 链路边界
+
+本任务中的“token 校验时解析 `tenant_id`”指：
+
+1. JWT validator / claims 结构能够成功反序列化 `tenant_id`
+2. refresh 链路与 logout 逻辑可以从 token payload 中恢复租户上下文
+
+不包括：
+
+1. gRPC `ValidateTokenResponse` 对外新增 `tenant_id`
+2. OIDC introspection 响应对外新增 `tenant_id`
+
+这两项留到 Task 4.2。
+
+---
+
+## 权衡与影响
+
+### 正向影响
+
+- access token 与 refresh token 具备显式租户语义。
+- refresh token 查询、吊销、重签发都能在 tenant scope 内完成。
+- `koduck-auth` 不再依赖本地遗留用户表为 refresh 兜真值。
+
+### 负向影响
+
+- `koduck-auth` 对 `koduck-user` internal API 的依赖更强。
+- `koduck-user` internal API 新增了一个按 `userId` 查询的端点。
+
+### 缓解措施
+
+- 新端点仍复用现有 `X-Consumer-Username` 与 `X-Tenant-Id` 约束，不引入额外认证模型。
+- 对外 gRPC / introspection 契约不在本任务内扩张，降低变更面。
+
+---
+
+## 兼容性影响
+
+1. **JWT 兼容性**: 新签发 token 会比旧 token 多一个 `tenant_id` claim；旧 refresh token 仍可通过 payload 解析失败路径返回未授权。
+2. **internal API 兼容性**: `UserDetailsResponse` 增加 `tenantId` 属于向后兼容扩展；新增 `GET /internal/users/{userId}` 不影响旧调用方。
+3. **运行时兼容性**: 仍保留 `default` tenant 兼容路径，供未显式带租户的链路继续工作。
+
+---
+
+## 相关文档
+
+- [koduck-auth-user-tenant-semantics.md](../../../docs/design/koduck-auth-user-tenant-semantics.md)
+- [koduck-auth-user-tenant-semantics-tasks.md](../../../docs/implementation/koduck-auth-user-tenant-semantics-tasks.md)
+- [ADR-0022](./0022-inventory-tenant-id-contract-impacts.md)
+- [ADR-0023](./0023-add-tenant-id-to-security-domain-tables.md)
+
+---
+
+## 变更日志
+
+| 日期 | 变更 | 作者 |
+|------|------|------|
+| 2026-04-11 | 初始版本 | @hailingu |

--- a/koduck-auth/src/grpc/token_service.rs
+++ b/koduck-auth/src/grpc/token_service.rs
@@ -14,6 +14,8 @@ use prost_types::Timestamp;
 use tonic::{Request, Response, Status};
 use tracing::info;
 
+const DEFAULT_TENANT_ID: &str = "default";
+
 /// gRPC TokenService implementation
 #[derive(Clone)]
 pub struct GrpcTokenService {
@@ -135,6 +137,7 @@ impl TokenService for GrpcTokenService {
             .jwt_service
             .generate_access_token(
                 req.user_id,
+                DEFAULT_TENANT_ID,
                 &req.username,
                 &req.email,
                 &req.roles,
@@ -144,7 +147,7 @@ impl TokenService for GrpcTokenService {
         // Generate refresh token using jwt_service
         let refresh_token = self
             .jwt_service
-            .generate_refresh_token(req.user_id)
+            .generate_refresh_token(req.user_id, DEFAULT_TENANT_ID)
             .map_err(Self::to_status)?;
 
         let response = GenerateTokenPairResponse {

--- a/koduck-auth/src/jwt/generator.rs
+++ b/koduck-auth/src/jwt/generator.rs
@@ -47,6 +47,7 @@ impl JwtService {
     pub fn generate_access_token(
         &self,
         user_id: i64,
+        tenant_id: &str,
         username: &str,
         email: &str,
         roles: &[String],
@@ -56,6 +57,7 @@ impl JwtService {
 
         let claims = Claims {
             sub: user_id.to_string(),
+            tenant_id: tenant_id.to_string(),
             username: username.to_string(),
             email: email.to_string(),
             roles: roles.to_vec(),
@@ -75,12 +77,13 @@ impl JwtService {
     }
 
     /// Generate refresh token
-    pub fn generate_refresh_token(&self, user_id: i64) -> Result<String> {
+    pub fn generate_refresh_token(&self, user_id: i64, tenant_id: &str) -> Result<String> {
         let now = Utc::now();
         let expiration = now + Duration::seconds(self.refresh_expiration);
 
         let claims = Claims {
             sub: user_id.to_string(),
+            tenant_id: tenant_id.to_string(),
             username: String::new(),
             email: String::new(),
             roles: vec![],

--- a/koduck-auth/src/model/token.rs
+++ b/koduck-auth/src/model/token.rs
@@ -15,6 +15,7 @@ pub enum TokenType {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Claims {
     pub sub: String,        // user_id
+    pub tenant_id: String,
     pub username: String,
     pub email: String,
     pub roles: Vec<String>,

--- a/koduck-auth/src/service/auth_service.rs
+++ b/koduck-auth/src/service/auth_service.rs
@@ -22,6 +22,8 @@ use std::sync::Arc;
 use std::time::Duration;
 use tracing::{error, info};
 
+const DEFAULT_TENANT_ID: &str = "default";
+
 /// Authentication service
 #[derive(Clone)]
 pub struct AuthService {
@@ -38,6 +40,8 @@ pub struct AuthService {
 #[derive(Debug, Deserialize)]
 struct InternalUserDetails {
     id: i64,
+    #[serde(rename = "tenantId")]
+    tenant_id: String,
     username: String,
     email: String,
     #[serde(rename = "passwordHash")]
@@ -101,7 +105,7 @@ impl AuthService {
 
         // Fetch user from koduck-user internal API instead of local auth DB.
         let user = self
-            .fetch_user_from_user_service(&req.username)
+            .fetch_user_from_user_service(DEFAULT_TENANT_ID, &req.username)
             .await?
             .ok_or_else(|| AppError::Unauthorized("Invalid username or password".to_string()))?;
 
@@ -141,17 +145,24 @@ impl AuthService {
         self.redis.reset_login_attempts(&ip).await?;
 
         // Get user roles
-        let roles = self.fetch_user_roles_from_user_service(user.id).await?;
+        let roles = self
+            .fetch_user_roles_from_user_service(&user.tenant_id, user.id)
+            .await?;
 
         // Update last login in koduck-user
-        self.update_last_login_in_user_service(user.id, &ip).await?;
+        self.update_last_login_in_user_service(&user.tenant_id, user.id, &ip)
+            .await?;
+
+        let tokens = self
+            .generate_token_pair(user.id, &user.tenant_id, &user.username, &user.email, &roles)
+            .await?;
 
         let auth_user = User {
             id: user.id,
-            username: user.username,
-            email: user.email,
-            password_hash: user.password_hash,
-            nickname: user.nickname,
+            username: user.username.clone(),
+            email: user.email.clone(),
+            password_hash: user.password_hash.clone(),
+            nickname: user.nickname.clone(),
             avatar_url: None,
             status: Self::parse_user_status(&user.status),
             email_verified: false,
@@ -159,9 +170,6 @@ impl AuthService {
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         };
-
-        // Generate tokens
-        let tokens = self.generate_token_pair(&auth_user, &roles).await?;
 
         Ok(TokenResponse::new(tokens, UserInfo::from(auth_user)))
     }
@@ -174,6 +182,7 @@ impl AuthService {
 
         let created = self
             .create_user_in_user_service(
+                DEFAULT_TENANT_ID,
                 req.username,
                 req.email,
                 password_hash,
@@ -182,14 +191,26 @@ impl AuthService {
             .await?;
         info!("User registered successfully via user-service: {}", created.id);
 
-        let roles = self.fetch_user_roles_from_user_service(created.id).await?;
+        let roles = self
+            .fetch_user_roles_from_user_service(&created.tenant_id, created.id)
+            .await?;
+
+        let tokens = self
+            .generate_token_pair(
+                created.id,
+                &created.tenant_id,
+                &created.username,
+                &created.email,
+                &roles,
+            )
+            .await?;
 
         let user = User {
             id: created.id,
-            username: created.username,
-            email: created.email,
-            password_hash: created.password_hash,
-            nickname: created.nickname,
+            username: created.username.clone(),
+            email: created.email.clone(),
+            password_hash: created.password_hash.clone(),
+            nickname: created.nickname.clone(),
             avatar_url: None,
             status: Self::parse_user_status(&created.status),
             email_verified: false,
@@ -197,8 +218,6 @@ impl AuthService {
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         };
-
-        let tokens = self.generate_token_pair(&user, &roles).await?;
 
         Ok(TokenResponse::new(
             tokens,
@@ -209,11 +228,17 @@ impl AuthService {
     /// Refresh access token
     pub async fn refresh_token(&self, req: RefreshTokenRequest) -> Result<TokenResponse> {
         let refresh_token_hash = Self::hash_token(&req.refresh_token);
+        let claims = Self::try_extract_claims_without_verification(&req.refresh_token)
+            .ok_or_else(|| AppError::Unauthorized("Invalid refresh token".to_string()))?;
+
+        if !matches!(claims.token_type, TokenType::Refresh) {
+            return Err(AppError::Unauthorized("Invalid refresh token".to_string()));
+        }
 
         // Find refresh token
         let token_record = self
             .token_repo
-            .find_by_token(&refresh_token_hash)
+            .find_by_token_in_tenant(&claims.tenant_id, &refresh_token_hash)
             .await?
             .ok_or_else(|| AppError::Unauthorized("Invalid refresh token".to_string()))?;
 
@@ -229,24 +254,39 @@ impl AuthService {
 
         // Get user
         let user = self
-            .user_repo
-            .find_by_id(token_record.user_id)
+            .fetch_user_by_id_from_user_service(&token_record.tenant_id, token_record.user_id)
             .await?
             .ok_or_else(|| AppError::NotFound("User not found".to_string()))?;
 
         // Revoke old token
-        self.token_repo.revoke(&refresh_token_hash).await?;
+        self.token_repo
+            .revoke_in_tenant(&token_record.tenant_id, &refresh_token_hash)
+            .await?;
 
         // Get roles
-        let roles = self.user_repo.get_user_roles(user.id).await?;
+        let roles = self
+            .fetch_user_roles_from_user_service(&token_record.tenant_id, user.id)
+            .await?;
 
-        // Generate new tokens
-        let tokens = self.generate_token_pair(&user, &roles).await?;
+        let tokens = self
+            .generate_token_pair(user.id, &user.tenant_id, &user.username, &user.email, &roles)
+            .await?;
 
-        Ok(TokenResponse::new(
-            tokens,
-            UserInfo::from(user),
-        ))
+        let response_user = User {
+            id: user.id,
+            username: user.username.clone(),
+            email: user.email.clone(),
+            password_hash: user.password_hash.clone(),
+            nickname: user.nickname.clone(),
+            avatar_url: None,
+            status: Self::parse_user_status(&user.status),
+            email_verified: false,
+            last_login_at: None,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        };
+
+        Ok(TokenResponse::new(tokens, UserInfo::from(response_user)))
     }
 
     /// Logout user
@@ -254,16 +294,22 @@ impl AuthService {
         // Revoke refresh token if provided
         if let Some(token) = refresh_token {
             let token_hash = Self::hash_token(&token);
-            self.token_repo.revoke(&token_hash).await?;
-
-            // Best-effort JWT claim parsing to support access-token blacklist on logout.
             if let Some(claims) = Self::try_extract_claims_without_verification(&token) {
-                if matches!(claims.token_type, TokenType::Access) {
-                    self.redis
-                        .add_to_token_blacklist(&claims.jti, claims.exp)
-                        .await?;
-                    info!("Access token blacklisted on logout: jti={}", claims.jti);
+                match claims.token_type {
+                    TokenType::Access => {
+                        self.redis
+                            .add_to_token_blacklist(&claims.jti, claims.exp)
+                            .await?;
+                        info!("Access token blacklisted on logout: jti={}", claims.jti);
+                    }
+                    TokenType::Refresh => {
+                        self.token_repo
+                            .revoke_in_tenant(&claims.tenant_id, &token_hash)
+                            .await?;
+                    }
                 }
+            } else {
+                self.token_repo.revoke(&token_hash).await?;
             }
         };
 
@@ -295,17 +341,25 @@ impl AuthService {
 
     /// Generate token pair for user
     /// Uses JWT service to generate real tokens
-    async fn generate_token_pair(&self, user: &User, roles: &[String]) -> Result<TokenPair> {
+    async fn generate_token_pair(
+        &self,
+        user_id: i64,
+        tenant_id: &str,
+        username: &str,
+        email: &str,
+        roles: &[String],
+    ) -> Result<TokenPair> {
         // Generate JWT access token
         let access_token = self.jwt_service.generate_access_token(
-            user.id,
-            &user.username,
-            &user.email,
+            user_id,
+            tenant_id,
+            username,
+            email,
             roles,
         )?;
 
         // Generate JWT refresh token
-        let refresh_token = self.jwt_service.generate_refresh_token(user.id)?;
+        let refresh_token = self.jwt_service.generate_refresh_token(user_id, tenant_id)?;
 
         // Save refresh token hash to database
         let mut hasher = Sha256::new();
@@ -315,10 +369,10 @@ impl AuthService {
             + chrono::Duration::seconds(self.config.jwt.refresh_token_expiration_secs);
 
         self.token_repo
-            .save(user.id, &refresh_token_hash, expires_at)
+            .save_for_tenant(tenant_id, user_id, &refresh_token_hash, expires_at)
             .await?;
 
-        info!("Generated token pair for user: {}", user.id);
+        info!("Generated token pair for user: {} in tenant {}", user_id, tenant_id);
 
         Ok(TokenPair::new(
             access_token,
@@ -549,6 +603,7 @@ impl AuthService {
 
     async fn fetch_user_from_user_service(
         &self,
+        tenant_id: &str,
         username_or_email: &str,
     ) -> Result<Option<InternalUserDetails>> {
         let endpoint = if username_or_email.contains('@') {
@@ -568,7 +623,8 @@ impl AuthService {
         let client = reqwest::Client::new();
         let request = client
             .get(endpoint)
-            .header("X-Consumer-Username", "koduck-auth");
+            .header("X-Consumer-Username", "koduck-auth")
+            .header("X-Tenant-Id", tenant_id);
 
         let response = tokio::time::timeout(
             Duration::from_secs(self.config.client.user_service_timeout_secs),
@@ -596,7 +652,54 @@ impl AuthService {
         Ok(Some(user))
     }
 
-    async fn fetch_user_roles_from_user_service(&self, user_id: i64) -> Result<Vec<String>> {
+    async fn fetch_user_by_id_from_user_service(
+        &self,
+        tenant_id: &str,
+        user_id: i64,
+    ) -> Result<Option<InternalUserDetails>> {
+        let endpoint = format!(
+            "{}/internal/users/{}",
+            self.config.client.user_service_url.trim_end_matches('/'),
+            user_id
+        );
+
+        let client = reqwest::Client::new();
+        let request = client
+            .get(endpoint)
+            .header("X-Consumer-Username", "koduck-auth")
+            .header("X-Tenant-Id", tenant_id);
+
+        let response = tokio::time::timeout(
+            Duration::from_secs(self.config.client.user_service_timeout_secs),
+            request.send(),
+        )
+        .await
+        .map_err(|_| AppError::ServiceUnavailable("User service request timed out".to_string()))?
+        .map_err(|e| AppError::ServiceUnavailable(format!("User service request failed: {}", e)))?;
+
+        if response.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+
+        if !response.status().is_success() {
+            return Err(AppError::ServiceUnavailable(format!(
+                "User service returned status {}",
+                response.status()
+            )));
+        }
+
+        let user = response
+            .json::<InternalUserDetails>()
+            .await
+            .map_err(|e| AppError::Internal(format!("Failed to decode user response: {}", e)))?;
+        Ok(Some(user))
+    }
+
+    async fn fetch_user_roles_from_user_service(
+        &self,
+        tenant_id: &str,
+        user_id: i64,
+    ) -> Result<Vec<String>> {
         let endpoint = format!(
             "{}/internal/users/{}/roles",
             self.config.client.user_service_url.trim_end_matches('/'),
@@ -606,7 +709,8 @@ impl AuthService {
         let client = reqwest::Client::new();
         let request = client
             .get(endpoint)
-            .header("X-Consumer-Username", "koduck-auth");
+            .header("X-Consumer-Username", "koduck-auth")
+            .header("X-Tenant-Id", tenant_id);
 
         let response = tokio::time::timeout(
             Duration::from_secs(self.config.client.user_service_timeout_secs),
@@ -631,6 +735,7 @@ impl AuthService {
 
     async fn create_user_in_user_service(
         &self,
+        tenant_id: &str,
         username: String,
         email: String,
         password_hash: String,
@@ -653,6 +758,7 @@ impl AuthService {
         let request = client
             .post(endpoint)
             .header("X-Consumer-Username", "koduck-auth")
+            .header("X-Tenant-Id", tenant_id)
             .json(&payload);
 
         let response = tokio::time::timeout(
@@ -687,7 +793,12 @@ impl AuthService {
         }
     }
 
-    async fn update_last_login_in_user_service(&self, user_id: i64, ip: &str) -> Result<()> {
+    async fn update_last_login_in_user_service(
+        &self,
+        tenant_id: &str,
+        user_id: i64,
+        ip: &str,
+    ) -> Result<()> {
         let endpoint = format!(
             "{}/internal/users/{}/last-login",
             self.config.client.user_service_url.trim_end_matches('/'),
@@ -702,6 +813,7 @@ impl AuthService {
         let request = client
             .put(endpoint)
             .header("X-Consumer-Username", "koduck-auth")
+            .header("X-Tenant-Id", tenant_id)
             .json(&payload);
 
         let response = tokio::time::timeout(

--- a/koduck-auth/src/service/token_service.rs
+++ b/koduck-auth/src/service/token_service.rs
@@ -140,6 +140,7 @@ mod tests {
 
         let claims = Claims {
             sub: "123".to_string(),
+            tenant_id: "tenant-a".to_string(),
             username: "testuser".to_string(),
             email: "test@example.com".to_string(),
             roles: vec!["user".to_string(), "admin".to_string()],

--- a/koduck-user/src/main/java/com/koduck/controller/user/InternalUserController.java
+++ b/koduck-user/src/main/java/com/koduck/controller/user/InternalUserController.java
@@ -35,6 +35,19 @@ public class InternalUserController {
         this.userService = userService;
     }
 
+    @GetMapping("/users/{userId}")
+    public ResponseEntity<UserDetailsResponse> findById(
+            @PathVariable Long userId,
+            @RequestHeader(value = "X-Consumer-Username", required = false) String consumer,
+            @RequestHeader(value = "X-Tenant-Id", required = false) String tenantId) {
+        String consumerName = requireConsumer(consumer);
+        String resolvedTenantId = resolveTenantId(tenantId);
+        logAudit(consumerName, resolvedTenantId, "findById", String.valueOf(userId));
+        return userService.findById(resolvedTenantId, userId)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
     @GetMapping("/users/by-username/{username}")
     public ResponseEntity<UserDetailsResponse> findByUsername(
             @PathVariable String username,

--- a/koduck-user/src/main/java/com/koduck/dto/user/user/UserDetailsResponse.java
+++ b/koduck-user/src/main/java/com/koduck/dto/user/user/UserDetailsResponse.java
@@ -21,6 +21,7 @@ import java.time.LocalDateTime;
 public class UserDetailsResponse {
 
     private Long id;
+    private String tenantId;
     private String username;
     private String email;
     private String passwordHash;

--- a/koduck-user/src/main/java/com/koduck/service/UserService.java
+++ b/koduck-user/src/main/java/com/koduck/service/UserService.java
@@ -47,6 +47,8 @@ public interface UserService {
 
     // === 内部 API ===
 
+    Optional<UserDetailsResponse> findById(String tenantId, Long userId);
+
     Optional<UserDetailsResponse> findByUsername(String tenantId, String username);
 
     Optional<UserDetailsResponse> findByEmail(String tenantId, String email);

--- a/koduck-user/src/main/java/com/koduck/service/impl/UserServiceImpl.java
+++ b/koduck-user/src/main/java/com/koduck/service/impl/UserServiceImpl.java
@@ -216,6 +216,13 @@ public class UserServiceImpl implements UserService {
 
     @Override
     @Transactional(readOnly = true)
+    public Optional<UserDetailsResponse> findById(String tenantId, Long userId) {
+        return userRepository.findByIdAndTenantId(userId, resolveTenantId(tenantId))
+                .map(this::buildUserDetailsResponse);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
     public Optional<UserDetailsResponse> findByUsername(String tenantId, String username) {
         return userRepository.findByTenantIdAndUsername(resolveTenantId(tenantId), username)
                 .map(this::buildUserDetailsResponse);
@@ -342,6 +349,7 @@ public class UserServiceImpl implements UserService {
     private UserDetailsResponse buildUserDetailsResponse(User user) {
         return UserDetailsResponse.builder()
                 .id(user.getId())
+                .tenantId(user.getTenantId())
                 .username(user.getUsername())
                 .email(user.getEmail())
                 .passwordHash(user.getPasswordHash())

--- a/koduck-user/src/test/java/com/koduck/controller/user/InternalUserControllerTest.java
+++ b/koduck-user/src/test/java/com/koduck/controller/user/InternalUserControllerTest.java
@@ -58,6 +58,7 @@ class InternalUserControllerTest {
     void shouldFindUserByUsername() throws Exception {
         userService.userByUsername = Optional.of(UserDetailsResponse.builder()
                 .id(1001L)
+                .tenantId(TENANT_ID)
                 .username("alice")
                 .email("alice@koduck.com")
                 .passwordHash("hash")
@@ -69,7 +70,28 @@ class InternalUserControllerTest {
                         .header("X-Tenant-Id", TENANT_ID))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").value(1001))
+                .andExpect(jsonPath("$.tenantId").value(TENANT_ID))
                 .andExpect(jsonPath("$.username").value("alice"));
+        org.junit.jupiter.api.Assertions.assertEquals(TENANT_ID, userService.lastTenantId);
+    }
+
+    @Test
+    void shouldFindUserById() throws Exception {
+        userService.userById = Optional.of(UserDetailsResponse.builder()
+                .id(1001L)
+                .tenantId(TENANT_ID)
+                .username("alice")
+                .email("alice@koduck.com")
+                .passwordHash("hash")
+                .status("ACTIVE")
+                .build());
+
+        mockMvc.perform(get("/internal/users/1001")
+                        .header("X-Consumer-Username", "koduck-auth")
+                        .header("X-Tenant-Id", TENANT_ID))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1001))
+                .andExpect(jsonPath("$.tenantId").value(TENANT_ID));
         org.junit.jupiter.api.Assertions.assertEquals(TENANT_ID, userService.lastTenantId);
     }
 
@@ -87,6 +109,7 @@ class InternalUserControllerTest {
     void shouldFallbackToDefaultTenantWhenTenantHeaderMissing() throws Exception {
         userService.userByUsername = Optional.of(UserDetailsResponse.builder()
                 .id(1001L)
+                .tenantId(DEFAULT_TENANT_ID)
                 .username("alice")
                 .email("alice@koduck.com")
                 .passwordHash("hash")
@@ -112,6 +135,7 @@ class InternalUserControllerTest {
     void shouldFindUserByEmail() throws Exception {
         userService.userByEmail = Optional.of(UserDetailsResponse.builder()
                 .id(1002L)
+                .tenantId(TENANT_ID)
                 .username("bob")
                 .email("bob@koduck.com")
                 .passwordHash("hash")
@@ -147,6 +171,7 @@ class InternalUserControllerTest {
                 .build();
         userService.createdUser = UserDetailsResponse.builder()
                 .id(1003L)
+                .tenantId(TENANT_ID)
                 .username("carol")
                 .email("carol@koduck.com")
                 .passwordHash("hash")
@@ -306,6 +331,7 @@ class InternalUserControllerTest {
 
     static class StubUserService implements UserService {
 
+        private Optional<UserDetailsResponse> userById = Optional.empty();
         private Optional<UserDetailsResponse> userByUsername = Optional.empty();
         private Optional<UserDetailsResponse> userByEmail = Optional.empty();
         private String lastTenantId;
@@ -364,6 +390,12 @@ class InternalUserControllerTest {
         @Override
         public List<RoleInfo> getUserRolesInfo(String tenantId, Long userId) {
             throw new UnsupportedOperationException("Not used in this test");
+        }
+
+        @Override
+        public Optional<UserDetailsResponse> findById(String tenantId, Long userId) {
+            this.lastTenantId = tenantId;
+            return userById;
         }
 
         @Override

--- a/koduck-user/src/test/java/com/koduck/controller/user/UserControllerAuthBoundaryTest.java
+++ b/koduck-user/src/test/java/com/koduck/controller/user/UserControllerAuthBoundaryTest.java
@@ -122,6 +122,11 @@ class UserControllerAuthBoundaryTest {
         }
 
         @Override
+        public Optional<UserDetailsResponse> findById(String tenantId, Long userId) {
+            throw new UnsupportedOperationException("Not used in this test");
+        }
+
+        @Override
         public Optional<UserDetailsResponse> findByUsername(String tenantId, String username) {
             throw new UnsupportedOperationException("Not used in this test");
         }


### PR DESCRIPTION
Closes #776

## Summary

- add `tenant_id` to JWT claims and write it into both access and refresh tokens
- make refresh and logout tenant-aware by scoping refresh token lookup and revoke operations
- add `koduck-user` internal user lookup by `userId` and return `tenantId` for tenant-safe refresh

## Verification

- `mvn -f koduck-user/pom.xml -Dtest=InternalUserControllerTest,UserControllerAuthBoundaryTest test`
- `docker build -t koduck-user:dev ./koduck-user`
- `docker build -t koduck-auth:dev ./koduck-auth`
- `kubectl rollout restart deployment/dev-koduck-user -n koduck-dev`
- `kubectl rollout status deployment/dev-koduck-user -n koduck-dev --timeout=180s`
- `kubectl rollout restart deployment/dev-koduck-auth -n koduck-dev`
- `kubectl rollout status deployment/dev-koduck-auth -n koduck-dev --timeout=180s`
