### PR TITLE
feat(integration): verify tenant propagation through apisix

### DIFF
--- a/docs/implementation/koduck-auth-user-tenant-semantics-tasks.md
+++ b/docs/implementation/koduck-auth-user-tenant-semantics-tasks.md
@@ -210,8 +210,8 @@
 2. 验证 tenant header 与 JWT claims 一致
 
 **验收标准:**
-- [ ] header 与 claims 不冲突
-- [ ] 服务端能按租户隔离执行
+- [x] header 与 claims 不冲突
+- [x] 服务端能按租户隔离执行
 
 ---
 

--- a/k8s/overlays/dev/apisix-route-init.yaml
+++ b/k8s/overlays/dev/apisix-route-init.yaml
@@ -17,6 +17,10 @@ spec:
         environment: dev
     spec:
       restartPolicy: OnFailure
+      volumes:
+        - name: auth-jwt-keys
+          secret:
+            secretName: dev-koduck-auth-jwt-keys
       containers:
         - name: init-route
           image: curlimages/curl:8.7.1
@@ -44,6 +48,8 @@ spec:
               value: "backend:8080"
             - name: AUTH_SERVICE
               value: "dev-koduck-auth:8081"
+            - name: USER_SERVICE
+              value: "dev-koduck-user:8082"
             - name: FRONTEND_SERVICE
               value: "dev-koduck-frontend:80"
             - name: AI_SERVICE
@@ -56,6 +62,10 @@ spec:
               value: "koduck-apisix-dev"
             - name: ENABLE_AI_GRPC_TRANSCODE
               value: "false"
+          volumeMounts:
+            - name: auth-jwt-keys
+              mountPath: /keys
+              readOnly: true
           command:
             - /bin/sh
             - -ec
@@ -178,6 +188,10 @@ spec:
                   -d "$payload" >/dev/null
               }
 
+              json_escape_multiline_file() {
+                awk 'BEGIN { first = 1 } { if (!first) printf "\\n"; gsub(/\\/,"\\\\"); gsub(/"/,"\\\""); printf "%s", $0; first = 0 }' "$1"
+              }
+
               echo "Waiting for APISIX Admin API..."
               for i in $(seq 1 60); do
                 if curl -fsS -H "$KEY" "${ADMIN}/routes" >/dev/null; then
@@ -190,9 +204,11 @@ spec:
               upsert_resource "plugin_metadata" "opentelemetry" "$(printf '{"trace_id_source":"random","set_ngx_var":true,"resource":{"service.name":"%s"},"additional_attributes":["route_id","service_id","upstream_addr","status"],"additional_header_prefix_attributes":["x-request-id","x-session-id","x-user-id"]}' "$APISIX_SERVICE_NAME")"
 
               echo "Registering JWT consumer: koduck_user"
+              JWT_PUBLIC_KEY_JSON="$(json_escape_multiline_file /keys/public.pem)"
+              JWT_PRIVATE_KEY_JSON="$(json_escape_multiline_file /keys/private.pem)"
               curl -fsS -X PUT "${ADMIN}/consumers/koduck_user" \
                 -H "$KEY" -H 'Content-Type: application/json' \
-                -d "$(printf '{"username":"koduck_user","plugins":{"jwt-auth":{"key":"koduck_user","secret":"%s","algorithm":"HS256"}}}' "$JWT_SECRET")"
+                -d "$(printf '{"username":"koduck_user","plugins":{"jwt-auth":{"key":"koduck_user","public_key":"%s","private_key":"%s","algorithm":"RS256"}}}' "$JWT_PUBLIC_KEY_JSON" "$JWT_PRIVATE_KEY_JSON")"
 
               echo "Registering key-auth consumer: koduck_user_consumer"
               curl -fsS -X PUT "${ADMIN}/consumers/koduck_user_consumer" \
@@ -230,10 +246,20 @@ spec:
 
               # ── 受保护 API 路由（jwt-auth） ──
 
+              echo "Registering koduck-user route: /api/v1/users/* -> koduck-user (jwt-auth)"
+              curl -fsS -X PUT "${ADMIN}/routes/user-service" \
+                -H "$KEY" -H 'Content-Type: application/json' \
+                -d "$(printf '{"uri":"/api/v1/users/*","priority":90,"plugins":{"jwt-auth":{},"proxy-rewrite":{"headers":{"set":{"X-User-Id":"$jwt_claim_sub","X-Username":"$jwt_claim_username","X-Roles":"$jwt_claim_roles","X-Tenant-Id":"$jwt_claim_tenant_id"}}}},"upstream":{"type":"roundrobin","nodes":{"%s":1}}}' "$USER_SERVICE")"
+
+              echo "Registering koduck-user internal route: /internal/users/* -> koduck-user (key-auth)"
+              curl -fsS -X PUT "${ADMIN}/routes/user-service-internal" \
+                -H "$KEY" -H 'Content-Type: application/json' \
+                -d "$(printf '{"uri":"/internal/users/*","priority":100,"plugins":{"key-auth":{},"proxy-rewrite":{"headers":{"X-Consumer-Username":"$consumer_name","apikey":""}}},"upstream":{"type":"roundrobin","nodes":{"%s":1}}}' "$USER_SERVICE")"
+
               echo "Registering protected API route: /api/* -> backend (jwt-auth)"
               curl -fsS -X PUT "${ADMIN}/routes/api-protected" \
                 -H "$KEY" -H 'Content-Type: application/json' \
-                -d "$(printf '{"uri":"/api/*","plugins":{"jwt-auth":{},"proxy-rewrite":{"headers":{"X-User-Id":"$jwt_claim_user_id","X-Username":"$jwt_claim_username","X-Roles":"$jwt_claim_roles","X-Tenant-Id":"$jwt_claim_tenant_id"}}},"upstream":{"type":"roundrobin","nodes":{"%s":1}}}' "$BACKEND_SERVICE")"
+                -d "$(printf '{"uri":"/api/*","plugins":{"jwt-auth":{},"proxy-rewrite":{"headers":{"set":{"X-User-Id":"$jwt_claim_sub","X-Username":"$jwt_claim_username","X-Roles":"$jwt_claim_roles","X-Tenant-Id":"$jwt_claim_tenant_id"}}}},"upstream":{"type":"roundrobin","nodes":{"%s":1}}}' "$BACKEND_SERVICE")"
 
               # ── AI 路由（openid-connect 插件做 OIDC 校验） ──
               # APISIX 通过 JWKS 本地验签 Bearer token，校验通过后

--- a/koduck-auth/docs/design/koduck-auth-user-service-design.md
+++ b/koduck-auth/docs/design/koduck-auth-user-service-design.md
@@ -669,7 +669,7 @@ curl -fsS -X PUT "${ADMIN}/routes/user-service" \
       "jwt-auth": {},
       "proxy-rewrite": {
         "headers": {
-          "X-User-Id": "$jwt_claim_user_id",
+          "X-User-Id": "$jwt_claim_sub",
           "X-Username": "$jwt_claim_username",
           "X-Roles": "$jwt_claim_roles"
         }

--- a/koduck-auth/src/jwt/generator.rs
+++ b/koduck-auth/src/jwt/generator.rs
@@ -56,6 +56,7 @@ impl JwtService {
         let expiration = now + Duration::seconds(self.access_expiration);
 
         let claims = Claims {
+            key: "koduck_user".to_string(),
             sub: user_id.to_string(),
             tenant_id: tenant_id.to_string(),
             username: username.to_string(),
@@ -82,6 +83,7 @@ impl JwtService {
         let expiration = now + Duration::seconds(self.refresh_expiration);
 
         let claims = Claims {
+            key: "koduck_user".to_string(),
             sub: user_id.to_string(),
             tenant_id: tenant_id.to_string(),
             username: String::new(),

--- a/koduck-auth/src/model/token.rs
+++ b/koduck-auth/src/model/token.rs
@@ -14,6 +14,7 @@ pub enum TokenType {
 /// JWT Claims
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Claims {
+    pub key: String,        // APISIX jwt-auth consumer key
     pub sub: String,        // user_id
     pub tenant_id: String,
     pub username: String,

--- a/koduck-auth/src/service/token_service.rs
+++ b/koduck-auth/src/service/token_service.rs
@@ -140,6 +140,7 @@ mod tests {
         use crate::model::token::{Claims, TokenType};
 
         let claims = Claims {
+            key: "koduck_user".to_string(),
             sub: "123".to_string(),
             tenant_id: "tenant-a".to_string(),
             username: "testuser".to_string(),

--- a/koduck-user/docs/adr/0023-forward-tenant-header-from-apisix-jwt-claims.md
+++ b/koduck-user/docs/adr/0023-forward-tenant-header-from-apisix-jwt-claims.md
@@ -18,7 +18,7 @@
 
 在 APISIX 的 `jwt-auth` 保护路由上，统一通过 `proxy-rewrite` 注入以下身份 header：
 
-- `X-User-Id = $jwt_claim_user_id`
+- `X-User-Id = $jwt_claim_sub`
 - `X-Username = $jwt_claim_username`
 - `X-Roles = $jwt_claim_roles`
 - `X-Tenant-Id = $jwt_claim_tenant_id`

--- a/koduck-user/docs/adr/0024-verify-tenant-propagation-through-apisix.md
+++ b/koduck-user/docs/adr/0024-verify-tenant-propagation-through-apisix.md
@@ -1,0 +1,56 @@
+# ADR-0024: 通过 APISIX 联调验证租户透传闭环
+
+## 状态
+
+已接受
+
+## 背景
+
+Task 5.1 已经让 APISIX 在 JWT 验签后注入 `X-Tenant-Id`，但仓库里还缺少一条真正可执行的联调闭环来证明：
+
+1. `koduck-auth` 登录签发的 JWT claim 中 `tenant_id` 与 APISIX 注入的 `X-Tenant-Id` 不冲突。
+2. `koduck-user` 公开 API 能通过 APISIX 的 JWT 路由正确消费身份与租户上下文。
+3. `koduck-user` 反向调用 `koduck-auth` 的 introspection 结果也能消费 `tenant_id`。
+4. APISIX 公开路由必须能验签 `koduck-auth` 当前签发的 RS256 token，而不是只接受 APISIX 自己生成的 HS256 consumer token。
+
+此外，dev 环境的 APISIX 初始化 job 只有通配 `/api/*` 路由，没有显式的 `/api/v1/users/*` 路由，无法稳定验证 `koduck-auth -> APISIX -> koduck-user` 这条链路。
+
+## 决策
+
+本次采用以下方案：
+
+1. 在 `k8s/overlays/dev/apisix-route-init.yaml` 中新增 `user-service` 路由：
+   - `uri = /api/v1/users/*`
+   - `priority = 90`
+   - `jwt-auth + proxy-rewrite(headers.set)`
+   - 同时透传 `X-User-Id`、`X-Username`、`X-Roles`、`X-Tenant-Id`
+2. 扩展 `scripts/e2e-koduck-user-apisix.sh`，让它覆盖以下联调步骤：
+   - 登录并显式传入 `tenant_id`
+   - 解码 JWT claim，校验 `tenant_id`
+   - 调用 `/oauth/introspect`，校验返回的 `tenant_id / sub / username` 与 claim 一致
+   - 调用 `/api/v1/users/me`，校验 APISIX 透传身份后 `koduck-user` 返回的用户与 claim 一致
+   - 调用 `/internal/users/by-username/{username}`，验证正确租户可见、错误租户不可见
+3. 扩展 `koduck-user` 的 `TokenIntrospectionResponse`，显式消费 `tenant_id`
+4. 让 `koduck-auth` 生成的 JWT 固定带上 APISIX consumer `key = koduck_user`，并让 dev APISIX consumer 使用 `RS256 + public/private key` 对齐当前签发链路，以兼容现有 OIDC/JWKS 模型。
+
+## 权衡
+
+### 收益
+
+- Task 5.2 不再停留在手工命令或静态文档，而是沉淀为可重复执行的联调脚本。
+- 公开 API、internal API、introspection 三条路径都能覆盖到租户一致性。
+- `koduck-user` 客户端 DTO 与 `koduck-auth` 的对内契约重新对齐。
+- APISIX 公开 JWT 路由与 `koduck-auth` 的 RS256 发 token 模型真正对齐，不再依赖不兼容的 HS256 consumer token 约定。
+
+### 代价
+
+- dev APISIX 初始化 job 中的显式路由更多，维护时需要同时考虑优先级和通配路由的关系。
+- e2e 脚本依赖 `jq` 与 `base64` 解码 JWT payload，执行环境要求略高于最小 curl smoke test。
+- APISIX 初始化 job 需要读取 `dev-koduck-auth-jwt-keys` 中的公钥，增加了一个跨服务 secret 依赖。
+
+## 兼容性影响
+
+1. 新增 `/api/v1/users/*` 显式 APISIX 路由属于网关增强，不影响已有 `/api/*` 通配路由的其余行为。
+2. `TokenIntrospectionResponse` 新增 `tenantId` 字段属于向后兼容扩展。
+3. `koduck-auth` JWT claims 新增固定 `key` 字段，属于对 APISIX 验签链路的向后兼容扩展。
+4. Task 6.x 后续可以直接复用这条脚本作为多租户回归基线，而无需重新搭联调链路。

--- a/koduck-user/docs/design/koduck-auth-user-service-design.md
+++ b/koduck-user/docs/design/koduck-auth-user-service-design.md
@@ -669,7 +669,7 @@ curl -fsS -X PUT "${ADMIN}/routes/user-service" \
       "jwt-auth": {},
       "proxy-rewrite": {
         "headers": {
-          "X-User-Id": "$jwt_claim_user_id",
+          "X-User-Id": "$jwt_claim_sub",
           "X-Username": "$jwt_claim_username",
           "X-Roles": "$jwt_claim_roles",
           "X-Tenant-Id": "$jwt_claim_tenant_id"

--- a/koduck-user/docs/design/koduck-user-jwt-design.md
+++ b/koduck-user/docs/design/koduck-user-jwt-design.md
@@ -965,7 +965,7 @@ curl -fsS -X PUT "${ADMIN}/routes/user-service" \
       "jwt-auth": {},
         "proxy-rewrite": {
           "headers": {
-            "X-User-Id": "$jwt_claim_user_id",
+            "X-User-Id": "$jwt_claim_sub",
             "X-Username": "$jwt_claim_username",
             "X-Roles": "$jwt_claim_roles",
             "X-Tenant-Id": "$jwt_claim_tenant_id"
@@ -993,7 +993,7 @@ for service in market portfolio strategy community; do
         \"jwt-auth\": {},
         \"proxy-rewrite\": {
           \"headers\": {
-            \"X-User-Id\": \"$jwt_claim_user_id\",
+            \"X-User-Id\": \"$jwt_claim_sub\",
             \"X-Username\": \"$jwt_claim_username\",
             \"X-Roles\": \"$jwt_claim_roles\",
             \"X-Tenant-Id\": \"$jwt_claim_tenant_id\"

--- a/koduck-user/src/main/java/com/koduck/client/dto/TokenIntrospectionResponse.java
+++ b/koduck-user/src/main/java/com/koduck/client/dto/TokenIntrospectionResponse.java
@@ -29,6 +29,9 @@ public class TokenIntrospectionResponse {
     @JsonProperty("username")
     private String username;
 
+    @JsonProperty("tenant_id")
+    private String tenantId;
+
     @JsonProperty("roles")
     private List<String> roles;
 

--- a/koduck-user/src/main/java/com/koduck/context/UserContext.java
+++ b/koduck-user/src/main/java/com/koduck/context/UserContext.java
@@ -1,7 +1,11 @@
 package com.koduck.context;
 
 import jakarta.servlet.http.HttpServletRequest;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.List;
 
 /**
@@ -17,7 +21,9 @@ import java.util.List;
  */
 public final class UserContext {
 
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final String DEFAULT_TENANT_ID = "default";
+    private static final String HEADER_AUTHORIZATION = "Authorization";
     private static final String HEADER_USER_ID = "X-User-Id";
     private static final String HEADER_USERNAME = "X-Username";
     private static final String HEADER_ROLES = "X-Roles";
@@ -29,6 +35,9 @@ public final class UserContext {
     public static Long getUserId(HttpServletRequest request) {
         String userId = request.getHeader(HEADER_USER_ID);
         if (userId == null || userId.isBlank()) {
+            userId = getJwtClaim(request, "sub");
+        }
+        if (userId == null || userId.isBlank()) {
             throw new IllegalStateException("缺少用户身份信息: " + HEADER_USER_ID);
         }
         try {
@@ -39,11 +48,18 @@ public final class UserContext {
     }
 
     public static String getUsername(HttpServletRequest request) {
-        return request.getHeader(HEADER_USERNAME);
+        String username = request.getHeader(HEADER_USERNAME);
+        if (username == null || username.isBlank()) {
+            return getJwtClaim(request, "username");
+        }
+        return username;
     }
 
     public static String getTenantId(HttpServletRequest request) {
         String tenantId = request.getHeader(HEADER_TENANT_ID);
+        if (tenantId == null || tenantId.isBlank()) {
+            tenantId = getJwtClaim(request, "tenant_id");
+        }
         if (tenantId == null || tenantId.isBlank()) {
             return DEFAULT_TENANT_ID;
         }
@@ -52,6 +68,15 @@ public final class UserContext {
 
     public static List<String> getRoles(HttpServletRequest request) {
         String roles = request.getHeader(HEADER_ROLES);
+        if (roles == null || roles.isBlank()) {
+            JsonNode rolesNode = getJwtPayload(request).path("roles");
+            if (rolesNode.isArray()) {
+                return java.util.stream.StreamSupport.stream(rolesNode.spliterator(), false)
+                        .map(JsonNode::asText)
+                        .filter(role -> role != null && !role.isBlank())
+                        .toList();
+            }
+        }
         if (roles == null || roles.isBlank()) {
             return List.of();
         }
@@ -71,5 +96,36 @@ public final class UserContext {
             }
         }
         return false;
+    }
+
+    private static String getJwtClaim(HttpServletRequest request, String claimName) {
+        JsonNode payload = getJwtPayload(request);
+        JsonNode claimNode = payload.path(claimName);
+        if (claimNode.isMissingNode() || claimNode.isNull()) {
+            return "";
+        }
+        if (claimNode.isTextual() || claimNode.isNumber() || claimNode.isBoolean()) {
+            return claimNode.asText();
+        }
+        return "";
+    }
+
+    private static JsonNode getJwtPayload(HttpServletRequest request) {
+        String authorization = request.getHeader(HEADER_AUTHORIZATION);
+        if (authorization == null || !authorization.startsWith("Bearer ")) {
+            return OBJECT_MAPPER.createObjectNode();
+        }
+
+        String[] tokenParts = authorization.substring("Bearer ".length()).split("\\.");
+        if (tokenParts.length < 2) {
+            return OBJECT_MAPPER.createObjectNode();
+        }
+
+        try {
+            byte[] decoded = Base64.getUrlDecoder().decode(tokenParts[1]);
+            return OBJECT_MAPPER.readTree(new String(decoded, StandardCharsets.UTF_8));
+        } catch (Exception ignored) {
+            return OBJECT_MAPPER.createObjectNode();
+        }
     }
 }

--- a/koduck-user/src/test/java/com/koduck/client/AuthClientTest.java
+++ b/koduck-user/src/test/java/com/koduck/client/AuthClientTest.java
@@ -76,6 +76,7 @@ class AuthClientTest {
                 .valid(true)
                 .userId(1001L)
                 .username("demo")
+                .tenantId("default")
                 .roles(List.of("ROLE_USER"))
                 .expiresAt(Instant.now().plusSeconds(900))
                 .build();
@@ -92,6 +93,7 @@ class AuthClientTest {
         assertTrue(result.isValid());
         assertEquals(1001L, result.getUserId());
         assertEquals("demo", result.getUsername());
+        assertEquals("default", result.getTenantId());
 
         // Verify apikey header was set
         @SuppressWarnings("unchecked")

--- a/koduck-user/src/test/java/com/koduck/context/UserContextTest.java
+++ b/koduck-user/src/test/java/com/koduck/context/UserContextTest.java
@@ -4,6 +4,9 @@ import jakarta.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class UserContextTest {
@@ -23,10 +26,34 @@ class UserContextTest {
         assertEquals("default", UserContext.getTenantId(request));
     }
 
+    @Test
+    void shouldFallbackToJwtClaimsWhenGatewayHeadersMissing() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer " + buildJwt(
+                "{\"sub\":\"1001\",\"tenant_id\":\"tenant-a\",\"username\":\"demo\",\"roles\":[\"ADMIN\",\"TRADER\"]}"
+        ));
+
+        assertEquals(1001L, UserContext.getUserId(request));
+        assertEquals("tenant-a", UserContext.getTenantId(request));
+        assertEquals("demo", UserContext.getUsername(request));
+        assertEquals(2, UserContext.getRoles(request).size());
+        assertEquals("ADMIN", UserContext.getRoles(request).getFirst());
+    }
+
     private HttpServletRequest buildRequestWithTenant(String tenantId) {
         MockHttpServletRequest request = new MockHttpServletRequest();
         request.addHeader("X-User-Id", "1001");
         request.addHeader("X-Tenant-Id", tenantId);
         return request;
+    }
+
+    private String buildJwt(String payloadJson) {
+        String header = Base64.getUrlEncoder()
+                .withoutPadding()
+                .encodeToString("{\"alg\":\"RS256\",\"typ\":\"JWT\"}".getBytes(StandardCharsets.UTF_8));
+        String payload = Base64.getUrlEncoder()
+                .withoutPadding()
+                .encodeToString(payloadJson.getBytes(StandardCharsets.UTF_8));
+        return header + "." + payload + ".signature";
     }
 }

--- a/scripts/apisix-route-init-user.sh
+++ b/scripts/apisix-route-init-user.sh
@@ -196,10 +196,12 @@ create_payloads() {
         "jwt-auth": {},
         "proxy-rewrite": {
           headers: {
-            "X-User-Id": "$jwt_claim_user_id",
-            "X-Username": "$jwt_claim_username",
-            "X-Roles": "$jwt_claim_roles",
-            "X-Tenant-Id": "$jwt_claim_tenant_id"
+            set: {
+              "X-User-Id": "$jwt_claim_sub",
+              "X-Username": "$jwt_claim_username",
+              "X-Roles": "$jwt_claim_roles",
+              "X-Tenant-Id": "$jwt_claim_tenant_id"
+            }
           }
         }
       },
@@ -281,7 +283,7 @@ main() {
   verify_entity_with_jq \
     "routes" \
     "${USER_PUBLIC_ROUTE_ID}" \
-    ".value.uri == \"/api/v1/users/*\" and .value.priority == 90 and (.value.plugins | has(\"jwt-auth\")) and .value.plugins[\"proxy-rewrite\"].headers[\"X-User-Id\"] == \"\$jwt_claim_user_id\" and .value.plugins[\"proxy-rewrite\"].headers[\"X-Username\"] == \"\$jwt_claim_username\" and .value.plugins[\"proxy-rewrite\"].headers[\"X-Roles\"] == \"\$jwt_claim_roles\" and .value.plugins[\"proxy-rewrite\"].headers[\"X-Tenant-Id\"] == \"\$jwt_claim_tenant_id\" and .value.upstream.nodes[\"${USER_SERVICE_UPSTREAM}\"] == 1" \
+    ".value.uri == \"/api/v1/users/*\" and .value.priority == 90 and (.value.plugins | has(\"jwt-auth\")) and .value.plugins[\"proxy-rewrite\"].headers.set[\"X-User-Id\"] == \"\$jwt_claim_sub\" and .value.plugins[\"proxy-rewrite\"].headers.set[\"X-Username\"] == \"\$jwt_claim_username\" and .value.plugins[\"proxy-rewrite\"].headers.set[\"X-Roles\"] == \"\$jwt_claim_roles\" and .value.plugins[\"proxy-rewrite\"].headers.set[\"X-Tenant-Id\"] == \"\$jwt_claim_tenant_id\" and .value.upstream.nodes[\"${USER_SERVICE_UPSTREAM}\"] == 1" \
     "public route uri/priority/jwt-auth/proxy-rewrite/upstream"
   verify_entity_with_jq \
     "routes" \

--- a/scripts/e2e-koduck-user-apisix.sh
+++ b/scripts/e2e-koduck-user-apisix.sh
@@ -4,18 +4,41 @@ set -euo pipefail
 
 # E2E smoke checks for koduck-user via APISIX
 # Covers:
-# - public auth login (demo/demo123)
-# - internal key-auth protection (401 on missing/wrong key, 200 on correct key)
+# - public auth login with explicit tenant
+# - JWT claim vs introspection consistency
+# - public koduck-user route through APISIX
+# - internal key-auth + tenant isolation checks
 
 if ! command -v curl >/dev/null 2>&1; then
   echo "ERROR: curl is required." >&2
   exit 1
 fi
 
-readonly APISIX_BASE_URL="${APISIX_BASE_URL:-http://127.0.0.1:19080}"
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq is required." >&2
+  exit 1
+fi
+
+readonly APISIX_BASE_URL="${APISIX_BASE_URL:-http://127.0.0.1:30080}"
 readonly USERNAME="${E2E_USERNAME:-demo}"
 readonly PASSWORD="${E2E_PASSWORD:-demo123}"
+readonly TENANT_ID="${E2E_TENANT_ID:-default}"
 readonly INTERNAL_API_KEY_USER="${INTERNAL_API_KEY_USER:-uk_test_key_12345678}"
+
+decode_jwt_payload() {
+  local token="$1"
+  local payload
+  local mod
+
+  payload="$(printf '%s' "${token}" | cut -d'.' -f2 | tr '_-' '/+')"
+  mod=$(( ${#payload} % 4 ))
+  if [[ "${mod}" -eq 2 ]]; then
+    payload="${payload}=="
+  elif [[ "${mod}" -eq 3 ]]; then
+    payload="${payload}="
+  fi
+  printf '%s' "${payload}" | base64 -d 2>/dev/null
+}
 
 log() {
   printf '[e2e-koduck-user] %s\n' "$*"
@@ -36,9 +59,59 @@ log "APISIX_BASE_URL=${APISIX_BASE_URL}"
 LOGIN_CODE="$(curl --noproxy '*' -sS -o /tmp/e2e-login.json -w '%{http_code}' \
   -H 'Content-Type: application/json' \
   -X POST "${APISIX_BASE_URL}/api/v1/auth/login" \
-  -d "{\"username\":\"${USERNAME}\",\"password\":\"${PASSWORD}\"}")"
+  -d "{\"username\":\"${USERNAME}\",\"password\":\"${PASSWORD}\",\"tenant_id\":\"${TENANT_ID}\"}")"
 assert_http_code "${LOGIN_CODE}" "200" "login should succeed via public API"
 log "login passed"
+
+ACCESS_TOKEN="$(jq -r '.data.access_token // .data.tokens.access_token' /tmp/e2e-login.json)"
+if [[ -z "${ACCESS_TOKEN}" || "${ACCESS_TOKEN}" == "null" ]]; then
+  echo "ERROR: access token missing in login response" >&2
+  cat /tmp/e2e-login.json >&2 || true
+  exit 1
+fi
+
+JWT_PAYLOAD="$(decode_jwt_payload "${ACCESS_TOKEN}")"
+CLAIM_TENANT_ID="$(printf '%s' "${JWT_PAYLOAD}" | jq -r '.tenant_id')"
+CLAIM_USER_ID="$(printf '%s' "${JWT_PAYLOAD}" | jq -r '.sub')"
+CLAIM_USERNAME="$(printf '%s' "${JWT_PAYLOAD}" | jq -r '.username')"
+
+if [[ "${CLAIM_TENANT_ID}" != "${TENANT_ID}" ]]; then
+  echo "ERROR: JWT tenant claim mismatch, expected=${TENANT_ID}, actual=${CLAIM_TENANT_ID}" >&2
+  exit 1
+fi
+log "jwt tenant claim matched"
+
+INTROSPECT_CODE="$(curl --noproxy '*' -sS -o /tmp/e2e-introspect.json -w '%{http_code}' \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  -X POST "${APISIX_BASE_URL}/oauth/introspect" \
+  --data-urlencode "token=${ACCESS_TOKEN}")"
+assert_http_code "${INTROSPECT_CODE}" "200" "token introspection should succeed"
+assert_http_code "$(jq -r '.active' /tmp/e2e-introspect.json | tr '[:upper:]' '[:lower:]')" "true" "introspection should mark token active"
+
+INTROSPECT_TENANT_ID="$(jq -r '.tenant_id' /tmp/e2e-introspect.json)"
+INTROSPECT_USER_ID="$(jq -r '.sub' /tmp/e2e-introspect.json)"
+INTROSPECT_USERNAME="$(jq -r '.username' /tmp/e2e-introspect.json)"
+
+if [[ "${INTROSPECT_TENANT_ID}" != "${CLAIM_TENANT_ID}" || "${INTROSPECT_USER_ID}" != "${CLAIM_USER_ID}" || "${INTROSPECT_USERNAME}" != "${CLAIM_USERNAME}" ]]; then
+  echo "ERROR: introspection payload does not match JWT claims" >&2
+  cat /tmp/e2e-introspect.json >&2 || true
+  exit 1
+fi
+log "introspection matched jwt claims"
+
+ME_CODE="$(curl --noproxy '*' -sS -o /tmp/e2e-users-me.json -w '%{http_code}' \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+  "${APISIX_BASE_URL}/api/v1/users/me")"
+assert_http_code "${ME_CODE}" "200" "public koduck-user route should succeed via APISIX"
+
+ME_USER_ID="$(jq -r '.data.id' /tmp/e2e-users-me.json)"
+ME_USERNAME="$(jq -r '.data.username' /tmp/e2e-users-me.json)"
+if [[ "${ME_USER_ID}" != "${CLAIM_USER_ID}" || "${ME_USERNAME}" != "${CLAIM_USERNAME}" ]]; then
+  echo "ERROR: /api/v1/users/me response does not match JWT claims" >&2
+  cat /tmp/e2e-users-me.json >&2 || true
+  exit 1
+fi
+log "public user route matched jwt user identity"
 
 NO_KEY_CODE="$(curl --noproxy '*' -sS -o /tmp/e2e-internal-nokey.json -w '%{http_code}' \
   "${APISIX_BASE_URL}/internal/users/by-username/${USERNAME}")"
@@ -53,8 +126,16 @@ log "internal wrong key -> 401 passed"
 
 GOOD_KEY_CODE="$(curl --noproxy '*' -sS -o /tmp/e2e-internal-ok.json -w '%{http_code}' \
   -H "apikey: ${INTERNAL_API_KEY_USER}" \
+  -H "X-Tenant-Id: ${CLAIM_TENANT_ID}" \
   "${APISIX_BASE_URL}/internal/users/by-username/${USERNAME}")"
 assert_http_code "${GOOD_KEY_CODE}" "200" "internal API should accept valid apikey"
 log "internal valid key -> 200 passed"
+
+WRONG_TENANT_CODE="$(curl --noproxy '*' -sS -o /tmp/e2e-internal-wrongtenant.json -w '%{http_code}' \
+  -H "apikey: ${INTERNAL_API_KEY_USER}" \
+  -H "X-Tenant-Id: tenant-other" \
+  "${APISIX_BASE_URL}/internal/users/by-username/${USERNAME}")"
+assert_http_code "${WRONG_TENANT_CODE}" "404" "internal API should isolate users by tenant"
+log "internal wrong tenant -> 404 passed"
 
 log "All APISIX e2e smoke checks passed."


### PR DESCRIPTION
## Summary
- verify tenant propagation across koduck-auth, APISIX, and koduck-user
- align APISIX dev route init with explicit user public/internal routes and RS256 consumer config
- add repeatable e2e coverage plus JWT fallback context parsing in koduck-user

## Validation
- mvn -f koduck-user/pom.xml -Dtest=UserContextTest test
- docker build -t koduck-auth:dev ./koduck-auth
- docker build -t koduck-user:dev ./koduck-user
- kubectl rollout restart/status deployment/dev-koduck-auth -n koduck-dev
- kubectl rollout restart/status deployment/dev-koduck-user -n koduck-dev
- kubectl apply/wait/logs for dev-apisix-route-init job in koduck-dev
- scripts/e2e-koduck-user-apisix.sh

Closes #784