### PR TITLE
feat(memory): unify generated stub exposure

### DIFF
--- a/docs/implementation/koduck-memory-koduck-ai-tasks.md
+++ b/docs/implementation/koduck-memory-koduck-ai-tasks.md
@@ -104,8 +104,8 @@
 3. proto 变更可触发重编译
 
 **验收标准:**
-- [ ] server/client stub 生成成功
-- [ ] 空 server 可注册启动
+- [x] server/client stub 生成成功
+- [x] 空 server 可注册启动
 
 ### Task 2.3: 数据库 migration 基线
 **详细要求:**

--- a/koduck-memory/Cargo.lock
+++ b/koduck-memory/Cargo.lock
@@ -1029,6 +1029,7 @@ dependencies = [
  "sqlx",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "toml",
  "tonic",
  "tonic-build",

--- a/koduck-memory/Cargo.toml
+++ b/koduck-memory/Cargo.toml
@@ -24,6 +24,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "time"
 thiserror = "1.0"
 anyhow = "1.0"
 sqlx = { version = "0.7", features = ["runtime-tokio-rustls", "postgres"] }
+tokio-stream = { version = "0.1", features = ["net"] }
 
 [build-dependencies]
 tonic-build = "0.11"

--- a/koduck-memory/docs/adr/0006-generated-stub-exposure-and-startup-verification.md
+++ b/koduck-memory/docs/adr/0006-generated-stub-exposure-and-startup-verification.md
@@ -1,0 +1,108 @@
+# ADR-0006: 统一暴露 generated stubs 并验证空 server 可启动
+
+- Status: Accepted
+- Date: 2026-04-12
+- Issue: #798
+
+## Context
+
+Task 2.1 已经冻结了 `memory.v1` southbound contract，但 Task 2.2 要解决的是另外一层问题：
+
+1. `tonic-build` 虽然已经在工作，但生成结果仍主要通过 `include_proto!` 的内部路径被零散引用。
+2. server/client message types 没有统一的对外暴露入口，调用方需要知道较深的 generated module 结构。
+3. 当前没有直接证明“空 server 使用生成的 stubs 可以注册并启动”的测试。
+
+在进入 Task 2.4 和后续 `koduck-ai -> koduck-memory` 集成前，需要先把 generated stub 的
+使用入口和启动基线稳定下来。
+
+## Decision
+
+### 继续使用 tonic-build 作为 stub 生成器
+
+保留现有 `build.rs` 的 `tonic-build` 方案，继续生成：
+
+1. contract stubs
+2. memory service stubs
+3. file descriptor set
+
+同时保留 `cargo:rerun-if-changed=proto/...` 声明，确保 proto 变更会触发重编译。
+
+### 在 api 层提供统一暴露入口
+
+新增：
+
+1. `api::contract`
+2. `api::memory`
+
+并在 `api::mod` 中统一 re-export：
+
+1. request / response messages
+2. `MemoryServiceClient`
+3. `MemoryServiceServer`
+4. `MemoryService` trait
+5. `FILE_DESCRIPTOR_SET`
+
+这样调用侧只依赖 `crate::api::...`，不必直接耦合 `include_proto!` 生成路径。
+
+### 用启动测试验证空 server 可注册
+
+新增异步测试：
+
+1. 在临时端口上启动 `MemoryServiceServer`
+2. 用 `MemoryServiceClient` 建连
+3. 调用 `GetCapabilities`
+4. 验证 service / contract version / default retrieve policy
+
+这条测试证明：
+
+1. generated server stub 可注册
+2. generated client stub 可调用
+3. 当前空骨架服务可完成最小启动闭环
+
+## Consequences
+
+### 正向影响
+
+1. generated stubs 的使用入口更稳定，后续模块不必再感知 generated namespace 细节。
+2. Task 2.4 和 Task 6.1 在接入时可以直接依赖统一的 `api` 模块。
+3. “空 server 可注册启动”从隐含事实变成了明确测试保障。
+
+### 权衡与代价
+
+1. `api` 层增加了一层轻量 re-export，模块数稍微变多。
+2. 为了做启动测试，引入了 `tokio-stream` 的 `net` feature。
+3. 测试仍是最小闭环，只验证 stub 注册与调用，不覆盖真实业务实现。
+
+### 兼容性影响
+
+1. 现有内部引用路径从 `api::proto::memory::...` 收敛到 `api::...`，属于仓内实现整理。
+2. 对外 southbound contract 本身没有新增 breaking change。
+
+## Alternatives Considered
+
+### 1. 保持直接引用 include_proto! 生成路径
+
+- 未采用理由：generated namespace 对调用方暴露过深，不利于后续重构和统一使用方式。
+
+### 2. 只依赖编译成功，不增加启动测试
+
+- 未采用理由：编译通过并不能直接证明 server/client stubs 能组成最小运行闭环。
+
+### 3. 把生成代码手动写入仓库
+
+- 未采用理由：会增加 generated artifact 维护成本，也违背当前 `tonic-build` 流程。
+
+## Verification
+
+- `docker run --rm ... cargo test`
+- `docker build -t koduck-memory:dev ./koduck-memory`
+- `kubectl rollout restart deployment/dev-koduck-memory -n koduck-dev`
+- `kubectl rollout status deployment/dev-koduck-memory -n koduck-dev --timeout=180s`
+- `kubectl logs deployment/dev-koduck-memory -n koduck-dev`
+
+## References
+
+- 设计文档: [koduck-memory-for-koduck-ai.md](../../../docs/design/koduck-memory-for-koduck-ai.md)
+- 任务清单: [koduck-memory-koduck-ai-tasks.md](../../../docs/implementation/koduck-memory-koduck-ai-tasks.md)
+- 前序 ADR: [0005-freeze-memory-v1-contract.md](./0005-freeze-memory-v1-contract.md)
+- Issue: [#798](https://github.com/hailingu/koduck-quant/issues/798)

--- a/koduck-memory/src/api/contract.rs
+++ b/koduck-memory/src/api/contract.rs
@@ -1,0 +1,1 @@
+pub use super::proto::contract::{Capability, ErrorDetail, RequestMeta};

--- a/koduck-memory/src/api/memory.rs
+++ b/koduck-memory/src/api/memory.rs
@@ -1,0 +1,8 @@
+pub use super::proto::memory::memory_service_client::MemoryServiceClient;
+pub use super::proto::memory::memory_service_server::{MemoryService, MemoryServiceServer};
+pub use super::proto::memory::{
+    AppendMemoryRequest, AppendMemoryResponse, GetSessionRequest, GetSessionResponse, MemoryEntry,
+    MemoryHit, QueryMemoryRequest, QueryMemoryResponse, RetrievePolicy, SessionInfo,
+    SummarizeMemoryRequest, SummarizeMemoryResponse, UpsertSessionMetaRequest,
+    UpsertSessionMetaResponse,
+};

--- a/koduck-memory/src/api/mod.rs
+++ b/koduck-memory/src/api/mod.rs
@@ -1,1 +1,13 @@
+pub mod contract;
+pub mod memory;
 pub mod proto;
+
+pub use contract::{Capability, ErrorDetail, RequestMeta};
+pub use memory::{
+    AppendMemoryRequest, AppendMemoryResponse, GetSessionRequest, GetSessionResponse,
+    MemoryEntry, MemoryHit, MemoryService, MemoryServiceClient, MemoryServiceServer,
+    QueryMemoryRequest, QueryMemoryResponse, RetrievePolicy, SessionInfo,
+    SummarizeMemoryRequest, SummarizeMemoryResponse, UpsertSessionMetaRequest,
+    UpsertSessionMetaResponse,
+};
+pub use proto::FILE_DESCRIPTOR_SET;

--- a/koduck-memory/src/app/lifecycle.rs
+++ b/koduck-memory/src/app/lifecycle.rs
@@ -5,10 +5,7 @@ use tokio::sync::broadcast;
 use tonic::transport::Server;
 use tracing::{error, info};
 
-use crate::api::proto::{
-    memory::memory_service_server::MemoryServiceServer,
-    FILE_DESCRIPTOR_SET,
-};
+use crate::api::{MemoryServiceServer, FILE_DESCRIPTOR_SET};
 use crate::capability::MemoryGrpcService;
 use crate::config::AppConfig;
 use crate::observe;

--- a/koduck-memory/src/capability/service.rs
+++ b/koduck-memory/src/capability/service.rs
@@ -2,10 +2,9 @@ use std::collections::HashMap;
 
 use tonic::{Request, Response, Status};
 
-use crate::api::proto::contract::{Capability, ErrorDetail, RequestMeta};
-use crate::api::proto::memory::{
-    memory_service_server::MemoryService, AppendMemoryRequest, AppendMemoryResponse,
-    GetSessionRequest, GetSessionResponse, QueryMemoryRequest, QueryMemoryResponse,
+use crate::api::{
+    AppendMemoryRequest, AppendMemoryResponse, Capability, ErrorDetail, GetSessionRequest,
+    GetSessionResponse, MemoryService, QueryMemoryRequest, QueryMemoryResponse, RequestMeta,
     SummarizeMemoryRequest, SummarizeMemoryResponse, UpsertSessionMetaRequest,
     UpsertSessionMetaResponse,
 };
@@ -182,8 +181,17 @@ impl MemoryService for MemoryGrpcService {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use super::MemoryGrpcService;
-    use crate::api::proto::contract::RequestMeta;
+    use crate::api::{MemoryServiceClient, MemoryServiceServer, RequestMeta};
+    use crate::config::{
+        AppConfig, AppSection, CapabilitiesSection, IndexSection, ObjectStoreSection,
+        PostgresSection, ServerSection, SummarySection,
+    };
+    use tokio::net::TcpListener;
+    use tokio_stream::wrappers::TcpListenerStream;
+    use tonic::transport::{Channel, Server};
 
     fn valid_meta() -> RequestMeta {
         RequestMeta {
@@ -195,6 +203,35 @@ mod tests {
             idempotency_key: "idem-1".to_string(),
             deadline_ms: 5000,
             api_version: "memory.v1".to_string(),
+        }
+    }
+
+    fn test_config() -> AppConfig {
+        AppConfig {
+            app: AppSection {
+                name: "koduck-memory".to_string(),
+                version: "0.1.0".to_string(),
+                env: "test".to_string(),
+            },
+            server: ServerSection {
+                grpc_addr: "127.0.0.1:50051".to_string(),
+                metrics_addr: "127.0.0.1:9090".to_string(),
+            },
+            postgres: PostgresSection {
+                dsn: "postgresql://ignored:ignored@localhost:5432/postgres".to_string(),
+            },
+            object_store: ObjectStoreSection {
+                endpoint: "http://127.0.0.1:9000".to_string(),
+                bucket: "koduck-memory-test".to_string(),
+                access_key: "minioadmin".to_string(),
+                secret_key: "minioadmin".to_string(),
+                region: "ap-east-1".to_string(),
+            },
+            capabilities: CapabilitiesSection { ttl_secs: 60 },
+            summary: SummarySection { async_enabled: false },
+            index: IndexSection {
+                mode: "domain-first".to_string(),
+            },
         }
     }
 
@@ -218,5 +255,58 @@ mod tests {
 
         assert_eq!(error.code(), tonic::Code::InvalidArgument);
         assert_eq!(error.message(), "idempotency_key is required");
+    }
+
+    #[tokio::test]
+    async fn empty_server_can_register_and_start() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let incoming = TcpListenerStream::new(listener);
+        let service = MemoryGrpcService::from_config(&test_config());
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+
+        let server = tokio::spawn(async move {
+            Server::builder()
+                .add_service(MemoryServiceServer::new(service))
+                .serve_with_incoming_shutdown(incoming, async {
+                    let _ = shutdown_rx.await;
+                })
+                .await
+                .unwrap();
+        });
+
+        let endpoint = format!("http://{addr}");
+        let channel = Channel::from_shared(endpoint)
+            .unwrap()
+            .connect_timeout(Duration::from_secs(2))
+            .connect()
+            .await
+            .unwrap();
+        let mut client = MemoryServiceClient::new(channel);
+
+        let response = client
+            .get_capabilities(RequestMeta {
+                request_id: "req-1".to_string(),
+                session_id: "session-1".to_string(),
+                user_id: "user-1".to_string(),
+                tenant_id: "tenant-1".to_string(),
+                trace_id: "trace-1".to_string(),
+                idempotency_key: String::new(),
+                deadline_ms: 1000,
+                api_version: "memory.v1".to_string(),
+            })
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert_eq!(response.service, "memory");
+        assert_eq!(response.contract_versions, vec!["memory.v1".to_string()]);
+        assert_eq!(
+            response.features.get("retrieve_policy.default"),
+            Some(&"domain-first".to_string())
+        );
+
+        let _ = shutdown_tx.send(());
+        server.await.unwrap();
     }
 }


### PR DESCRIPTION
## Summary
- add unified api-level exports for generated contract and memory stubs
- add a startup test that proves the empty MemoryService server can register and respond through the generated client
- add ADR-0006, keep tonic-build as the source of truth, and mark Task 2.2 complete

## Verification
- docker run --rm -v /Users/guhailin/Git/koduck-quant/.worktrees/feature-koduck-memory-task2-2/koduck-memory:/app -w /app docker.m.daocloud.io/library/rust:1.88-slim-bookworm bash -lc "apt-get update >/dev/null && apt-get install -y protobuf-compiler >/dev/null && /usr/local/cargo/bin/cargo test"
- docker build -t koduck-memory:dev ./koduck-memory
- kubectl rollout restart deployment/dev-koduck-memory -n koduck-dev
- kubectl rollout status deployment/dev-koduck-memory -n koduck-dev --timeout=180s
- kubectl logs pod/dev-koduck-memory-79957cdc44-78w4b -n koduck-dev

Closes #798