### PR TITLE
feat(auth): expose tenant in grpc and introspection

### DIFF
--- a/docs/implementation/koduck-auth-user-tenant-semantics-tasks.md
+++ b/docs/implementation/koduck-auth-user-tenant-semantics-tasks.md
@@ -179,8 +179,8 @@
 3. 更新 introspection 结果
 
 **验收标准:**
-- [ ] 对内契约可返回 `tenant_id`
-- [ ] 下游服务可消费 `tenant_id`
+- [x] 对内契约可返回 `tenant_id`
+- [x] 下游服务可消费 `tenant_id`
 
 ### Task 4.3: 登录与 refresh 流程租户化
 **详细要求:**

--- a/koduck-auth/docs/adr/0025-expose-tenant-in-grpc-and-introspection.md
+++ b/koduck-auth/docs/adr/0025-expose-tenant-in-grpc-and-introspection.md
@@ -1,0 +1,144 @@
+# ADR-0025: Task 4.2 在 gRPC 与 introspection 契约中显式回传 tenant_id
+
+## 元数据
+
+- **状态**: 已接受
+- **日期**: 2026-04-11
+- **作者**: @hailingu
+- **相关**: #778, docs/implementation/koduck-auth-user-tenant-semantics-tasks.md Task 4.2, ADR-0022, ADR-0024
+
+---
+
+## 背景与问题陈述
+
+Task 4.1 已经让 `koduck-auth` 在 JWT claims 与 refresh 主链路内部保留 `tenant_id`，但对下游暴露的契约仍存在缺口：
+
+1. gRPC `ValidateTokenResponse` 没有 `tenant_id`
+2. gRPC `GetUserResponse.UserInfo` 没有 `tenant_id`
+3. introspection 结果 `TokenIntrospectionResult` / `IntrospectTokenResponse` 没有 `tenant_id`
+4. OIDC discovery `claims_supported` 没有声明 `tenant_id`
+
+这会导致下游虽然可以拿到 token 或 `user_id`，却仍然需要自行二次解析 JWT 才能恢复完整身份主键 `(tenant_id, user_id)`。
+
+---
+
+## 决策驱动因素
+
+1. **契约完整性**: 下游服务应通过稳定响应契约直接拿到 `tenant_id`。
+2. **避免重复解析**: 设计文档已经明确，下游不应把“再解析 JWT 原文”作为主路径。
+3. **真值一致性**: 对外返回的 `tenant_id` 必须来自 claims 或 `koduck-user` 真值，而不是 auth 本地遗留表的推断结果。
+4. **兼容演进**: 尽量用向后兼容的字段扩展完成契约升级，降低对既有调用方的破坏。
+
+---
+
+## 考虑的选项
+
+### 选项 1：只更新 introspection，不改 gRPC
+
+**优点**:
+- 改动更小
+
+**缺点**:
+- gRPC 下游仍然拿不到完整身份主键
+- 与 Task 1.2 的契约清单不一致
+
+### 选项 2：只在响应中增加 `tenant_id`，请求继续保持原样（选定）
+
+**优点**:
+- 满足 Task 4.2 的核心目标
+- 大多数变化是向后兼容的新增字段
+- 下游读取路径最短
+
+**缺点**:
+- `GetUserRequest` 若按用户名或邮箱查询，若不显式带 tenant scope，仍只能走 default 兼容路径
+
+### 选项 3：一次性把所有 gRPC request/response 都改成强制 tenant-aware
+
+**优点**:
+- 理论上更彻底
+
+**缺点**:
+- 与 Task 4.3、Task 5.x 的边界混叠
+- 一次性扩大变更面
+
+---
+
+## 决策结果
+
+采用 **选项 2**：
+
+1. `TokenIntrospectionResult` 增加 `tenant_id`
+2. gRPC `ValidateTokenResponse` 增加 `tenant_id`
+3. gRPC `UserInfo` 增加 `tenant_id`，从而让 `GetUserResponse` 能返回租户信息
+4. gRPC `IntrospectTokenResponse` 增加 `tenant_id`
+5. OIDC discovery `claims_supported` 增加 `tenant_id`
+6. `GetUserRequest` 增加可选 `tenant_id` 字段，用于用户名/邮箱查询时显式限定 tenant scope；缺失时保持 `default` 兼容
+7. `GetUser` 的读取路径切到 `koduck-user` internal API，避免依赖 `koduck-auth` 本地遗留表去拼装租户信息
+
+---
+
+## 实施细节
+
+### 变更文件
+
+| 文件 | 变更说明 |
+|------|------|
+| `koduck-auth/proto/koduck/auth/v1/auth.proto` | 为 `ValidateTokenResponse`、`IntrospectTokenResponse`、`UserInfo` 增加 `tenant_id`，并为 `GetUserRequest` 增加可选 `tenant_id` |
+| `koduck-auth/src/model/token.rs` | 为 `TokenIntrospectionResult` 增加 `tenant_id` |
+| `koduck-auth/src/model/user.rs` | 为内部 `UserInfo` 模型增加 `tenant_id` |
+| `koduck-auth/src/grpc/auth_service.rs` | gRPC `ValidateToken` / `GetUser` 回传 `tenant_id`，并将 `GetUser` 读取路径切到 tenant-aware internal API |
+| `koduck-auth/src/grpc/token_service.rs` | introspection 响应回传 `tenant_id` |
+| `koduck-auth/src/grpc/converter.rs` | proto 与内部模型互转时保留 `tenant_id` |
+| `koduck-auth/src/http/handler/oidc.rs` | OIDC discovery 声明 `tenant_id` claim 已支持 |
+
+### 下游消费约定
+
+1. 优先使用 `ValidateTokenResponse.tenant_id`
+2. 获取用户详情时优先使用 `GetUserResponse.user.tenant_id`
+3. 若走 RFC 7662 introspection，则读取 `tenant_id`
+4. 不再要求下游把解析原始 JWT 当作主路径
+
+---
+
+## 权衡与影响
+
+### 正向影响
+
+- gRPC 与 introspection 现在都能直接返回完整身份主键的一半 `tenant_id`。
+- 下游服务不再依赖 JWT 二次解析。
+- `GetUser` 响应的租户值来自 `koduck-user` 真值，不依赖 auth 本地遗留表。
+
+### 负向影响
+
+- proto 契约发生了字段扩展，需要下游重新生成 stub 才能直接使用新字段。
+- `GetUser` 增加了对 `koduck-user` internal API 的依赖。
+
+### 缓解措施
+
+- 所有新增字段都采用追加字段号的方式，保持 protobuf 向后兼容。
+- `GetUserRequest.tenant_id` 仍保留 `default` 兼容路径，降低旧调用方破坏性。
+
+---
+
+## 兼容性影响
+
+1. **protobuf 兼容性**: 追加字段属于向后兼容扩展；旧客户端仍可继续反序列化旧字段集合。
+2. **HTTP introspection 兼容性**: JSON 响应新增 `tenant_id` 字段，不影响旧消费者。
+3. **运行时兼容性**: `GetUserRequest.tenant_id` 缺失时继续回落到 `default` tenant。
+
+---
+
+## 相关文档
+
+- [koduck-auth-user-tenant-semantics.md](../../../docs/design/koduck-auth-user-tenant-semantics.md)
+- [koduck-auth-user-tenant-semantics-tasks.md](../../../docs/implementation/koduck-auth-user-tenant-semantics-tasks.md)
+- [ADR-0022](./0022-inventory-tenant-id-contract-impacts.md)
+- [ADR-0024](./0024-thread-tenant-through-jwt-refresh-chain.md)
+
+---
+
+## 变更日志
+
+| 日期 | 变更 | 作者 |
+|------|------|------|
+| 2026-04-11 | 初始版本 | @hailingu |

--- a/koduck-auth/proto/koduck/auth/v1/auth.proto
+++ b/koduck-auth/proto/koduck/auth/v1/auth.proto
@@ -79,6 +79,7 @@ message ValidateTokenResponse {
   string token_id = 6;
   google.protobuf.Timestamp issued_at = 7;
   TokenType token_type = 8;
+  string tenant_id = 9;
 }
 
 message GetUserRequest {
@@ -87,6 +88,7 @@ message GetUserRequest {
     string username = 2;
     string email = 3;
   }
+  string tenant_id = 4;
 }
 
 message GetUserResponse {
@@ -177,6 +179,7 @@ message IntrospectTokenResponse {
   repeated string aud = 10;
   string iss = 11;
   string jti = 12;
+  string tenant_id = 13;
 }
 
 message RefreshTokenRequest {
@@ -210,6 +213,7 @@ message UserInfo {
   bool email_verified = 7;
   google.protobuf.Timestamp created_at = 8;
   google.protobuf.Timestamp updated_at = 9;
+  string tenant_id = 10;
 }
 
 message TokenPair {

--- a/koduck-auth/src/grpc/auth_service.rs
+++ b/koduck-auth/src/grpc/auth_service.rs
@@ -16,6 +16,8 @@ use prost_types::Timestamp;
 use tonic::{Request, Response, Status};
 use tracing::{info, warn};
 
+const DEFAULT_TENANT_ID: &str = "default";
+
 /// gRPC AuthService implementation
 #[derive(Clone)]
 pub struct GrpcAuthService {
@@ -68,6 +70,7 @@ impl GrpcAuthService {
     fn to_proto_user_info(user: UserInfo) -> proto::UserInfo {
         proto::UserInfo {
             id: user.id,
+            tenant_id: user.tenant_id,
             username: user.username,
             email: user.email,
             nickname: user.nickname.unwrap_or_default(),
@@ -155,6 +158,7 @@ impl AuthService for GrpcAuthService {
 
                 let response = ValidateTokenResponse {
                     user_id,
+                    tenant_id: result.tenant_id.unwrap_or_default(),
                     username: result.username.unwrap_or_default(),
                     email: result.email.unwrap_or_default(),
                     roles: result.roles,
@@ -175,17 +179,26 @@ impl AuthService for GrpcAuthService {
         request: Request<GetUserRequest>,
     ) -> std::result::Result<Response<GetUserResponse>, Status> {
         let req = request.into_inner();
+        let tenant_id = if req.tenant_id.is_empty() {
+            DEFAULT_TENANT_ID.to_string()
+        } else {
+            req.tenant_id.clone()
+        };
 
         // Find user based on identifier type
         let user_result = match req.identifier {
             Some(get_user_request::Identifier::UserId(id)) => {
-                self.user_repo.find_by_id(id).await
+                self.auth_service.get_user_by_id_for_tenant(&tenant_id, id).await
             }
             Some(get_user_request::Identifier::Username(username)) => {
-                self.user_repo.find_by_username(&username).await
+                self.auth_service
+                    .get_user_by_username_for_tenant(&tenant_id, &username)
+                    .await
             }
             Some(get_user_request::Identifier::Email(email)) => {
-                self.user_repo.find_by_email(&email).await
+                self.auth_service
+                    .get_user_by_email_for_tenant(&tenant_id, &email)
+                    .await
             }
             None => {
                 return Err(Status::invalid_argument("Identifier required"));
@@ -195,11 +208,14 @@ impl AuthService for GrpcAuthService {
         match user_result {
             Ok(Some(user)) => {
                 // Get user roles
-                let roles = self.user_repo.get_user_roles(user.id).await
+                let roles = self
+                    .auth_service
+                    .get_user_roles_for_tenant(&user.tenant_id, user.id)
+                    .await
                     .map_err(Self::to_status)?;
 
                 let response = GetUserResponse {
-                    user: Some(Self::to_proto_user_info(UserInfo::from(user))),
+                    user: Some(Self::to_proto_user_info(user)),
                     roles,
                 };
                 Ok(Response::new(response))

--- a/koduck-auth/src/grpc/converter.rs
+++ b/koduck-auth/src/grpc/converter.rs
@@ -59,6 +59,9 @@ impl From<UserInfo> for proto::UserInfo {
             avatar_url: user.avatar_url.unwrap_or_default(),
             status: proto::UserStatus::from(user.status) as i32,
             email_verified: user.email_verified,
+            created_at: None,
+            updated_at: None,
+            tenant_id: user.tenant_id,
         }
     }
 }
@@ -67,6 +70,7 @@ impl From<proto::UserInfo> for UserInfo {
     fn from(user: proto::UserInfo) -> Self {
         UserInfo {
             id: user.id,
+            tenant_id: user.tenant_id,
             username: user.username,
             email: user.email,
             nickname: if user.nickname.is_empty() {

--- a/koduck-auth/src/grpc/token_service.rs
+++ b/koduck-auth/src/grpc/token_service.rs
@@ -88,6 +88,7 @@ impl TokenService for GrpcTokenService {
                     aud: vec![], // Not in our Claims format
                     iss: String::new(), // Not in Claims
                     jti: result.jti.unwrap_or_default(),
+                    tenant_id: result.tenant_id.unwrap_or_default(),
                 };
                 Ok(Response::new(response))
             }

--- a/koduck-auth/src/http/handler/oidc.rs
+++ b/koduck-auth/src/http/handler/oidc.rs
@@ -1,7 +1,7 @@
 //! OIDC discovery and token introspection handlers.
 
 use axum::{
-    extract::{Request, State},
+    extract::State,
     http::HeaderMap,
     response::Json,
 };
@@ -51,7 +51,7 @@ pub async fn openid_configuration(
         "jwks_uri": format!("{}/.well-known/jwks.json", base),
         "introspection_endpoint": format!("{}/oauth/introspect", base),
         "scopes_supported": ["openid", "profile"],
-        "claims_supported": ["sub", "username", "email", "roles", "exp", "iat", "jti"]
+        "claims_supported": ["sub", "tenant_id", "username", "email", "roles", "exp", "iat", "jti"]
     });
     Ok(Json(config))
 }

--- a/koduck-auth/src/model/token.rs
+++ b/koduck-auth/src/model/token.rs
@@ -79,6 +79,8 @@ pub struct TokenIntrospectionResult {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sub: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub tenant_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub username: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub email: Option<String>,
@@ -100,6 +102,7 @@ impl TokenIntrospectionResult {
         Self {
             active: false,
             sub: None,
+            tenant_id: None,
             username: None,
             email: None,
             jti: None,
@@ -115,6 +118,7 @@ impl TokenIntrospectionResult {
         Self {
             active: true,
             sub: Some(claims.sub.clone()),
+            tenant_id: Some(claims.tenant_id.clone()),
             username: Some(claims.username.clone()),
             email: Some(claims.email.clone()),
             jti: Some(claims.jti.clone()),

--- a/koduck-auth/src/model/user.rs
+++ b/koduck-auth/src/model/user.rs
@@ -41,6 +41,7 @@ pub struct User {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UserInfo {
     pub id: i64,
+    pub tenant_id: String,
     pub username: String,
     pub email: String,
     pub nickname: Option<String>,
@@ -53,6 +54,7 @@ impl From<User> for UserInfo {
     fn from(user: User) -> Self {
         Self {
             id: user.id,
+            tenant_id: "default".to_string(),
             username: user.username,
             email: user.email,
             nickname: user.nickname,

--- a/koduck-auth/src/service/auth_service.rs
+++ b/koduck-auth/src/service/auth_service.rs
@@ -9,7 +9,7 @@ use crate::{
         Claims, TokenType,
         ForgotPasswordRequest, LoginRequest, RegisterRequest,
         RefreshTokenRequest, ResetPasswordRequest, SecurityConfigResponse,
-        TokenPair, TokenResponse, User, UserInfo,
+        TokenPair, TokenResponse, UserInfo,
     },
     repository::{PasswordResetRepository, RedisCache, RefreshTokenRepository, UserRepository},
 };
@@ -157,21 +157,9 @@ impl AuthService {
             .generate_token_pair(user.id, &user.tenant_id, &user.username, &user.email, &roles)
             .await?;
 
-        let auth_user = User {
-            id: user.id,
-            username: user.username.clone(),
-            email: user.email.clone(),
-            password_hash: user.password_hash.clone(),
-            nickname: user.nickname.clone(),
-            avatar_url: None,
-            status: Self::parse_user_status(&user.status),
-            email_verified: false,
-            last_login_at: None,
-            created_at: chrono::Utc::now(),
-            updated_at: chrono::Utc::now(),
-        };
+        let user_info = Self::build_user_info_from_internal(&user);
 
-        Ok(TokenResponse::new(tokens, UserInfo::from(auth_user)))
+        Ok(TokenResponse::new(tokens, user_info))
     }
 
     /// Register new user
@@ -205,24 +193,9 @@ impl AuthService {
             )
             .await?;
 
-        let user = User {
-            id: created.id,
-            username: created.username.clone(),
-            email: created.email.clone(),
-            password_hash: created.password_hash.clone(),
-            nickname: created.nickname.clone(),
-            avatar_url: None,
-            status: Self::parse_user_status(&created.status),
-            email_verified: false,
-            last_login_at: None,
-            created_at: chrono::Utc::now(),
-            updated_at: chrono::Utc::now(),
-        };
+        let user_info = Self::build_user_info_from_internal(&created);
 
-        Ok(TokenResponse::new(
-            tokens,
-            UserInfo::from(user),
-        ))
+        Ok(TokenResponse::new(tokens, user_info))
     }
 
     /// Refresh access token
@@ -272,21 +245,9 @@ impl AuthService {
             .generate_token_pair(user.id, &user.tenant_id, &user.username, &user.email, &roles)
             .await?;
 
-        let response_user = User {
-            id: user.id,
-            username: user.username.clone(),
-            email: user.email.clone(),
-            password_hash: user.password_hash.clone(),
-            nickname: user.nickname.clone(),
-            avatar_url: None,
-            status: Self::parse_user_status(&user.status),
-            email_verified: false,
-            last_login_at: None,
-            created_at: chrono::Utc::now(),
-            updated_at: chrono::Utc::now(),
-        };
+        let user_info = Self::build_user_info_from_internal(&user);
 
-        Ok(TokenResponse::new(tokens, UserInfo::from(response_user)))
+        Ok(TokenResponse::new(tokens, user_info))
     }
 
     /// Logout user
@@ -601,6 +562,37 @@ impl AuthService {
         format!("{:x}", hasher.finalize())
     }
 
+    pub async fn get_user_by_id_for_tenant(
+        &self,
+        tenant_id: &str,
+        user_id: i64,
+    ) -> Result<Option<UserInfo>> {
+        let user = self.fetch_user_by_id_from_user_service(tenant_id, user_id).await?;
+        Ok(user.map(|details| Self::build_user_info_from_internal(&details)))
+    }
+
+    pub async fn get_user_by_username_for_tenant(
+        &self,
+        tenant_id: &str,
+        username: &str,
+    ) -> Result<Option<UserInfo>> {
+        let user = self.fetch_user_from_user_service(tenant_id, username).await?;
+        Ok(user.map(|details| Self::build_user_info_from_internal(&details)))
+    }
+
+    pub async fn get_user_by_email_for_tenant(
+        &self,
+        tenant_id: &str,
+        email: &str,
+    ) -> Result<Option<UserInfo>> {
+        let user = self.fetch_user_from_user_service(tenant_id, email).await?;
+        Ok(user.map(|details| Self::build_user_info_from_internal(&details)))
+    }
+
+    pub async fn get_user_roles_for_tenant(&self, tenant_id: &str, user_id: i64) -> Result<Vec<String>> {
+        self.fetch_user_roles_from_user_service(tenant_id, user_id).await
+    }
+
     async fn fetch_user_from_user_service(
         &self,
         tenant_id: &str,
@@ -840,6 +832,19 @@ impl AuthService {
             "INACTIVE" => crate::model::UserStatus::Inactive,
             "DELETED" => crate::model::UserStatus::Deleted,
             _ => crate::model::UserStatus::Active,
+        }
+    }
+
+    fn build_user_info_from_internal(user: &InternalUserDetails) -> UserInfo {
+        UserInfo {
+            id: user.id,
+            tenant_id: user.tenant_id.clone(),
+            username: user.username.clone(),
+            email: user.email.clone(),
+            nickname: user.nickname.clone(),
+            avatar_url: None,
+            status: Self::parse_user_status(&user.status),
+            email_verified: false,
         }
     }
 

--- a/koduck-auth/src/service/token_service.rs
+++ b/koduck-auth/src/service/token_service.rs
@@ -126,6 +126,7 @@ mod tests {
         let result = TokenIntrospectionResult::inactive();
         assert!(!result.active);
         assert!(result.sub.is_none());
+        assert!(result.tenant_id.is_none());
         assert!(result.username.is_none());
         assert!(result.email.is_none());
         assert!(result.jti.is_none());
@@ -155,6 +156,7 @@ mod tests {
         let result = TokenIntrospectionResult::from_claims(&claims);
         assert!(result.active);
         assert_eq!(result.sub, Some("123".to_string()));
+        assert_eq!(result.tenant_id, Some("tenant-a".to_string()));
         assert_eq!(result.username, Some("testuser".to_string()));
         assert_eq!(result.email, Some("test@example.com".to_string()));
         assert_eq!(result.jti, Some("jti-123".to_string()));


### PR DESCRIPTION
## Summary
- expose tenant_id in gRPC validate/get-user/introspection contracts
- thread tenant truth from koduck-user through auth service and proto converters
- update ADR and mark Task 4.2 checklist complete

## Verification
- docker build -t koduck-auth:dev ./koduck-auth
- kubectl rollout restart deployment/dev-koduck-auth -n koduck-dev
- kubectl rollout status deployment/dev-koduck-auth -n koduck-dev --timeout=180s

Closes #778