### PR TITLE
feat(auth): enforce tenant consistency in login and refresh

### DIFF
--- a/docs/implementation/koduck-auth-user-tenant-semantics-tasks.md
+++ b/docs/implementation/koduck-auth-user-tenant-semantics-tasks.md
@@ -188,8 +188,8 @@
 2. refresh token 流程保持 tenant 一致
 
 **验收标准:**
-- [ ] 登录和 refresh 不会错租户
-- [ ] 审计日志带 `tenant_id`
+- [x] 登录和 refresh 不会错租户
+- [x] 审计日志带 `tenant_id`
 
 ---
 

--- a/koduck-auth/docs/adr/0026-enforce-tenant-consistency-in-login-and-refresh.md
+++ b/koduck-auth/docs/adr/0026-enforce-tenant-consistency-in-login-and-refresh.md
@@ -1,0 +1,47 @@
+# ADR-0026: 在登录与 Refresh 流程中强制租户一致性
+
+## 状态
+
+已接受
+
+## 背景
+
+Task 4.1 与 Task 4.2 已经把 `tenant_id` 带入 JWT claims、introspection、gRPC 契约以及 `koduck-auth -> koduck-user` 的内部查询链路，但登录入口本身仍然存在两个缺口：
+
+1. 登录请求没有显式提供租户上下文时，`koduck-auth` 仍可能沿用默认租户，无法满足多租户登录的确定性要求。
+2. `audit_logs` 表虽然已经有 `tenant_id` 列，但登录与 refresh 成功链路并没有把租户写入审计记录，排障时缺少租户维度。
+
+根据 `docs/design/koduck-auth-user-tenant-semantics.md`，V1 的约束是：
+
+- 登录输入如果仍允许 `username` / `email`，则必须同时确定 `tenant_id`
+- refresh token 续签必须保持租户一致
+- 审计日志必须带 `tenant_id`
+
+## 决策
+
+本次在 `koduck-auth` 中采用以下方案：
+
+1. 登录请求支持显式 `tenant_id`，同时兼容从 `X-Tenant-Id` 读取租户上下文。
+2. 当登录请求既没有 body `tenant_id`，也没有 `X-Tenant-Id` 时，直接返回校验错误，不再静默回退到 `default`。
+3. 登录成功后，`koduck-auth` 会校验“请求租户”和“用户真值租户”一致，再签发 token。
+4. refresh 流程继续以 refresh token 记录中的 `tenant_id` 为准，并在续签前显式校验“token 租户”和“用户真值租户”一致。
+5. 新增认证审计写入仓储，对 `LOGIN_SUCCESS` 和 `REFRESH_TOKEN_SUCCESS` 记录显式写入 `tenant_id`。
+
+## 权衡
+
+### 收益
+
+- 登录入口不再依赖默认租户，避免多租户下的串租户认证。
+- refresh 链路除了依赖 header / token 查询，还多了一层应用侧一致性校验。
+- 审计日志具备租户维度，后续可直接按 `tenant_id` 排查认证问题。
+
+### 代价
+
+- 客户端或网关在登录场景下必须提供租户上下文，旧的“只传用户名密码”调用将收到 400。
+- `koduck-auth` 多维护了一层审计仓储，认证主链路会多一次 best-effort 数据库写入。
+
+## 兼容性影响
+
+1. 登录 API 向后新增了可选字段 `tenant_id`，同时要求调用方通过 body 或 `X-Tenant-Id` 至少提供一种租户上下文。
+2. 旧客户端如果没有租户选择能力，需要在接入前补齐租户输入或通过网关注入 `X-Tenant-Id`。
+3. refresh API 的输入结构不变，但成功后的审计记录现在会携带 `tenant_id`。

--- a/koduck-auth/proto/koduck/auth/v1/auth.proto
+++ b/koduck-auth/proto/koduck/auth/v1/auth.proto
@@ -58,6 +58,7 @@ message ValidateCredentialsRequest {
   string password = 2;
   string ip_address = 3;
   string user_agent = 4;
+  string tenant_id = 5;
 }
 
 message ValidateCredentialsResponse {

--- a/koduck-auth/src/grpc/auth_service.rs
+++ b/koduck-auth/src/grpc/auth_service.rs
@@ -112,6 +112,7 @@ impl AuthService for GrpcAuthService {
         let login_req = crate::model::LoginRequest {
             username: req.username,
             password: req.password,
+            tenant_id: Some(req.tenant_id),
             turnstile_token: None,
         };
 

--- a/koduck-auth/src/http/handler/auth.rs
+++ b/koduck-auth/src/http/handler/auth.rs
@@ -16,7 +16,7 @@ use crate::{
         RefreshTokenRequest, RegisterRequest, ResetPasswordRequest,
         SecurityConfigResponse, TokenResponse,
     },
-    repository::{PasswordResetRepository, RedisCache, RefreshTokenRepository, UserRepository},
+    repository::{AuditLogRepository, PasswordResetRepository, RedisCache, RefreshTokenRepository, UserRepository},
     service::AuthService as AuthServiceImpl,
     state::AppState,
 };
@@ -25,6 +25,7 @@ fn build_auth_service(state: &AppState) -> Result<AuthServiceImpl> {
     let user_repo = UserRepository::new(state.db_pool().clone());
     let token_repo = RefreshTokenRepository::new(state.db_pool().clone());
     let password_reset_repo = PasswordResetRepository::new(state.db_pool().clone());
+    let audit_log_repo = AuditLogRepository::new(state.db_pool().clone());
     let redis = RedisCache::new(state.redis_pool().clone());
     let config = Arc::new(state.config().clone());
 
@@ -32,6 +33,7 @@ fn build_auth_service(state: &AppState) -> Result<AuthServiceImpl> {
         user_repo,
         token_repo,
         password_reset_repo,
+        audit_log_repo,
         redis,
         state.jwt_service().clone(),
         state.db_pool().clone(),
@@ -46,6 +48,18 @@ pub async fn login(
     headers: HeaderMap,
     Json(req): Json<LoginRequest>,
 ) -> Result<Json<ApiResponse<TokenResponse>>> {
+    let tenant_id = headers
+        .get("X-Tenant-Id")
+        .and_then(|h| h.to_str().ok())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string);
+
+    let mut req = req;
+    if req.tenant_id.is_none() {
+        req.tenant_id = tenant_id;
+    }
+
     req.validate()?;
 
     let ip = addr.ip().to_string();

--- a/koduck-auth/src/main.rs
+++ b/koduck-auth/src/main.rs
@@ -13,7 +13,7 @@ use koduck_auth::{
     http::{create_metrics_router, create_router},
     init_state,
     jwt::{JwksService, JwtValidator},
-    repository::{PasswordResetRepository, RedisCache, RefreshTokenRepository, UserRepository},
+    repository::{AuditLogRepository, PasswordResetRepository, RedisCache, RefreshTokenRepository, UserRepository},
     service::{AuthService as AuthServiceImpl, TokenService as TokenServiceImpl},
 };
 
@@ -43,6 +43,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let user_repo = UserRepository::new(state.db_pool().clone());
     let token_repo = RefreshTokenRepository::new(state.db_pool().clone());
     let password_reset_repo = PasswordResetRepository::new(state.db_pool().clone());
+    let audit_log_repo = AuditLogRepository::new(state.db_pool().clone());
     let redis = RedisCache::new(state.redis_pool().clone());
 
     // Load public key for JWT validation and JWKS
@@ -63,6 +64,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         user_repo.clone(),
         token_repo.clone(),
         password_reset_repo,
+        audit_log_repo,
         redis.clone(),
         state.jwt_service().clone(),
         state.db_pool().clone(),

--- a/koduck-auth/src/model/audit.rs
+++ b/koduck-auth/src/model/audit.rs
@@ -1,0 +1,19 @@
+//! Audit log model definitions
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Audit log record stored in auth security tables.
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
+pub struct AuditLog {
+    pub id: i64,
+    pub tenant_id: String,
+    pub user_id: Option<i64>,
+    pub action: String,
+    pub resource: String,
+    pub resource_id: Option<String>,
+    pub ip_address: Option<String>,
+    pub user_agent: Option<String>,
+    pub details: Option<serde_json::Value>,
+    pub created_at: DateTime<Utc>,
+}

--- a/koduck-auth/src/model/mod.rs
+++ b/koduck-auth/src/model/mod.rs
@@ -1,10 +1,12 @@
 //! Data models
 
+pub mod audit;
 pub mod request;
 pub mod response;
 pub mod token;
 pub mod user;
 
+pub use audit::*;
 pub use request::*;
 pub use response::*;
 pub use token::*;

--- a/koduck-auth/src/model/request.rs
+++ b/koduck-auth/src/model/request.rs
@@ -1,22 +1,25 @@
 //! HTTP request DTOs
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use validator::Validate;
 
 /// Login request
-#[derive(Debug, Deserialize, Validate)]
+#[derive(Debug, Deserialize, Serialize, Validate)]
 pub struct LoginRequest {
     #[validate(length(min = 3, max = 100, message = "Username must be 3-100 characters"))]
     pub username: String, // Can be username or email
     
     #[validate(length(min = 6, max = 100, message = "Password must be 6-100 characters"))]
     pub password: String,
-    
+
+    #[validate(length(min = 1, max = 128, message = "tenant_id must be 1-128 characters"))]
+    pub tenant_id: Option<String>,
+
     pub turnstile_token: Option<String>,
 }
 
 /// Register request
-#[derive(Debug, Deserialize, Validate)]
+#[derive(Debug, Deserialize, Serialize, Validate)]
 pub struct RegisterRequest {
     #[validate(length(min = 3, max = 50, message = "Username must be 3-50 characters"))]
     #[validate(regex(path = "crate::model::USERNAME_REGEX", message = "Username can only contain letters, numbers, and underscores"))]
@@ -39,27 +42,27 @@ pub struct RegisterRequest {
 }
 
 /// Refresh token request
-#[derive(Debug, Deserialize, Validate)]
+#[derive(Debug, Deserialize, Serialize, Validate)]
 pub struct RefreshTokenRequest {
     #[validate(length(min = 1, message = "Refresh token is required"))]
     pub refresh_token: String,
 }
 
 /// Logout request
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct LogoutRequest {
     pub refresh_token: Option<String>,
 }
 
 /// Forgot password request
-#[derive(Debug, Deserialize, Validate)]
+#[derive(Debug, Deserialize, Serialize, Validate)]
 pub struct ForgotPasswordRequest {
     #[validate(email(message = "Invalid email format"))]
     pub email: String,
 }
 
 /// Reset password request
-#[derive(Debug, Deserialize, Validate)]
+#[derive(Debug, Deserialize, Serialize, Validate)]
 pub struct ResetPasswordRequest {
     #[validate(length(min = 1, message = "Token is required"))]
     pub token: String,
@@ -78,7 +81,7 @@ pub static USERNAME_REGEX: once_cell::sync::Lazy<regex::Regex> =
     });
 
 /// Change password request
-#[derive(Debug, Deserialize, Validate)]
+#[derive(Debug, Deserialize, Serialize, Validate)]
 pub struct ChangePasswordRequest {
     pub old_password: String,
     
@@ -90,7 +93,7 @@ pub struct ChangePasswordRequest {
 }
 
 /// Update profile request
-#[derive(Debug, Deserialize, Validate)]
+#[derive(Debug, Deserialize, Serialize, Validate)]
 pub struct UpdateProfileRequest {
     #[validate(length(max = 50, message = "Nickname must not exceed 50 characters"))]
     pub nickname: Option<String>,

--- a/koduck-auth/src/repository/audit_log_repository.rs
+++ b/koduck-auth/src/repository/audit_log_repository.rs
@@ -1,0 +1,74 @@
+//! Audit log repository
+
+use crate::{
+    error::{AppError, Result},
+    model::AuditLog,
+};
+use serde_json::Value;
+use sqlx::PgPool;
+
+/// Audit log repository
+#[derive(Debug, Clone)]
+pub struct AuditLogRepository {
+    pool: PgPool,
+}
+
+impl AuditLogRepository {
+    /// Create new audit log repository
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+
+    /// Persist one audit event.
+    pub async fn create(
+        &self,
+        tenant_id: &str,
+        user_id: Option<i64>,
+        action: &str,
+        resource: &str,
+        resource_id: Option<&str>,
+        ip_address: Option<&str>,
+        user_agent: Option<&str>,
+        details: Option<Value>,
+    ) -> Result<AuditLog> {
+        let audit_log = sqlx::query_as::<_, AuditLog>(
+            r#"
+            INSERT INTO audit_logs (
+                tenant_id,
+                user_id,
+                action,
+                resource,
+                resource_id,
+                ip_address,
+                user_agent,
+                details
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+            RETURNING
+                id,
+                tenant_id,
+                user_id,
+                action,
+                resource,
+                resource_id,
+                ip_address,
+                user_agent,
+                details,
+                created_at
+            "#,
+        )
+        .bind(tenant_id)
+        .bind(user_id)
+        .bind(action)
+        .bind(resource)
+        .bind(resource_id)
+        .bind(ip_address)
+        .bind(user_agent)
+        .bind(details)
+        .fetch_one(&self.pool)
+        .await
+        .map_err(AppError::Database)?;
+
+        Ok(audit_log)
+    }
+}

--- a/koduck-auth/src/repository/mod.rs
+++ b/koduck-auth/src/repository/mod.rs
@@ -1,10 +1,12 @@
 //! Repository layer for database access
 
+pub mod audit_log_repository;
 pub mod cache;
 pub mod password_reset_repository;
 pub mod refresh_token_repository;
 pub mod user_repository;
 
+pub use audit_log_repository::AuditLogRepository;
 pub use cache::RedisCache;
 pub use password_reset_repository::PasswordResetRepository;
 pub use refresh_token_repository::RefreshTokenRepository;

--- a/koduck-auth/src/service/auth_service.rs
+++ b/koduck-auth/src/service/auth_service.rs
@@ -11,16 +11,17 @@ use crate::{
         RefreshTokenRequest, ResetPasswordRequest, SecurityConfigResponse,
         TokenPair, TokenResponse, UserInfo,
     },
-    repository::{PasswordResetRepository, RedisCache, RefreshTokenRepository, UserRepository},
+    repository::{AuditLogRepository, PasswordResetRepository, RedisCache, RefreshTokenRepository, UserRepository},
 };
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use secrecy::ExposeSecret;
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 use sha2::{Digest, Sha256};
 use sqlx::PgPool;
 use std::sync::Arc;
 use std::time::Duration;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 const DEFAULT_TENANT_ID: &str = "default";
 
@@ -30,6 +31,7 @@ pub struct AuthService {
     user_repo: UserRepository,
     token_repo: RefreshTokenRepository,
     password_reset_repo: PasswordResetRepository,
+    audit_log_repo: AuditLogRepository,
     redis: RedisCache,
     jwt_service: JwtService,
     password_hasher: PasswordHasher,
@@ -74,6 +76,7 @@ impl AuthService {
         user_repo: UserRepository,
         token_repo: RefreshTokenRepository,
         password_reset_repo: PasswordResetRepository,
+        audit_log_repo: AuditLogRepository,
         redis: RedisCache,
         jwt_service: JwtService,
         db_pool: PgPool,
@@ -86,6 +89,7 @@ impl AuthService {
             user_repo,
             token_repo,
             password_reset_repo,
+            audit_log_repo,
             redis,
             jwt_service,
             password_hasher,
@@ -95,7 +99,15 @@ impl AuthService {
     }
 
     /// Login user
-    pub async fn login(&self, req: LoginRequest, ip: String, _user_agent: String) -> Result<TokenResponse> {
+    pub async fn login(&self, req: LoginRequest, ip: String, user_agent: String) -> Result<TokenResponse> {
+        let tenant_id = req
+            .tenant_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| AppError::Validation("tenant_id is required for login".to_string()))?
+            .to_string();
+
         // Check if IP is locked
         if self.redis.is_ip_locked(&ip).await? {
             return Err(AppError::Locked(
@@ -105,9 +117,15 @@ impl AuthService {
 
         // Fetch user from koduck-user internal API instead of local auth DB.
         let user = self
-            .fetch_user_from_user_service(DEFAULT_TENANT_ID, &req.username)
+            .fetch_user_from_user_service(&tenant_id, &req.username)
             .await?
             .ok_or_else(|| AppError::Unauthorized("Invalid username or password".to_string()))?;
+
+        if user.tenant_id != tenant_id {
+            return Err(AppError::Unauthorized(
+                "tenant_id does not match the authenticated user".to_string(),
+            ));
+        }
 
         // Verify password
         if !self
@@ -158,6 +176,21 @@ impl AuthService {
             .await?;
 
         let user_info = Self::build_user_info_from_internal(&user);
+
+        self.record_auth_audit_event(
+            &user.tenant_id,
+            Some(user.id),
+            "LOGIN_SUCCESS",
+            Some(&user.username),
+            Some(&ip),
+            Some(&user_agent),
+            json!({
+                "username": user.username,
+                "login_identifier": req.username,
+                "token_type": "refresh+access"
+            }),
+        )
+        .await;
 
         Ok(TokenResponse::new(tokens, user_info))
     }
@@ -231,6 +264,12 @@ impl AuthService {
             .await?
             .ok_or_else(|| AppError::NotFound("User not found".to_string()))?;
 
+        if user.tenant_id != token_record.tenant_id {
+            return Err(AppError::Unauthorized(
+                "refresh token tenant does not match the user".to_string(),
+            ));
+        }
+
         // Revoke old token
         self.token_repo
             .revoke_in_tenant(&token_record.tenant_id, &refresh_token_hash)
@@ -246,6 +285,21 @@ impl AuthService {
             .await?;
 
         let user_info = Self::build_user_info_from_internal(&user);
+        let user_id_resource = user.id.to_string();
+
+        self.record_auth_audit_event(
+            &user.tenant_id,
+            Some(user.id),
+            "REFRESH_TOKEN_SUCCESS",
+            Some(&user_id_resource),
+            None,
+            None,
+            json!({
+                "refresh_token_id": token_record.id,
+                "previous_token_tenant_id": token_record.tenant_id
+            }),
+        )
+        .await;
 
         Ok(TokenResponse::new(tokens, user_info))
     }
@@ -845,6 +899,39 @@ impl AuthService {
             avatar_url: None,
             status: Self::parse_user_status(&user.status),
             email_verified: false,
+        }
+    }
+
+    async fn record_auth_audit_event(
+        &self,
+        tenant_id: &str,
+        user_id: Option<i64>,
+        action: &str,
+        resource_id: Option<&str>,
+        ip_address: Option<&str>,
+        user_agent: Option<&str>,
+        details: serde_json::Value,
+    ) {
+        if let Err(err) = self
+            .audit_log_repo
+            .create(
+                tenant_id,
+                user_id,
+                action,
+                "AUTH",
+                resource_id,
+                ip_address,
+                user_agent,
+                Some(details),
+            )
+            .await
+        {
+            warn!(
+                tenant_id = tenant_id,
+                action = action,
+                error = %err,
+                "Failed to persist auth audit log"
+            );
         }
     }
 

--- a/koduck-auth/tests/common/harness.rs
+++ b/koduck-auth/tests/common/harness.rs
@@ -11,7 +11,7 @@ use koduck_auth::{
     init_state,
     jwt::{JwksService, JwtValidator},
     model::CreateUserDto,
-    repository::{PasswordResetRepository, RedisCache, RefreshTokenRepository, UserRepository},
+    repository::{AuditLogRepository, PasswordResetRepository, RedisCache, RefreshTokenRepository, UserRepository},
     service::{AuthService as AuthServiceImpl, TokenService as TokenServiceImpl},
     AppState,
 };
@@ -189,6 +189,7 @@ impl TestRuntime {
 
         let token_repo = RefreshTokenRepository::new(self.state.db_pool().clone());
         let password_reset_repo = PasswordResetRepository::new(self.state.db_pool().clone());
+        let audit_log_repo = AuditLogRepository::new(self.state.db_pool().clone());
         let redis = RedisCache::new(self.state.redis_pool().clone());
 
         let public_key = load_public_key(&cfg.jwt.public_key_path)
@@ -203,6 +204,7 @@ impl TestRuntime {
             self.user_repo.clone(),
             token_repo.clone(),
             password_reset_repo,
+            audit_log_repo,
             redis.clone(),
             self.state.jwt_service().clone(),
             self.state.db_pool().clone(),

--- a/koduck-auth/tests/integration_tests.rs
+++ b/koduck-auth/tests/integration_tests.rs
@@ -58,6 +58,7 @@ async fn test_login() {
     let request = LoginRequest {
         username: user.username.clone(),
         password: app.test_user.password.clone(),
+        tenant_id: Some("default".to_string()),
         turnstile_token: None,
     };
 
@@ -76,6 +77,7 @@ async fn test_login_invalid_credentials() {
     let request = LoginRequest {
         username: "nonexistent_user".to_string(),
         password: "wrong_password".to_string(),
+        tenant_id: Some("default".to_string()),
         turnstile_token: None,
     };
 
@@ -95,6 +97,7 @@ async fn test_refresh_token() {
             LoginRequest {
                 username: user.username.clone(),
                 password: app.test_user.password.clone(),
+                tenant_id: Some("default".to_string()),
                 turnstile_token: None,
             },
         )
@@ -151,6 +154,7 @@ async fn test_logout() {
             LoginRequest {
                 username: user.username.clone(),
                 password: app.test_user.password.clone(),
+                tenant_id: Some("default".to_string()),
                 turnstile_token: None,
             },
         )


### PR DESCRIPTION
## Summary
- require tenant context for login across HTTP and gRPC entrypoints
- enforce tenant consistency in login and refresh before issuing tokens
- persist tenant-aware auth audit logs and mark Task 4.3 complete

## Verification
- docker build -t koduck-auth:dev ./koduck-auth
- kubectl rollout restart deployment/dev-koduck-auth -n koduck-dev
- kubectl rollout status deployment/dev-koduck-auth -n koduck-dev --timeout=180s

Closes #780