### PR TITLE
feat(memory): 建立 memory_index_records L1 索引存储模型 (Task 5.1)

### DIFF
--- a/koduck-memory/docs/adr/0015-memory-index-records.md
+++ b/koduck-memory/docs/adr/0015-memory-index-records.md
@@ -1,0 +1,82 @@
+# ADR-0015: memory_index_records L1 索引存储模型
+
+- Status: Accepted
+- Date: 2026-04-12
+- Issue: #817
+
+## Context
+
+Task 5.1 要求建立 `memory_index_records` 表和相关的 L1 索引存储模型，为 QueryMemory 提供可直接消费的结构化索引数据。
+
+在 Phase 4（L0 写入与 append 语义）完成后，`memory/` 模块已有完整的 `MemoryEntryRepository`，支持记忆条目的写入和查询。
+`memory_index_records` 表已通过 migration 基线（0001）建好，但 `index/` 模块仍是 placeholder。
+
+需要解决：
+1. 如何映射 `memory_index_records` 表到 Rust 结构体（含 UUID、TEXT summary/snippet、NUMERIC score_hint）。
+2. 如何支持按 `tenant_id + domain_class` 和 `tenant_id + session_id` 的高效查询。
+3. 如何建立 L1 索引与 L0 原始材料的关联（通过 `source_uri` 字段）。
+
+## Decision
+
+### 模型层：`MemoryIndexRecord` 结构体
+
+定义 domain model 直接映射数据库列，使用 `sqlx::FromRow` 自动映射。
+
+### Repository 层：`MemoryIndexRepository`
+
+提供以下方法：
+
+1. **`insert(record)`** — 插入单条 index record，用于 L1 索引生成。
+2. **`list_by_domain(tenant_id, domain_class, limit)`** — 按 `tenant_id + domain_class` 查询，支持 DOMAIN_FIRST 策略。
+3. **`list_by_session(tenant_id, session_id, limit)`** — 按 `tenant_id + session_id` 查询，支持 session 范围限制。
+4. **`list_by_query(tenant_id, domain_class, query_text, limit)`** — 结合 domain_class 和 summary 全文搜索，支持 SUMMARY_FIRST 策略。
+
+### L1 与 L0 关联
+
+通过 `source_uri` 字段建立关联：
+- `source_uri` 存储指向 L0 对象的 URI（如 `s3://bucket/tenants/{tenant_id}/sessions/{session_id}/entries/{sequence_num}-{entry_id}.json`）
+- 使 L1 索引可追溯到原始 L0 材料
+
+### 依赖
+
+无需新增 Cargo 依赖。`uuid`、`chrono`、`sqlx`（含 postgres/uuid/chrono feature）均已在前序任务中引入。
+
+## Consequences
+
+### 正向影响
+
+1. `index/` 模块从 placeholder 变为可工作的数据访问层。
+2. 为 Task 5.2（DOMAIN_FIRST）和 Task 5.3（SUMMARY_FIRST）提供直接可用的 Repository。
+3. 高频查询索引支持 QueryMemory 的性能需求。
+
+### 权衡与代价
+
+1. `insert` 方法不做幂等校验 — L1 索引生成可能重复，由上层异步任务去重。
+2. 全文搜索依赖 PostgreSQL GIN 索引，复杂查询可能需要专门的搜索引擎。
+
+### 兼容性影响
+
+1. 无 proto 变更，完全向后兼容。
+2. 无 migration 变更，表结构已由 0001 基线定义。
+
+## Alternatives Considered
+
+### 1. 使用单独的全文检索引擎（如 Elasticsearch）
+
+- 未采用理由：V1 设计明确不引入额外依赖，使用 PostgreSQL GIN 索引足够支持基础需求。
+
+### 2. 将 L1 索引存储在对象存储
+
+- 未采用理由：L1 需要支持高频查询和复杂过滤，PostgreSQL 更适合此场景。
+
+## Verification
+
+- `docker build -t koduck-memory:dev ./koduck-memory`
+- `kubectl rollout restart deployment/dev-koduck-memory -n koduck-dev`
+
+## References
+
+- 设计文档: [koduck-memory-for-koduck-ai.md](../../../docs/design/koduck-memory-for-koduck-ai.md)
+- 任务清单: [koduck-memory-koduck-ai-tasks.md](../../../docs/implementation/koduck-memory-koduck-ai-tasks.md)
+- 前序 ADR: [0014-l0-object-storage-implementation.md](./0014-l0-object-storage-implementation.md)
+- Issue: [#817](https://github.com/hailingu/koduck-quant/issues/817)

--- a/koduck-memory/src/index/mod.rs
+++ b/koduck-memory/src/index/mod.rs
@@ -1,1 +1,13 @@
-//! Index module placeholder for L1 structured record generation.
+//! L1 structured index material management for memory retrieval.
+//!
+//! This module provides data models and repository for `memory_index_records` table,
+//! which stores structured L1 index material supporting:
+//! - DOMAIN_FIRST retrieval strategy
+//! - SUMMARY_FIRST retrieval strategy
+//! - L0 raw material traceability via source_uri
+
+pub mod model;
+pub mod repository;
+
+pub use model::{InsertMemoryIndexRecord, MemoryIndexRecord};
+pub use repository::MemoryIndexRepository;

--- a/koduck-memory/src/index/model.rs
+++ b/koduck-memory/src/index/model.rs
@@ -1,0 +1,136 @@
+use serde::{Deserialize, Serialize};
+use sqlx::FromRow;
+use uuid::Uuid;
+
+/// Domain model for `memory_index_records` table.
+/// Represents L1 structured index material for memory retrieval.
+#[derive(Debug, Clone, FromRow, Serialize, Deserialize)]
+pub struct MemoryIndexRecord {
+    pub id: Uuid,
+    pub tenant_id: String,
+    pub session_id: Uuid,
+    /// Optional reference to the originating memory entry
+    pub entry_id: Option<Uuid>,
+    /// Kind of memory: user, assistant, system, summary, fact, etc.
+    pub memory_kind: String,
+    /// Coarse domain classification for DOMAIN_FIRST filtering
+    pub domain_class: String,
+    /// Summary text used for negative filtering in SUMMARY_FIRST strategy
+    pub summary: String,
+    /// Optional snippet excerpt for display
+    pub snippet: Option<String>,
+    /// URI pointing to L0 raw material (e.g., s3://bucket/...)
+    pub source_uri: String,
+    /// Optional score hint for ranking (higher = more relevant), stored as NUMERIC in DB
+    pub score_hint: Option<String>,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub updated_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// Parameters for inserting a new memory index record.
+pub struct InsertMemoryIndexRecord {
+    pub id: Uuid,
+    pub tenant_id: String,
+    pub session_id: Uuid,
+    pub entry_id: Option<Uuid>,
+    pub memory_kind: String,
+    pub domain_class: String,
+    pub summary: String,
+    pub snippet: Option<String>,
+    pub source_uri: String,
+    pub score_hint: Option<String>,
+}
+
+impl InsertMemoryIndexRecord {
+    /// Create a new insert params with generated UUID and current timestamp.
+    pub fn new(
+        tenant_id: impl Into<String>,
+        session_id: Uuid,
+        memory_kind: impl Into<String>,
+        domain_class: impl Into<String>,
+        summary: impl Into<String>,
+        source_uri: impl Into<String>,
+    ) -> Self {
+        Self {
+            id: Uuid::new_v4(),
+            tenant_id: tenant_id.into(),
+            session_id,
+            entry_id: None,
+            memory_kind: memory_kind.into(),
+            domain_class: domain_class.into(),
+            summary: summary.into(),
+            snippet: None,
+            source_uri: source_uri.into(),
+            score_hint: None,
+        }
+    }
+
+    /// Set the optional entry_id reference.
+    pub fn with_entry_id(mut self, entry_id: Uuid) -> Self {
+        self.entry_id = Some(entry_id);
+        self
+    }
+
+    /// Set the optional snippet.
+    pub fn with_snippet(mut self, snippet: impl Into<String>) -> Self {
+        self.snippet = Some(snippet.into());
+        self
+    }
+
+    /// Set the optional score_hint as string representation.
+    pub fn with_score_hint(mut self, score_hint: impl Into<String>) -> Self {
+        self.score_hint = Some(score_hint.into());
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn insert_params_builder_works() {
+        let session_id = Uuid::new_v4();
+        let entry_id = Uuid::new_v4();
+        
+        let params = InsertMemoryIndexRecord::new(
+            "tenant-123",
+            session_id,
+            "user",
+            "chat",
+            "User asked about pricing",
+            "s3://bucket/tenants/tenant-123/sessions/{session_id}/entries/1-{entry_id}.json",
+        )
+        .with_entry_id(entry_id)
+        .with_snippet("What is the pricing?")
+        .with_score_hint("0.85");
+
+        assert_eq!(params.tenant_id, "tenant-123");
+        assert_eq!(params.session_id, session_id);
+        assert_eq!(params.entry_id, Some(entry_id));
+        assert_eq!(params.memory_kind, "user");
+        assert_eq!(params.domain_class, "chat");
+        assert_eq!(params.summary, "User asked about pricing");
+        assert_eq!(params.snippet, Some("What is the pricing?".to_string()));
+        assert_eq!(params.score_hint, Some("0.85".to_string()));
+    }
+
+    #[test]
+    fn insert_params_minimal_works() {
+        let session_id = Uuid::new_v4();
+        
+        let params = InsertMemoryIndexRecord::new(
+            "tenant-456",
+            session_id,
+            "assistant",
+            "chat",
+            "Assistant provided answer",
+            "s3://bucket/object.json",
+        );
+
+        assert_eq!(params.tenant_id, "tenant-456");
+        assert!(params.entry_id.is_none());
+        assert!(params.snippet.is_none());
+        assert!(params.score_hint.is_none());
+    }
+}

--- a/koduck-memory/src/index/repository.rs
+++ b/koduck-memory/src/index/repository.rs
@@ -1,0 +1,253 @@
+use sqlx::PgPool;
+use tracing::info;
+use uuid::Uuid;
+
+use crate::index::model::{InsertMemoryIndexRecord, MemoryIndexRecord};
+use crate::Result;
+
+/// DAO for `memory_index_records` table.
+#[derive(Clone)]
+pub struct MemoryIndexRepository {
+    pool: PgPool,
+}
+
+impl MemoryIndexRepository {
+    pub fn new(pool: &PgPool) -> Self {
+        Self {
+            pool: pool.clone(),
+        }
+    }
+
+    /// Insert a single memory index record.
+    ///
+    /// Returns the inserted record with generated timestamps.
+    pub async fn insert(&self, record: &InsertMemoryIndexRecord) -> Result<MemoryIndexRecord> {
+        let row = sqlx::query_as::<_, MemoryIndexRecord>(
+            r#"
+            INSERT INTO memory_index_records (
+                id, tenant_id, session_id, entry_id,
+                memory_kind, domain_class, summary, snippet,
+                source_uri, score_hint, created_at, updated_at
+            ) VALUES (
+                $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, now(), now()
+            )
+            RETURNING 
+                id, tenant_id, session_id, entry_id,
+                memory_kind, domain_class, summary, snippet,
+                source_uri, score_hint,
+                created_at, updated_at
+            "#,
+        )
+        .bind(record.id)
+        .bind(&record.tenant_id)
+        .bind(record.session_id)
+        .bind(record.entry_id)
+        .bind(&record.memory_kind)
+        .bind(&record.domain_class)
+        .bind(&record.summary)
+        .bind(&record.snippet)
+        .bind(&record.source_uri)
+        .bind(&record.score_hint)
+        .fetch_one(&self.pool)
+        .await?;
+
+        info!(
+            record_id = %row.id,
+            session_id = %row.session_id,
+            memory_kind = %row.memory_kind,
+            domain_class = %row.domain_class,
+            "memory index record inserted"
+        );
+
+        Ok(row)
+    }
+
+    /// List index records by tenant_id + domain_class.
+    ///
+    /// Used for DOMAIN_FIRST retrieval strategy.
+    /// Results are ordered by updated_at DESC (most recent first).
+    pub async fn list_by_domain(
+        &self,
+        tenant_id: &str,
+        domain_class: &str,
+        limit: i64,
+    ) -> Result<Vec<MemoryIndexRecord>> {
+        let rows = sqlx::query_as::<_, MemoryIndexRecord>(
+            r#"
+            SELECT 
+                id, tenant_id, session_id, entry_id,
+                memory_kind, domain_class, summary, snippet,
+                source_uri, score_hint,
+                created_at, updated_at
+            FROM memory_index_records
+            WHERE tenant_id = $1 AND domain_class = $2
+            ORDER BY updated_at DESC
+            LIMIT $3
+            "#,
+        )
+        .bind(tenant_id)
+        .bind(domain_class)
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows)
+    }
+
+    /// List index records by tenant_id + session_id + optional domain_class.
+    ///
+    /// Used for session-scoped memory retrieval.
+    /// Results are ordered by updated_at DESC (most recent first).
+    pub async fn list_by_session(
+        &self,
+        tenant_id: &str,
+        session_id: Uuid,
+        domain_class: Option<&str>,
+        limit: i64,
+    ) -> Result<Vec<MemoryIndexRecord>> {
+        let rows = if let Some(dc) = domain_class {
+            sqlx::query_as::<_, MemoryIndexRecord>(
+                r#"
+                SELECT 
+                    id, tenant_id, session_id, entry_id,
+                    memory_kind, domain_class, summary, snippet,
+                    source_uri, score_hint,
+                    created_at, updated_at
+                FROM memory_index_records
+                WHERE tenant_id = $1 AND session_id = $2 AND domain_class = $3
+                ORDER BY updated_at DESC
+                LIMIT $4
+                "#,
+            )
+            .bind(tenant_id)
+            .bind(session_id)
+            .bind(dc)
+            .bind(limit)
+            .fetch_all(&self.pool)
+            .await?
+        } else {
+            sqlx::query_as::<_, MemoryIndexRecord>(
+                r#"
+                SELECT 
+                    id, tenant_id, session_id, entry_id,
+                    memory_kind, domain_class, summary, snippet,
+                    source_uri, score_hint,
+                    created_at, updated_at
+                FROM memory_index_records
+                WHERE tenant_id = $1 AND session_id = $2
+                ORDER BY updated_at DESC
+                LIMIT $3
+                "#,
+            )
+            .bind(tenant_id)
+            .bind(session_id)
+            .bind(limit)
+            .fetch_all(&self.pool)
+            .await?
+        };
+
+        Ok(rows)
+    }
+
+    /// Search index records by tenant_id + domain_class + summary text match.
+    ///
+    /// Used for SUMMARY_FIRST retrieval strategy.
+    /// Uses PostgreSQL full-text search on summary field.
+    /// Results are ordered by updated_at DESC.
+    pub async fn search_by_summary(
+        &self,
+        tenant_id: &str,
+        domain_class: &str,
+        query_text: &str,
+        limit: i64,
+    ) -> Result<Vec<MemoryIndexRecord>> {
+        // Use simple to_tsquery for basic text matching
+        // In production, consider using websearch_to_tsquery or custom parsing
+        let ts_query = query_text.split_whitespace().collect::<Vec<_>>().join(" & ");
+        
+        let rows = sqlx::query_as::<_, MemoryIndexRecord>(
+            r#"
+            SELECT 
+                id, tenant_id, session_id, entry_id,
+                memory_kind, domain_class, summary, snippet,
+                source_uri, score_hint,
+                created_at, updated_at
+            FROM memory_index_records
+            WHERE tenant_id = $1 
+              AND domain_class = $2
+              AND to_tsvector('simple', summary) @@ to_tsquery('simple', $3)
+            ORDER BY updated_at DESC
+            LIMIT $4
+            "#,
+        )
+        .bind(tenant_id)
+        .bind(domain_class)
+        .bind(&ts_query)
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows)
+    }
+
+    /// Get a single record by ID.
+    pub async fn get_by_id(&self, id: Uuid) -> Result<Option<MemoryIndexRecord>> {
+        let row = sqlx::query_as::<_, MemoryIndexRecord>(
+            r#"
+            SELECT 
+                id, tenant_id, session_id, entry_id,
+                memory_kind, domain_class, summary, snippet,
+                source_uri, score_hint,
+                created_at, updated_at
+            FROM memory_index_records
+            WHERE id = $1
+            "#,
+        )
+        .bind(id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row)
+    }
+
+    /// Delete records by session_id (useful for session cleanup).
+    pub async fn delete_by_session(
+        &self,
+        tenant_id: &str,
+        session_id: Uuid,
+    ) -> Result<u64> {
+        let result = sqlx::query(
+            r#"
+            DELETE FROM memory_index_records
+            WHERE tenant_id = $1 AND session_id = $2
+            "#,
+        )
+        .bind(tenant_id)
+        .bind(session_id)
+        .execute(&self.pool)
+        .await?;
+
+        let deleted = result.rows_affected();
+        info!(
+            session_id = %session_id,
+            deleted_count = deleted,
+            "memory index records deleted for session"
+        );
+
+        Ok(deleted)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Note: Integration tests would require a test database.
+    // For now, we verify the repository structure compiles correctly.
+
+    #[test]
+    fn repository_new_works() {
+        // This is a compile-time check
+        // Actual functionality requires a database connection
+    }
+}


### PR DESCRIPTION
## 功能描述

建立 `memory_index_records` L1 索引存储模型，为 QueryMemory 提供可直接消费的结构化索引数据。

## 实现内容

- 新增 `MemoryIndexRecord` 模型，映射 `memory_index_records` 表结构
- 新增 `MemoryIndexRepository`，提供以下方法：
  - `insert` - 插入 L1 索引记录
  - `list_by_domain` - 按 domain_class 查询（支持 DOMAIN_FIRST 策略）
  - `list_by_session` - 按 session 查询（支持 session 范围限制）
  - `search_by_summary` - 全文搜索 summary（支持 SUMMARY_FIRST 策略）
  - `get_by_id` - 按 ID 查询单条记录
  - `delete_by_session` - 按 session 清理记录
- 更新 `index/mod.rs`，暴露模型和 Repository
- 创建 ADR-0015 记录设计决策

## 验收标准完成情况

- [x] `index/` 模块从 placeholder 变为可工作的 Repository 层
- [x] `MemoryIndexRecord` 模型映射数据库表结构
- [x] `MemoryIndexRepository` 提供 insert / list_by_domain / list_by_session 等方法
- [x] 高频查询索引可用
- [x] Docker 构建通过
- [x] k8s dev 环境 rollout 成功

## L1 与 L0 关联

通过 `source_uri` 字段建立 L1 索引到 L0 原始材料的追溯关系，`entry_id` 可选关联到 `memory_entries` 表。

Closes #817