### PR TITLE
feat(memory): freeze memory v1 contract

### DIFF
--- a/docs/design/koduck-memory-for-koduck-ai.md
+++ b/docs/design/koduck-memory-for-koduck-ai.md
@@ -139,14 +139,16 @@ V1 契约基于 `memory.v1`，入口包括：
 - `request_id`
 - `session_id`
 - `user_id`
+- `tenant_id`
 - `trace_id`
 - `deadline_ms`
 - `api_version`
-- `idempotency_key`（写操作建议必填）
+- `idempotency_key`（`UpsertSessionMeta` / `AppendMemory` / `SummarizeMemory` 必填）
 
 语义要求：
 
 - `request_id` 用于日志、错误回传与幂等追踪
+- `session_id` / `tenant_id` / `user_id` 共同限定会话与租户上下文
 - `trace_id` 用于链路观测
 - `deadline_ms` 必须向内部存储和异步任务调度传播
 - `idempotency_key` 用于抵御上游 retry 导致的重复写入

--- a/docs/implementation/koduck-memory-koduck-ai-tasks.md
+++ b/docs/implementation/koduck-memory-koduck-ai-tasks.md
@@ -94,8 +94,8 @@
 3. 预留可扩展 protobuf tag
 
 **验收标准:**
-- [ ] `memory.v1` 明确为长期 southbound contract
-- [ ] proto 编号与语义评审通过
+- [x] `memory.v1` 明确为长期 southbound contract
+- [x] proto 编号与语义评审通过
 
 ### Task 2.2: 生成 server/client stub
 **详细要求:**

--- a/koduck-ai/proto/koduck/contract/v1/shared.proto
+++ b/koduck-ai/proto/koduck/contract/v1/shared.proto
@@ -4,14 +4,21 @@ package koduck.contract.v1;
 option go_package = "github.com/hailingu/koduck-quant/proto/koduck/contract/v1;contractv1";
 
 message RequestMeta {
+  // Required for every memory.v1 RPC in the long-lived southbound contract.
   string request_id = 1;
   string session_id = 2;
   string user_id = 3;
   string tenant_id = 4;
   string trace_id = 5;
+  // Required for write-like operations such as UpsertSessionMeta, AppendMemory,
+  // and SummarizeMemory task submission.
   string idempotency_key = 6;
   int64 deadline_ms = 7;
   string api_version = 8;
+
+  // Reserve a small block so future metadata can evolve without destabilizing
+  // the first frozen tag layout.
+  reserved 9 to 19;
 }
 
 message ErrorDetail {

--- a/koduck-ai/proto/koduck/memory/v1/memory.proto
+++ b/koduck-ai/proto/koduck/memory/v1/memory.proto
@@ -7,6 +7,9 @@ import "koduck/contract/v1/shared.proto";
 option go_package = "github.com/hailingu/koduck-quant/proto/koduck/memory/v1;memoryv1";
 
 // MemoryService — 会话记忆管理服务（first-class service contract）
+//
+// This proto is the frozen long-lived southbound contract between koduck-ai
+// and koduck-memory for V1. Existing tag numbers must remain stable.
 service MemoryService {
   // 能力发现与版本协商
   rpc GetCapabilities(koduck.contract.v1.RequestMeta) returns (koduck.contract.v1.Capability);
@@ -35,6 +38,11 @@ message UpsertSessionMetaRequest {
   string title = 3;
   string status = 4;
   map<string, string> extra = 5;
+  string parent_session_id = 6;
+  string forked_from_session_id = 7;
+  int64 last_message_at = 8;
+
+  reserved 9 to 19;
 }
 
 message UpsertSessionMetaResponse {
@@ -47,6 +55,8 @@ message UpsertSessionMetaResponse {
 message GetSessionRequest {
   koduck.contract.v1.RequestMeta meta = 1;
   string session_id = 2;
+
+  reserved 3 to 19;
 }
 
 message GetSessionResponse {
@@ -61,11 +71,13 @@ message QueryMemoryRequest {
   koduck.contract.v1.RequestMeta meta = 1;
   string query_text = 2;
   string session_id = 3;
-  repeated string tags = 4;
+  string domain_class = 4;
   int32 top_k = 5;
   RetrievePolicy retrieve_policy = 6;
   string page_token = 7;
   int32 page_size = 8;
+
+  reserved 9 to 19;
 }
 
 message QueryMemoryResponse {
@@ -81,6 +93,8 @@ message AppendMemoryRequest {
   koduck.contract.v1.RequestMeta meta = 1;
   string session_id = 2;
   repeated MemoryEntry entries = 3;
+
+  reserved 4 to 19;
 }
 
 message AppendMemoryResponse {
@@ -95,6 +109,8 @@ message SummarizeMemoryRequest {
   koduck.contract.v1.RequestMeta meta = 1;
   string session_id = 2;
   string strategy = 3;
+
+  reserved 4 to 19;
 }
 
 message SummarizeMemoryResponse {
@@ -108,12 +124,18 @@ message SummarizeMemoryResponse {
 // 会话信息
 message SessionInfo {
   string session_id = 1;
-  string title = 2;
-  string status = 3;
-  int64 created_at = 4;
-  int64 updated_at = 5;
-  int64 last_message_at = 6;
-  map<string, string> extra = 7;
+  string tenant_id = 2;
+  string user_id = 3;
+  string parent_session_id = 4;
+  string forked_from_session_id = 5;
+  string title = 6;
+  string status = 7;
+  int64 created_at = 8;
+  int64 updated_at = 9;
+  int64 last_message_at = 10;
+  map<string, string> extra = 11;
+
+  reserved 12 to 19;
 }
 
 // 记忆检索命中结果
@@ -123,6 +145,8 @@ message MemoryHit {
   float score = 3;
   repeated string match_reasons = 4;
   string snippet = 5;
+
+  reserved 6 to 19;
 }
 
 // 记忆条目
@@ -131,6 +155,8 @@ message MemoryEntry {
   string content = 2;
   int64 timestamp = 3;
   map<string, string> metadata = 4;
+
+  reserved 5 to 19;
 }
 
 // ==================== Enums ====================
@@ -138,7 +164,9 @@ message MemoryEntry {
 // 记忆检索策略
 enum RetrievePolicy {
   RETRIEVE_POLICY_UNSPECIFIED = 0;
-  RETRIEVE_POLICY_KEYWORD_FIRST = 1;
+  RETRIEVE_POLICY_DOMAIN_FIRST = 1;
   RETRIEVE_POLICY_SUMMARY_FIRST = 2;
   RETRIEVE_POLICY_HYBRID = 3;
+
+  reserved 4 to 19;
 }

--- a/koduck-memory/docs/adr/0005-freeze-memory-v1-contract.md
+++ b/koduck-memory/docs/adr/0005-freeze-memory-v1-contract.md
@@ -1,0 +1,129 @@
+# ADR-0005: 冻结 memory.v1 southbound contract
+
+- Status: Accepted
+- Date: 2026-04-12
+- Issue: #796
+
+## Context
+
+Task 2.1 的目标是把 `koduck-ai` 与 `koduck-memory` 之间的 `memory.v1` southbound contract
+从“可工作的初稿”收敛为“后续阶段可以持续依赖的长期契约”。
+
+在本次冻结前，proto 仍有几个明显问题：
+
+1. `QueryMemory` 仍保留 `tags` 与 `KEYWORD_FIRST` 语义，但设计文档已经定稿为
+   `domain_class` 与 `DOMAIN_FIRST`。
+2. 会话链路字段如 `parent_session_id`、`forked_from_session_id`、`tenant_id`、`user_id`
+   还没有完整进入 message 结构。
+3. `RequestMeta` 里的必填约束没有在契约注释与服务校验中明确下来。
+4. proto 没有预留明确扩展位，后续继续演化容易破坏 tag 稳定性。
+
+Task 2.2 之后会基于这份契约生成 stub，Task 3/4/5 会继续在这个 tag 布局上实现真实语义，
+所以本阶段必须先把编号、字段语义和默认检索策略定稳。
+
+## Decision
+
+### 将 memory.v1 明确为长期 southbound contract
+
+在 `koduck-ai/proto` 与 `koduck-memory/proto` 两处 proto 中增加冻结说明，明确：
+
+1. `memory.v1` 是 `koduck-ai -> koduck-memory` 的长期 southbound contract
+2. 现有 tag 编号在 V1 生命周期内保持稳定
+3. 扩展优先使用已预留的 tag 段，而不是重排既有字段
+
+### 对齐 QueryMemory 的 V1 语义
+
+把 `QueryMemoryRequest` 中的 `tags` 改为 `domain_class`，并把检索策略枚举改为：
+
+1. `RETRIEVE_POLICY_DOMAIN_FIRST`
+2. `RETRIEVE_POLICY_SUMMARY_FIRST`
+3. `RETRIEVE_POLICY_HYBRID`
+
+不再把 `KEYWORD_FIRST` 保留为 V1 正式语义，避免和设计文档冲突。
+
+### 补齐会话真值与 lineage 相关字段
+
+在 `UpsertSessionMetaRequest` / `SessionInfo` 中显式冻结以下字段：
+
+1. `tenant_id`
+2. `user_id`
+3. `parent_session_id`
+4. `forked_from_session_id`
+5. `last_message_at`
+
+这样 Task 3 的 session truth 实现可以直接基于稳定字段展开。
+
+### 明确 RequestMeta 必填规则
+
+将以下字段明确为所有 `memory.v1` RPC 的基础必填项：
+
+1. `request_id`
+2. `session_id`
+3. `user_id`
+4. `tenant_id`
+5. `trace_id`
+6. `deadline_ms`
+7. `api_version`
+
+同时把 `idempotency_key` 明确为 `UpsertSessionMeta`、`AppendMemory`、
+`SummarizeMemory` 这类写/任务投递路径的必填项，并在 `koduck-memory` 的 skeleton
+校验逻辑中同步执行。
+
+### 为 V1 预留扩展 tag
+
+在 `RequestMeta` 和各个关键 message / enum 中预留小范围 tag 段，给后续：
+
+1. more retrieval filters
+2. richer memory metadata
+3. backward-compatible capability expansion
+
+留下演进空间，而不破坏已冻结布局。
+
+## Consequences
+
+### 正向影响
+
+1. Task 2.2 生成的 server/client stub 将基于更稳定的字段布局。
+2. Task 3 的 session truth 和 lineage 语义不再依赖临时字段或额外解释。
+3. `QueryMemory` 的默认路径正式切换为设计定稿的 `DOMAIN_FIRST`。
+4. `RequestMeta` 校验范围更明确，后续错误语义更容易统一。
+
+### 权衡与代价
+
+1. 这是一次 pre-freeze 的 breaking alignment，会让当前早期 proto 与最初 skeleton 有差异。
+2. 仓库中 `koduck-ai` 与 `koduck-memory` 双份 proto 需要保持同步，短期内有维护成本。
+3. 目前只是冻结字段与语义，不代表业务实现已经完成；真实功能仍由后续任务承接。
+
+### 兼容性影响
+
+1. `RETRIEVE_POLICY_KEYWORD_FIRST` 不再作为 `memory.v1` 的正式 V1 策略。
+2. `QueryMemoryRequest.tags` 被 `domain_class` 取代，后续调用方必须按新字段语义生成请求。
+3. 写路径缺少 `idempotency_key` 时，`koduck-memory` skeleton 会更早返回参数错误。
+
+## Alternatives Considered
+
+### 1. 保持当前 proto 不动，只在 ADR 中声明真实语义
+
+- 未采用理由：字段和设计分离会把 Task 2.2 之后的 stub 建立在错误契约上。
+
+### 2. 等 Task 3/4 开始实现时再一起修 proto
+
+- 未采用理由：那时会把契约冻结与业务实现耦合，回滚和评审成本更高。
+
+### 3. 只更新 koduck-memory 本地 proto，不同步 koduck-ai
+
+- 未采用理由：会让 southbound 调用方和服务端对同一契约拥有不同事实来源。
+
+## Verification
+
+- `docker build -t koduck-memory:dev ./koduck-memory`
+- `kubectl rollout restart deployment/dev-koduck-memory -n koduck-dev`
+- `kubectl rollout status deployment/dev-koduck-memory -n koduck-dev --timeout=180s`
+- `kubectl logs deployment/dev-koduck-memory -n koduck-dev`
+
+## References
+
+- 设计文档: [koduck-memory-for-koduck-ai.md](../../../docs/design/koduck-memory-for-koduck-ai.md)
+- 任务清单: [koduck-memory-koduck-ai-tasks.md](../../../docs/implementation/koduck-memory-koduck-ai-tasks.md)
+- 前序 ADR: [0004-minio-bootstrap-and-bucket-init.md](./0004-minio-bootstrap-and-bucket-init.md)
+- Issue: [#796](https://github.com/hailingu/koduck-quant/issues/796)

--- a/koduck-memory/proto/koduck/contract/v1/shared.proto
+++ b/koduck-memory/proto/koduck/contract/v1/shared.proto
@@ -4,14 +4,21 @@ package koduck.contract.v1;
 option go_package = "github.com/hailingu/koduck-quant/proto/koduck/contract/v1;contractv1";
 
 message RequestMeta {
+  // Required for every memory.v1 RPC in the long-lived southbound contract.
   string request_id = 1;
   string session_id = 2;
   string user_id = 3;
   string tenant_id = 4;
   string trace_id = 5;
+  // Required for write-like operations such as UpsertSessionMeta, AppendMemory,
+  // and SummarizeMemory task submission.
   string idempotency_key = 6;
   int64 deadline_ms = 7;
   string api_version = 8;
+
+  // Reserve a small block so future metadata can evolve without destabilizing
+  // the first frozen tag layout.
+  reserved 9 to 19;
 }
 
 message ErrorDetail {

--- a/koduck-memory/proto/koduck/memory/v1/memory.proto
+++ b/koduck-memory/proto/koduck/memory/v1/memory.proto
@@ -6,6 +6,8 @@ import "koduck/contract/v1/shared.proto";
 
 option go_package = "github.com/hailingu/koduck-quant/proto/koduck/memory/v1;memoryv1";
 
+// This proto is the frozen long-lived southbound contract between koduck-ai
+// and koduck-memory for V1. Existing tag numbers must remain stable.
 service MemoryService {
   rpc GetCapabilities(koduck.contract.v1.RequestMeta) returns (koduck.contract.v1.Capability);
   rpc UpsertSessionMeta(UpsertSessionMetaRequest) returns (UpsertSessionMetaResponse);
@@ -21,6 +23,11 @@ message UpsertSessionMetaRequest {
   string title = 3;
   string status = 4;
   map<string, string> extra = 5;
+  string parent_session_id = 6;
+  string forked_from_session_id = 7;
+  int64 last_message_at = 8;
+
+  reserved 9 to 19;
 }
 
 message UpsertSessionMetaResponse {
@@ -31,6 +38,8 @@ message UpsertSessionMetaResponse {
 message GetSessionRequest {
   koduck.contract.v1.RequestMeta meta = 1;
   string session_id = 2;
+
+  reserved 3 to 19;
 }
 
 message GetSessionResponse {
@@ -43,11 +52,13 @@ message QueryMemoryRequest {
   koduck.contract.v1.RequestMeta meta = 1;
   string query_text = 2;
   string session_id = 3;
-  repeated string tags = 4;
+  string domain_class = 4;
   int32 top_k = 5;
   RetrievePolicy retrieve_policy = 6;
   string page_token = 7;
   int32 page_size = 8;
+
+  reserved 9 to 19;
 }
 
 message QueryMemoryResponse {
@@ -61,6 +72,8 @@ message AppendMemoryRequest {
   koduck.contract.v1.RequestMeta meta = 1;
   string session_id = 2;
   repeated MemoryEntry entries = 3;
+
+  reserved 4 to 19;
 }
 
 message AppendMemoryResponse {
@@ -73,6 +86,8 @@ message SummarizeMemoryRequest {
   koduck.contract.v1.RequestMeta meta = 1;
   string session_id = 2;
   string strategy = 3;
+
+  reserved 4 to 19;
 }
 
 message SummarizeMemoryResponse {
@@ -83,12 +98,18 @@ message SummarizeMemoryResponse {
 
 message SessionInfo {
   string session_id = 1;
-  string title = 2;
-  string status = 3;
-  int64 created_at = 4;
-  int64 updated_at = 5;
-  int64 last_message_at = 6;
-  map<string, string> extra = 7;
+  string tenant_id = 2;
+  string user_id = 3;
+  string parent_session_id = 4;
+  string forked_from_session_id = 5;
+  string title = 6;
+  string status = 7;
+  int64 created_at = 8;
+  int64 updated_at = 9;
+  int64 last_message_at = 10;
+  map<string, string> extra = 11;
+
+  reserved 12 to 19;
 }
 
 message MemoryHit {
@@ -97,6 +118,8 @@ message MemoryHit {
   float score = 3;
   repeated string match_reasons = 4;
   string snippet = 5;
+
+  reserved 6 to 19;
 }
 
 message MemoryEntry {
@@ -104,11 +127,15 @@ message MemoryEntry {
   string content = 2;
   int64 timestamp = 3;
   map<string, string> metadata = 4;
+
+  reserved 5 to 19;
 }
 
 enum RetrievePolicy {
   RETRIEVE_POLICY_UNSPECIFIED = 0;
-  RETRIEVE_POLICY_KEYWORD_FIRST = 1;
+  RETRIEVE_POLICY_DOMAIN_FIRST = 1;
   RETRIEVE_POLICY_SUMMARY_FIRST = 2;
   RETRIEVE_POLICY_HYBRID = 3;
+
+  reserved 4 to 19;
 }

--- a/koduck-memory/src/capability/service.rs
+++ b/koduck-memory/src/capability/service.rs
@@ -66,8 +66,31 @@ impl MemoryGrpcService {
         if meta.request_id.trim().is_empty() {
             return Err(Status::invalid_argument("request_id is required"));
         }
+        if meta.session_id.trim().is_empty() {
+            return Err(Status::invalid_argument("session_id is required"));
+        }
+        if meta.user_id.trim().is_empty() {
+            return Err(Status::invalid_argument("user_id is required"));
+        }
+        if meta.tenant_id.trim().is_empty() {
+            return Err(Status::invalid_argument("tenant_id is required"));
+        }
         if meta.trace_id.trim().is_empty() {
             return Err(Status::invalid_argument("trace_id is required"));
+        }
+        if meta.deadline_ms <= 0 {
+            return Err(Status::invalid_argument("deadline_ms must be greater than 0"));
+        }
+        if meta.api_version.trim().is_empty() {
+            return Err(Status::invalid_argument("api_version is required"));
+        }
+        Ok(())
+    }
+
+    fn validate_write_meta(meta: &RequestMeta) -> Result<(), Status> {
+        Self::validate_meta(meta)?;
+        if meta.idempotency_key.trim().is_empty() {
+            return Err(Status::invalid_argument("idempotency_key is required"));
         }
         Ok(())
     }
@@ -87,7 +110,7 @@ impl MemoryService for MemoryGrpcService {
         &self,
         request: Request<UpsertSessionMetaRequest>,
     ) -> Result<Response<UpsertSessionMetaResponse>, Status> {
-        Self::validate_meta(request.get_ref().meta.as_ref().ok_or_else(|| {
+        Self::validate_write_meta(request.get_ref().meta.as_ref().ok_or_else(|| {
             Status::invalid_argument("meta is required")
         })?)?;
         Ok(Response::new(UpsertSessionMetaResponse {
@@ -129,7 +152,7 @@ impl MemoryService for MemoryGrpcService {
         &self,
         request: Request<AppendMemoryRequest>,
     ) -> Result<Response<AppendMemoryResponse>, Status> {
-        Self::validate_meta(request.get_ref().meta.as_ref().ok_or_else(|| {
+        Self::validate_write_meta(request.get_ref().meta.as_ref().ok_or_else(|| {
             Status::invalid_argument("meta is required")
         })?)?;
         Ok(Response::new(AppendMemoryResponse {
@@ -143,7 +166,7 @@ impl MemoryService for MemoryGrpcService {
         &self,
         request: Request<SummarizeMemoryRequest>,
     ) -> Result<Response<SummarizeMemoryResponse>, Status> {
-        Self::validate_meta(request.get_ref().meta.as_ref().ok_or_else(|| {
+        Self::validate_write_meta(request.get_ref().meta.as_ref().ok_or_else(|| {
             Status::invalid_argument("meta is required")
         })?)?;
         Ok(Response::new(SummarizeMemoryResponse {
@@ -154,5 +177,46 @@ impl MemoryService for MemoryGrpcService {
             ),
             error: Self::not_implemented_error("SummarizeMemory"),
         }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::MemoryGrpcService;
+    use crate::api::proto::contract::RequestMeta;
+
+    fn valid_meta() -> RequestMeta {
+        RequestMeta {
+            request_id: "req-1".to_string(),
+            session_id: "session-1".to_string(),
+            user_id: "user-1".to_string(),
+            tenant_id: "tenant-1".to_string(),
+            trace_id: "trace-1".to_string(),
+            idempotency_key: "idem-1".to_string(),
+            deadline_ms: 5000,
+            api_version: "memory.v1".to_string(),
+        }
+    }
+
+    #[test]
+    fn validate_meta_rejects_missing_tenant_id() {
+        let mut meta = valid_meta();
+        meta.tenant_id.clear();
+
+        let error = MemoryGrpcService::validate_meta(&meta).unwrap_err();
+
+        assert_eq!(error.code(), tonic::Code::InvalidArgument);
+        assert_eq!(error.message(), "tenant_id is required");
+    }
+
+    #[test]
+    fn validate_write_meta_requires_idempotency_key() {
+        let mut meta = valid_meta();
+        meta.idempotency_key.clear();
+
+        let error = MemoryGrpcService::validate_write_meta(&meta).unwrap_err();
+
+        assert_eq!(error.code(), tonic::Code::InvalidArgument);
+        assert_eq!(error.message(), "idempotency_key is required");
     }
 }


### PR DESCRIPTION
## Summary
- freeze the memory.v1 southbound contract and align the proto with the design doc semantics
- make RequestMeta required-field rules explicit and reserve protobuf extension ranges for V1 evolution
- tighten koduck-memory skeleton validation, add ADR-0005, and mark Task 2.1 complete

## Verification
- docker run --rm -v /Users/guhailin/Git/koduck-quant/.worktrees/feature-koduck-memory-task2-1/koduck-memory:/app -w /app docker.m.daocloud.io/library/rust:1.88-slim-bookworm bash -lc "apt-get update >/dev/null && apt-get install -y protobuf-compiler >/dev/null && /usr/local/cargo/bin/cargo test"
- docker build -t koduck-memory:dev ./koduck-memory
- kubectl rollout restart deployment/dev-koduck-memory -n koduck-dev
- kubectl rollout status deployment/dev-koduck-memory -n koduck-dev --timeout=180s
- kubectl logs pod/dev-koduck-memory-7df9589b54-zsrjd -n koduck-dev

Closes #796