### PR TITLE
feat(memory): bootstrap minio object storage in dev

### DIFF
--- a/docs/implementation/koduck-memory-koduck-ai-tasks.md
+++ b/docs/implementation/koduck-memory-koduck-ai-tasks.md
@@ -73,9 +73,9 @@
 3. 为服务配置对象存储 secret 与 endpoint
 
 **验收标准:**
-- [ ] dev 环境存在可用 MinIO
-- [ ] `koduck-memory` 可访问 bucket
-- [ ] L0 对象存储前置基础就绪
+- [x] dev 环境存在可用 MinIO
+- [x] `koduck-memory` 可访问 bucket
+- [x] L0 对象存储前置基础就绪
 
 ---
 

--- a/k8s/base/minio.yaml
+++ b/k8s/base/minio.yaml
@@ -1,0 +1,117 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio-secret
+  namespace: koduck
+type: Opaque
+stringData:
+  root-user: "minioadmin"
+  root-password: "minioadmin"
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: minio-data
+  namespace: koduck
+  labels:
+    app: minio
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 512Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+  namespace: koduck
+  labels:
+    app: minio
+spec:
+  type: ClusterIP
+  selector:
+    app: minio
+  ports:
+    - name: api
+      port: 9000
+      targetPort: api
+      protocol: TCP
+    - name: console
+      port: 9001
+      targetPort: console
+      protocol: TCP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+  namespace: koduck
+  labels:
+    app: minio
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: minio
+  template:
+    metadata:
+      labels:
+        app: minio
+    spec:
+      containers:
+        - name: minio
+          image: minio/minio:latest
+          imagePullPolicy: IfNotPresent
+          args:
+            - server
+            - /data
+            - --console-address
+            - ":9001"
+          ports:
+            - name: api
+              containerPort: 9000
+              protocol: TCP
+            - name: console
+              containerPort: 9001
+              protocol: TCP
+          env:
+            - name: MINIO_ROOT_USER
+              valueFrom:
+                secretKeyRef:
+                  name: minio-secret
+                  key: root-user
+            - name: MINIO_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: minio-secret
+                  key: root-password
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 300m
+              memory: 512Mi
+          volumeMounts:
+            - name: minio-data
+              mountPath: /data
+          livenessProbe:
+            httpGet:
+              path: /minio/health/live
+              port: api
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /minio/health/ready
+              port: api
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 3
+      volumes:
+        - name: minio-data
+          persistentVolumeClaim:
+            claimName: minio-data

--- a/k8s/overlays/dev/koduck-memory.yaml
+++ b/k8s/overlays/dev/koduck-memory.yaml
@@ -7,6 +7,26 @@ spec:
   replicas: 1
   template:
     spec:
+      initContainers:
+        - name: wait-for-object-store
+          image: minio/mc:latest
+          imagePullPolicy: IfNotPresent
+          envFrom:
+            - secretRef:
+                name: koduck-memory-secrets
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              until mc alias set objectstore "${OBJECT_STORE__ENDPOINT}" "${OBJECT_STORE__ACCESS_KEY}" "${OBJECT_STORE__SECRET_KEY}"; do
+                echo "waiting for object store endpoint ${OBJECT_STORE__ENDPOINT}"
+                sleep 2
+              done
+              until mc stat "objectstore/${OBJECT_STORE__BUCKET}"; do
+                echo "waiting for bucket ${OBJECT_STORE__BUCKET}"
+                sleep 2
+              done
       containers:
         - name: koduck-memory
           image: koduck-memory:dev

--- a/k8s/overlays/dev/kustomization.yaml
+++ b/k8s/overlays/dev/kustomization.yaml
@@ -10,9 +10,11 @@ resources:
   - ../../base/koduck-user.yaml
   - ../../base/koduck-ai.yaml
   - ../../base/koduck-memory.yaml
+  - ../../base/minio.yaml
   - ../../base/postgres.yaml
   - ../../base/redis.yaml
   - ./apisix.yaml
+  - ./minio.yaml
 
 patchesStrategicMerge:
   - ./frontend.yaml

--- a/k8s/overlays/dev/minio.yaml
+++ b/k8s/overlays/dev/minio.yaml
@@ -1,0 +1,47 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: minio-bucket-init
+  namespace: koduck
+  labels:
+    app: minio-bucket-init
+spec:
+  backoffLimit: 6
+  ttlSecondsAfterFinished: 300
+  template:
+    metadata:
+      labels:
+        app: minio-bucket-init
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: bucket-init
+          image: minio/mc:latest
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: MINIO_ENDPOINT
+              value: "http://dev-minio:9000"
+            - name: MINIO_BUCKET
+              value: "koduck-memory-dev"
+            - name: MINIO_ROOT_USER
+              valueFrom:
+                secretKeyRef:
+                  name: minio-secret
+                  key: root-user
+            - name: MINIO_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: minio-secret
+                  key: root-password
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              until mc alias set local "${MINIO_ENDPOINT}" "${MINIO_ROOT_USER}" "${MINIO_ROOT_PASSWORD}"; do
+                echo "waiting for minio endpoint ${MINIO_ENDPOINT}"
+                sleep 2
+              done
+              mc mb --ignore-existing "local/${MINIO_BUCKET}"
+              mc anonymous set none "local/${MINIO_BUCKET}" || true
+              mc stat "local/${MINIO_BUCKET}"

--- a/koduck-memory/docs/adr/0004-minio-bootstrap-and-bucket-init.md
+++ b/koduck-memory/docs/adr/0004-minio-bootstrap-and-bucket-init.md
@@ -1,0 +1,100 @@
+# ADR-0004: 为 koduck-memory 建立 MinIO bootstrap 与 bucket 初始化基线
+
+- Status: Accepted
+- Date: 2026-04-12
+- Issue: #794
+
+## Context
+
+Task 1.3 完成后，`koduck-memory` 已经具备 PostgreSQL readiness 与基础观测能力，但
+L0 原始材料依赖的对象存储仍停留在配置层，没有实际的 dev 基础设施承接：
+
+1. `koduck-dev` 中还没有可用的 MinIO pod / service / pvc。
+2. `OBJECT_STORE__ENDPOINT` 与 bucket 名称虽然已经进入配置，但 bucket 并不会自动初始化。
+3. 后续 Task 4.3 需要把原始记忆材料写入 S3 兼容对象存储，因此必须先把 dev 的对象存储基线建起来。
+
+Task 1.4 的目标不是实现 L0 写入逻辑，而是把对象存储基础设施、bucket 准备流程和服务侧
+可达性校验先稳定下来。
+
+## Decision
+
+### dev 环境使用 MinIO 作为 S3 兼容对象存储
+
+在 Kubernetes 中新增：
+
+1. `minio-secret`
+2. `minio-data` PVC
+3. `minio` Deployment
+4. `minio` Service
+
+MinIO 仅作为 dev bootstrap 基础设施使用，承接后续 L0 原始材料对象。
+
+### 使用 Job 进行 bucket 初始化
+
+新增 `minio-bucket-init` Job，使用 `minio/mc`：
+
+1. 等待 MinIO API 就绪
+2. 建立 `koduck-memory-dev` bucket
+3. 对 bucket 执行一次 `mc stat` 作为成功信号
+
+这样 bucket 初始化不依赖人工登录控制台，也不会耦合到 `koduck-memory` 镜像构建流程。
+
+### 在 koduck-memory 启动前校验 bucket 可访问
+
+为 `koduck-memory` Deployment 增加 `wait-for-object-store` initContainer，使用与
+主容器同一份 `koduck-memory-secrets`：
+
+1. 通过 `OBJECT_STORE__ENDPOINT`
+2. 使用 `OBJECT_STORE__ACCESS_KEY` / `OBJECT_STORE__SECRET_KEY`
+3. 对 `OBJECT_STORE__BUCKET` 执行 `mc stat`
+
+只有 bucket 可访问时主容器才会启动。这样 rollout 结果可以直接反映对象存储前置条件是否满足。
+
+## Consequences
+
+### 正向影响
+
+1. `koduck-dev` 现在具备可用的 S3 兼容对象存储，不再只是配置占位。
+2. bucket 初始化流程被显式固化为 Job，后续新环境 bootstrap 更简单。
+3. `koduck-memory` 的 rollout 现在会把对象存储可达性纳入启动前校验，降低后续 L0 写入前置风险。
+
+### 权衡与代价
+
+1. 本阶段仍使用单副本 MinIO，只满足 dev 与 bootstrap 诉求，不代表生产级对象存储设计。
+2. `minio/mc:latest` 用于快速建立 bootstrap 能力，后续可以再收敛到固定 digest。
+3. bucket 初始化仍是一次性 Job；如果未来清空 PVC，需要重新触发 Job 或重建资源。
+
+### 兼容性影响
+
+1. `koduck-dev` 新增 `dev-minio` Service 与对应 PVC，会占用额外本地磁盘。
+2. `koduck-memory` Pod 新增 initContainer，因此对象存储不可用时会停留在初始化阶段而不是直接启动成功。
+
+## Alternatives Considered
+
+### 1. 在 koduck-memory 应用启动后再按需创建 bucket
+
+- 未采用理由：会把基础设施准备与业务写路径耦合在一起，不利于明确 bootstrap 责任边界。
+
+### 2. 仅增加 MinIO Deployment，不提供 bucket 初始化流程
+
+- 未采用理由：后续仍需手工创建 bucket，容易让 dev 环境出现“服务在、bucket 不在”的半完成状态。
+
+### 3. 直接在本阶段接入正式云 S3
+
+- 未采用理由：Task 1.4 面向 dev 基础设施，优先需要的是本地可重复 bootstrap，而不是正式云依赖。
+
+## Verification
+
+- `docker build -t koduck-memory:dev ./koduck-memory`
+- `kubectl apply --validate=false -f /tmp/koduck-dev-rendered-task1-4.yaml`
+- `kubectl rollout status deployment/dev-minio -n koduck-dev`
+- `kubectl wait --for=condition=complete job/dev-minio-bucket-init -n koduck-dev --timeout=180s`
+- `kubectl rollout status deployment/dev-koduck-memory -n koduck-dev --timeout=180s`
+- `kubectl logs job/dev-minio-bucket-init -n koduck-dev`
+
+## References
+
+- 设计文档: [koduck-memory-for-koduck-ai.md](../../../docs/design/koduck-memory-for-koduck-ai.md)
+- 任务清单: [koduck-memory-koduck-ai-tasks.md](../../../docs/implementation/koduck-memory-koduck-ai-tasks.md)
+- 前序 ADR: [0003-postgres-readiness-and-observability.md](./0003-postgres-readiness-and-observability.md)
+- Issue: [#794](https://github.com/hailingu/koduck-quant/issues/794)


### PR DESCRIPTION
## Summary
- add a dev MinIO deployment, service, secret, and PVC as the object-store bootstrap baseline
- add a bucket initialization job and a koduck-memory init container that blocks startup until the configured bucket is accessible
- add ADR-0004 and mark Task 1.4 complete in the implementation checklist

## Verification
- docker build -t koduck-memory:dev ./koduck-memory
- kubectl apply --validate=false -f /tmp/koduck-dev-rendered-task1-4.yaml
- kubectl rollout status deployment/dev-minio -n koduck-dev --timeout=180s
- kubectl wait --for=condition=complete job/dev-minio-bucket-init -n koduck-dev --timeout=180s
- kubectl rollout status deployment/dev-koduck-memory -n koduck-dev --timeout=180s
- kubectl logs job/dev-minio-bucket-init -n koduck-dev
- kubectl logs pod/dev-koduck-memory-57bc959579-mrdnp -c wait-for-object-store -n koduck-dev

Closes #794