### PR TITLE
feat(memory): implement AppendMemory for task 4.2

### DIFF
--- a/koduck-memory/docs/adr/0013-append-memory-implementation.md
+++ b/koduck-memory/docs/adr/0013-append-memory-implementation.md
@@ -1,0 +1,82 @@
+# ADR-0013: AppendMemory 实现
+
+- Status: Accepted
+- Date: 2026-04-12
+- Issue: #812
+
+## Context
+
+Task 4.2 要求实现 `AppendMemory` gRPC handler，支持批量追加记忆条目，包含幂等去重和顺序控制。
+
+在 Task 4.1 完成后，`memory/` 模块已有 `MemoryEntryRepository`，支持单条插入和按 session 查询。
+`memory_idempotency_keys` 表已通过 migration 基线（0001）建好，但尚未使用。
+
+需要解决：
+1. 如何基于 `idempotency_key`（来自 `RequestMeta`）实现请求级幂等。
+2. 如何为同一 session 的条目分配递增的 `sequence_num`。
+3. 如何在并发写入场景下利用 DB UNIQUE 约束保证顺序语义。
+4. 如何将主写路径与索引/摘要解耦。
+
+## Decision
+
+### 幂等机制：`memory_idempotency_keys` 表
+
+1. 收到 `AppendMemory` 请求后，先尝试 INSERT `memory_idempotency_keys`，以 `idempotency_key` 为主键。
+2. INSERT 成功 → 首次请求，继续写入。
+3. INSERT 失败（主键冲突）→ 重复请求，查询已写入条数直接返回。
+
+### 顺序控制：max(sequence_num) + 偏移
+
+1. 在事务中查询当前 session 的 `max(sequence_num)`（不存在则为 0）。
+2. 新条目的 sequence_num = max_seq + 1, max_seq + 2, ... max_seq + N。
+3. 利用 UNIQUE 约束 `(tenant_id, session_id, sequence_num)` 拒绝并发冲突。
+
+### L0 URI 占位
+
+Task 4.3 负责 L0 对象存储写入。本阶段 `l0_uri` 使用占位值 `l0://pending/{entry_id}`，
+标记该条目的原始材料尚未写入对象存储。
+
+### 解耦策略
+
+`AppendMemory` 仅写入 `memory_entries`，不触发索引或摘要生成。
+后续 Task 5.x / 7.x 独立实现索引与摘要路径。
+
+## Consequences
+
+### 正向影响
+
+1. `AppendMemory` 从 stub 变为可工作的 RPC。
+2. 幂等保证客户端重试不会产生重复数据。
+3. sequence_num 递增 + UNIQUE 约束保证顺序语义。
+
+### 权衡与代价
+
+1. 使用 `SELECT max(sequence_num) + FOR UPDATE` 锁行而非乐观锁 — 在同一 session 高并发场景下会串行化，但符合设计文档对顺序语义的严格保证。
+2. `l0_uri` 占位值将在 Task 4.3 完成后被替换。
+
+### 兼容性影响
+
+1. 无 proto 变更，完全向后兼容。
+2. 无 migration 变更，`memory_idempotency_keys` 表已由 0001 基线定义。
+
+## Alternatives Considered
+
+### 1. 客户端自分配 sequence_num
+
+- 未采用理由：需要信任客户端，无法防止并发冲突或重复 sequence_num。
+
+### 2. 乐观锁 + 重试
+
+- 未采用理由：增加实现复杂度，且同一 session 的写入频率不高，悲观锁足够。
+
+## Verification
+
+- `docker build -t koduck-memory:dev ./koduck-memory`
+- `kubectl rollout restart deployment/dev-koduck-memory -n koduck-dev`
+
+## References
+
+- 设计文档: [koduck-memory-for-koduck-ai.md](../../../docs/design/koduck-memory-for-koduck-ai.md)
+- 任务清单: [koduck-memory-koduck-ai-tasks.md](../../../docs/implementation/koduck-memory-koduck-ai-tasks.md)
+- 前序 ADR: [0012-memory-entries-storage-model.md](./0012-memory-entries-storage-model.md)
+- Issue: [#812](https://github.com/hailingu/koduck-quant/issues/812)

--- a/koduck-memory/src/capability/service.rs
+++ b/koduck-memory/src/capability/service.rs
@@ -4,11 +4,12 @@ use tonic::{Request, Response, Status};
 
 use crate::api::{
     AppendMemoryRequest, AppendMemoryResponse, Capability, ErrorDetail, GetSessionRequest,
-    GetSessionResponse, MemoryService, QueryMemoryRequest, QueryMemoryResponse, RequestMeta,
-    SummarizeMemoryRequest, SummarizeMemoryResponse, UpsertSessionMetaRequest,
+    GetSessionResponse, MemoryEntry, MemoryService, QueryMemoryRequest, QueryMemoryResponse,
+    RequestMeta, SummarizeMemoryRequest, SummarizeMemoryResponse, UpsertSessionMetaRequest,
     UpsertSessionMetaResponse,
 };
 use crate::config::AppConfig;
+use crate::memory::{IdempotencyRepository, InsertMemoryEntry, MemoryEntryRepository, metadata_to_jsonb};
 use crate::session::{SessionRepository, UpsertSession, extra_to_jsonb, parse_optional_uuid, parse_uuid};
 use crate::store::RuntimeState;
 
@@ -29,6 +30,15 @@ impl MemoryGrpcService {
 
     fn session_repo(&self) -> SessionRepository {
         SessionRepository::new(self.runtime.pool())
+    }
+
+    #[allow(dead_code)]
+    fn entry_repo(&self) -> MemoryEntryRepository {
+        MemoryEntryRepository::new(self.runtime.pool())
+    }
+
+    fn idempotency_repo(&self) -> IdempotencyRepository {
+        IdempotencyRepository::new(self.runtime.pool())
     }
 
     fn capability_response(&self) -> Capability {
@@ -235,13 +245,134 @@ impl MemoryService for MemoryGrpcService {
         &self,
         request: Request<AppendMemoryRequest>,
     ) -> Result<Response<AppendMemoryResponse>, Status> {
-        Self::validate_write_meta(request.get_ref().meta.as_ref().ok_or_else(|| {
-            Status::invalid_argument("meta is required")
-        })?)?;
+        let req = request.get_ref();
+        let meta = req
+            .meta
+            .as_ref()
+            .ok_or_else(|| Status::invalid_argument("meta is required"))?;
+        Self::validate_write_meta(meta)?;
+
+        if req.entries.is_empty() {
+            return Ok(Response::new(AppendMemoryResponse {
+                ok: true,
+                appended_count: 0,
+                error: None,
+            }));
+        }
+
+        let session_id =
+            parse_uuid(&req.session_id).map_err(|e| Status::invalid_argument(format!("invalid session_id: {e}")))?;
+
+        // Step 1: Idempotency check
+        let is_new = self
+            .idempotency_repo()
+            .try_record(
+                &meta.idempotency_key,
+                &meta.tenant_id,
+                session_id,
+                "append_memory",
+                &meta.request_id,
+            )
+            .await
+            .map_err(|e| Status::internal(format!("idempotency check failed: {e}")))?;
+
+        if !is_new {
+            // Duplicate request — nothing new to append
+            return Ok(Response::new(AppendMemoryResponse {
+                ok: true,
+                appended_count: 0,
+                error: None,
+            }));
+        }
+
+        // Step 2: Allocate sequence numbers within a transaction
+        let pool = self.runtime.pool();
+        let tenant_id = meta.tenant_id.clone();
+        let entries_count = req.entries.len() as i64;
+
+        let mut tx = pool
+            .begin()
+            .await
+            .map_err(|e| Status::internal(format!("failed to begin transaction: {e}")))?;
+
+        let max_seq = sqlx::query_scalar::<_, Option<i64>>(
+            r#"
+            SELECT MAX(sequence_num)
+            FROM memory_entries
+            WHERE tenant_id = $1 AND session_id = $2
+            FOR UPDATE
+            "#,
+        )
+        .bind(&tenant_id)
+        .bind(session_id)
+        .fetch_one(&mut *tx)
+        .await
+        .map_err(|e| Status::internal(format!("failed to query max sequence_num: {e}")))?;
+
+        let base_seq = max_seq.unwrap_or(0);
+
+        // Step 3: Insert entries
+        let mut appended = 0i32;
+        for (i, entry) in req.entries.iter().enumerate() {
+            let entry_id = uuid::Uuid::new_v4();
+            let message_ts = chrono::DateTime::from_timestamp_millis(entry.timestamp)
+                .unwrap_or_else(chrono::Utc::now);
+
+            let insert = InsertMemoryEntry {
+                id: entry_id,
+                tenant_id: tenant_id.clone(),
+                session_id,
+                sequence_num: base_seq + (i as i64) + 1,
+                role: entry.role.clone(),
+                raw_content_ref: format!("ref://{}", entry_id),
+                message_ts,
+                metadata_json: metadata_to_jsonb(&entry.metadata),
+                l0_uri: format!("l0://pending/{}", entry_id),
+            };
+
+            let result = sqlx::query(
+                r#"
+                INSERT INTO memory_entries (
+                    id, tenant_id, session_id, sequence_num,
+                    role, raw_content_ref, message_ts, metadata_json,
+                    l0_uri, created_at
+                ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, now())
+                "#,
+            )
+            .bind(insert.id)
+            .bind(&insert.tenant_id)
+            .bind(insert.session_id)
+            .bind(insert.sequence_num)
+            .bind(&insert.role)
+            .bind(&insert.raw_content_ref)
+            .bind(insert.message_ts)
+            .bind(&insert.metadata_json)
+            .bind(&insert.l0_uri)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| Status::internal(format!("failed to insert memory entry: {e}")))?;
+
+            if result.rows_affected() > 0 {
+                appended += 1;
+            }
+        }
+
+        tx.commit()
+            .await
+            .map_err(|e| Status::internal(format!("failed to commit transaction: {e}")))?;
+
+        tracing::info!(
+            session_id = %session_id,
+            tenant_id = %tenant_id,
+            appended_count = appended,
+            requested_count = entries_count,
+            "append_memory completed"
+        );
+
         Ok(Response::new(AppendMemoryResponse {
-            ok: false,
-            appended_count: 0,
-            error: Self::not_implemented_error("AppendMemory"),
+            ok: true,
+            appended_count: appended,
+            error: None,
         }))
     }
 
@@ -268,7 +399,10 @@ mod tests {
     use std::time::Duration;
 
     use super::MemoryGrpcService;
-    use crate::api::{GetSessionRequest, MemoryServiceClient, MemoryServiceServer, RequestMeta, UpsertSessionMetaRequest};
+    use crate::api::{
+        AppendMemoryRequest, GetSessionRequest, MemoryEntry, MemoryServiceClient,
+        MemoryServiceServer, RequestMeta, UpsertSessionMetaRequest,
+    };
     use crate::config::{
         AppConfig, AppSection, CapabilitiesSection, IndexSection, ObjectStoreSection,
         PostgresSection, ServerSection, SummarySection,
@@ -807,6 +941,249 @@ mod tests {
         assert_eq!(session.extra.get("source"), Some(&"gRPC".to_string()));
         assert_eq!(session.extra.get("version"), Some(&"v2".to_string()));
         assert_eq!(session.last_message_at, 1700000050000);
+
+        let _ = shutdown_tx.send(());
+        server.await.unwrap();
+    }
+
+    // ---- Task 4.2: AppendMemory tests ----
+
+    #[tokio::test]
+    async fn append_memory_inserts_entries_and_returns_count() {
+        let config = test_config();
+        let runtime = RuntimeState::initialize(&config).await.unwrap();
+        let (mut client, shutdown_tx, server) = start_test_server(config, runtime).await;
+
+        let session_id = Uuid::new_v4();
+        let sid_str = session_id.to_string();
+
+        // Seed a session
+        client
+            .upsert_session_meta(UpsertSessionMetaRequest {
+                meta: Some(write_meta_with_idempotency("t42-seed", &sid_str)),
+                session_id: sid_str.clone(),
+                title: "Append Test".to_string(),
+                status: "active".to_string(),
+                parent_session_id: String::new(),
+                forked_from_session_id: String::new(),
+                last_message_at: 1700000000000,
+                extra: [].into(),
+            })
+            .await
+            .unwrap()
+            .into_inner();
+
+        let mut meta1 = HashMap::new();
+        meta1.insert("message_id".to_string(), "msg-001".to_string());
+        let mut meta2 = HashMap::new();
+        meta2.insert("message_id".to_string(), "msg-002".to_string());
+
+        let resp = client
+            .append_memory(AppendMemoryRequest {
+                meta: Some(write_meta_with_idempotency("t42-append-1", &sid_str)),
+                session_id: sid_str.clone(),
+                entries: vec![
+                    MemoryEntry {
+                        role: "user".to_string(),
+                        content: "Hello, world!".to_string(),
+                        timestamp: 1700000000000,
+                        metadata: meta1,
+                    },
+                    MemoryEntry {
+                        role: "assistant".to_string(),
+                        content: "Hi there!".to_string(),
+                        timestamp: 1700000001000,
+                        metadata: meta2,
+                    },
+                ],
+            })
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert!(resp.ok);
+        assert_eq!(resp.appended_count, 2);
+        assert!(resp.error.is_none());
+
+        let _ = shutdown_tx.send(());
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn append_memory_idempotent_duplicate_returns_zero() {
+        let config = test_config();
+        let runtime = RuntimeState::initialize(&config).await.unwrap();
+        let (mut client, shutdown_tx, server) = start_test_server(config, runtime).await;
+
+        let session_id = Uuid::new_v4();
+        let sid_str = session_id.to_string();
+
+        // Seed a session
+        client
+            .upsert_session_meta(UpsertSessionMetaRequest {
+                meta: Some(write_meta_with_idempotency("t42-idem-seed", &sid_str)),
+                session_id: sid_str.clone(),
+                title: "Idempotency Test".to_string(),
+                status: "active".to_string(),
+                parent_session_id: String::new(),
+                forked_from_session_id: String::new(),
+                last_message_at: 1700000000000,
+                extra: [].into(),
+            })
+            .await
+            .unwrap()
+            .into_inner();
+
+        let idem_key = "t42-idem-dup";
+        let entries = vec![MemoryEntry {
+            role: "user".to_string(),
+            content: "test".to_string(),
+            timestamp: 1700000000000,
+            metadata: HashMap::new(),
+        }];
+
+        // First request
+        let resp1 = client
+            .append_memory(AppendMemoryRequest {
+                meta: Some(write_meta_with_idempotency(idem_key, &sid_str)),
+                session_id: sid_str.clone(),
+                entries: entries.clone(),
+            })
+            .await
+            .unwrap()
+            .into_inner();
+        assert!(resp1.ok);
+        assert_eq!(resp1.appended_count, 1);
+
+        // Duplicate request (same idempotency_key)
+        let resp2 = client
+            .append_memory(AppendMemoryRequest {
+                meta: Some(write_meta_with_idempotency(idem_key, &sid_str)),
+                session_id: sid_str.clone(),
+                entries,
+            })
+            .await
+            .unwrap()
+            .into_inner();
+        assert!(resp2.ok);
+        assert_eq!(resp2.appended_count, 0);
+        assert!(resp2.error.is_none());
+
+        let _ = shutdown_tx.send(());
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn append_memory_sequential_appends_increment_sequence() {
+        let config = test_config();
+        let runtime = RuntimeState::initialize(&config).await.unwrap();
+        let (mut client, shutdown_tx, server) = start_test_server(config, runtime).await;
+
+        let session_id = Uuid::new_v4();
+        let sid_str = session_id.to_string();
+
+        // Seed a session
+        client
+            .upsert_session_meta(UpsertSessionMetaRequest {
+                meta: Some(write_meta_with_idempotency("t42-seq-seed", &sid_str)),
+                session_id: sid_str.clone(),
+                title: "Sequence Test".to_string(),
+                status: "active".to_string(),
+                parent_session_id: String::new(),
+                forked_from_session_id: String::new(),
+                last_message_at: 1700000000000,
+                extra: [].into(),
+            })
+            .await
+            .unwrap()
+            .into_inner();
+
+        // First append: 2 entries → sequence 1, 2
+        let resp1 = client
+            .append_memory(AppendMemoryRequest {
+                meta: Some(write_meta_with_idempotency("t42-seq-1", &sid_str)),
+                session_id: sid_str.clone(),
+                entries: vec![
+                    MemoryEntry {
+                        role: "user".to_string(),
+                        content: "first".to_string(),
+                        timestamp: 1700000000000,
+                        metadata: HashMap::new(),
+                    },
+                    MemoryEntry {
+                        role: "assistant".to_string(),
+                        content: "second".to_string(),
+                        timestamp: 1700000001000,
+                        metadata: HashMap::new(),
+                    },
+                ],
+            })
+            .await
+            .unwrap()
+            .into_inner();
+        assert!(resp1.ok);
+        assert_eq!(resp1.appended_count, 2);
+
+        // Second append: 1 entry → sequence 3
+        let resp2 = client
+            .append_memory(AppendMemoryRequest {
+                meta: Some(write_meta_with_idempotency("t42-seq-2", &sid_str)),
+                session_id: sid_str.clone(),
+                entries: vec![MemoryEntry {
+                    role: "user".to_string(),
+                    content: "third".to_string(),
+                    timestamp: 1700000002000,
+                    metadata: HashMap::new(),
+                }],
+            })
+            .await
+            .unwrap()
+            .into_inner();
+        assert!(resp2.ok);
+        assert_eq!(resp2.appended_count, 1);
+
+        let _ = shutdown_tx.send(());
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn append_memory_empty_entries_returns_zero() {
+        let config = test_config();
+        let runtime = RuntimeState::initialize(&config).await.unwrap();
+        let (mut client, shutdown_tx, server) = start_test_server(config, runtime).await;
+
+        let session_id = Uuid::new_v4();
+        let sid_str = session_id.to_string();
+
+        // Seed a session
+        client
+            .upsert_session_meta(UpsertSessionMetaRequest {
+                meta: Some(write_meta_with_idempotency("t42-empty-seed", &sid_str)),
+                session_id: sid_str.clone(),
+                title: "Empty Test".to_string(),
+                status: "active".to_string(),
+                parent_session_id: String::new(),
+                forked_from_session_id: String::new(),
+                last_message_at: 1700000000000,
+                extra: [].into(),
+            })
+            .await
+            .unwrap()
+            .into_inner();
+
+        let resp = client
+            .append_memory(AppendMemoryRequest {
+                meta: Some(write_meta_with_idempotency("t42-empty", &sid_str)),
+                session_id: sid_str.clone(),
+                entries: vec![],
+            })
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert!(resp.ok);
+        assert_eq!(resp.appended_count, 0);
+        assert!(resp.error.is_none());
 
         let _ = shutdown_tx.send(());
         server.await.unwrap();

--- a/koduck-memory/src/memory/idempotency.rs
+++ b/koduck-memory/src/memory/idempotency.rs
@@ -1,0 +1,71 @@
+use sqlx::PgPool;
+use tracing::info;
+use uuid::Uuid;
+
+use crate::Result;
+
+/// DAO for `memory_idempotency_keys` table.
+#[derive(Clone)]
+pub struct IdempotencyRepository {
+    pool: PgPool,
+}
+
+impl IdempotencyRepository {
+    pub fn new(pool: &PgPool) -> Self {
+        Self {
+            pool: pool.clone(),
+        }
+    }
+
+    /// Try to record a new idempotency key.
+    /// Returns `true` if this is a new key (first request), `false` if duplicate.
+    ///
+    /// Uses `INSERT ... ON CONFLICT DO NOTHING` + `RETURNING` to atomically
+    /// check-and-insert in a single round trip.
+    pub async fn try_record(
+        &self,
+        idempotency_key: &str,
+        tenant_id: &str,
+        session_id: Uuid,
+        operation: &str,
+        request_id: &str,
+    ) -> Result<bool> {
+        let now = chrono::Utc::now();
+        let expires_at = now + chrono::Duration::hours(24);
+
+        let row = sqlx::query_scalar::<_, String>(
+            r#"
+            INSERT INTO memory_idempotency_keys (
+                idempotency_key, tenant_id, session_id,
+                operation, request_id, created_at, expires_at
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7)
+            ON CONFLICT (idempotency_key) DO NOTHING
+            RETURNING idempotency_key
+            "#,
+        )
+        .bind(idempotency_key)
+        .bind(tenant_id)
+        .bind(session_id)
+        .bind(operation)
+        .bind(request_id)
+        .bind(now)
+        .bind(expires_at)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        let is_new = row.is_some();
+        if is_new {
+            info!(
+                idempotency_key = %idempotency_key,
+                "new idempotency key recorded"
+            );
+        } else {
+            info!(
+                idempotency_key = %idempotency_key,
+                "duplicate idempotency key detected"
+            );
+        }
+
+        Ok(is_new)
+    }
+}

--- a/koduck-memory/src/memory/mod.rs
+++ b/koduck-memory/src/memory/mod.rs
@@ -1,5 +1,7 @@
+pub mod idempotency;
 pub mod model;
 pub mod repository;
 
+pub use idempotency::IdempotencyRepository;
 pub use model::{MemoryEntry, InsertMemoryEntry, metadata_to_jsonb};
 pub use repository::MemoryEntryRepository;

--- a/koduck-memory/src/memory/repository.rs
+++ b/koduck-memory/src/memory/repository.rs
@@ -18,6 +18,31 @@ impl MemoryEntryRepository {
         }
     }
 
+    /// Get the current max `sequence_num` for a given session.
+    /// Returns 0 if no entries exist for the session.
+    ///
+    /// Uses `FOR UPDATE` to lock the row and prevent concurrent allocations.
+    pub async fn get_max_sequence_num(
+        &self,
+        tenant_id: &str,
+        session_id: Uuid,
+    ) -> Result<i64> {
+        let max_seq = sqlx::query_scalar::<_, Option<i64>>(
+            r#"
+            SELECT MAX(sequence_num)
+            FROM memory_entries
+            WHERE tenant_id = $1 AND session_id = $2
+            FOR UPDATE
+            "#,
+        )
+        .bind(tenant_id)
+        .bind(session_id)
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(max_seq.unwrap_or(0))
+    }
+
     /// Insert a single memory entry.
     ///
     /// Relies on DB UNIQUE constraint `(tenant_id, session_id, sequence_num)`


### PR DESCRIPTION
## Summary

- Implement `AppendMemory` gRPC handler: batch insert memory entries with idempotency dedup and sequence_num ordering
- Add `IdempotencyRepository` using `memory_idempotency_keys` table for request-level dedup via `INSERT ... ON CONFLICT DO NOTHING`
- Add `get_max_sequence_num` to `MemoryEntryRepository` with `FOR UPDATE` lock for concurrent-safe sequence allocation
- Add integration tests: normal append, idempotent duplicate, sequential appends, empty entries

Closes #812

## Test plan

- [x] Docker build passes
- [x] K8s rollout successful
- [x] Integration tests cover: batch insert, idempotency, sequence increment, empty entries
- [ ] Manual verification via gRPC client

🤖 Generated with [Claude Code](https://claude.com/claude-code)