### PR TITLE
feat(ai): implement memory fail-open strategy (Task 6.2)

### DIFF
--- a/docs/implementation/koduck-memory-koduck-ai-tasks.md
+++ b/docs/implementation/koduck-memory-koduck-ai-tasks.md
@@ -283,8 +283,10 @@
 3. `GetSession / UpsertSessionMeta` 错误有告警与 fallback
 
 **验收标准:**
-- [ ] memory 故障不阻塞主 chat
-- [ ] 失败路径可在日志和指标中观测
+- [x] memory 故障不阻塞主 chat
+- [x] 失败路径可在日志和指标中观测
+
+**实现 PR:** #828
 
 ### Task 6.3: capability 协商接入
 **详细要求:**

--- a/koduck-ai/src/api/mod.rs
+++ b/koduck-ai/src/api/mod.rs
@@ -33,6 +33,7 @@ use crate::{
     reliability::{
         degrade::{DegradeDecision, DegradeRoute},
         error::{AppError, ErrorCode, UpstreamService},
+        memory_fail_open::MemoryFailOpenOperation,
         retry_budget::RetryDirective,
     },
     stream::sse::{PendingStreamEvent, ResumeCursor, StreamEventData},
@@ -138,10 +139,7 @@ pub async fn chat(
         "chat request received"
     );
 
-    let memory_snapshot = match prepare_memory_context(&state, &request, &memory_ctx).await {
-        Ok(snapshot) => snapshot,
-        Err(err) => return api_error_response(err, request_id),
-    };
+    let memory_snapshot = prepare_memory_context(&state, &request, &memory_ctx).await;
 
     let response = if state.config.llm.stub_enabled {
         build_stub_chat_response(
@@ -200,7 +198,13 @@ pub async fn chat(
     )
     .await
     {
-        return api_error_response(err, request_id);
+        state.memory_fail_open.log_fail_open(
+            MemoryFailOpenOperation::AppendMemory,
+            &request_id,
+            &session_id,
+            &err,
+        );
+        // fail-open: response already generated, return it to user
     }
 
     let mut res_headers = HeaderMap::new();
@@ -276,10 +280,7 @@ pub async fn chat_stream(
     let memory_snapshot = if resume_cursor.is_resume() {
         None
     } else {
-        match prepare_memory_context(&state, &request.chat, &memory_ctx).await {
-            Ok(snapshot) => Some(snapshot),
-            Err(err) => return api_error_response(err, request_id),
-        }
+        Some(prepare_memory_context(&state, &request.chat, &memory_ctx).await)
     };
 
     let session = if resume_cursor.is_resume() {
@@ -326,7 +327,13 @@ pub async fn chat_stream(
             )
             .await
             {
-                return api_error_response(err, request_id);
+                state.memory_fail_open.log_fail_open(
+                    MemoryFailOpenOperation::AppendMemory,
+                    &request_id,
+                    &session_id,
+                    &err,
+                );
+                // fail-open: stub stream will proceed regardless
             }
             spawn_stub_stream(
                 Arc::clone(&session),
@@ -482,11 +489,11 @@ pub async fn chat_stream(
                     )
                     .await
                     {
-                        warn!(
-                            request_id = %append_ctx.request_id,
-                            session_id = %append_ctx.session_id,
-                            error = %err,
-                            "failed to persist streamed conversation into memory"
+                        append_state.memory_fail_open.log_fail_open(
+                            MemoryFailOpenOperation::AppendMemory,
+                            &append_ctx.request_id,
+                            &append_ctx.session_id,
+                            &err,
                         );
                     }
                 };
@@ -646,11 +653,11 @@ pub async fn chat_stream(
                     )
                     .await
                     {
-                        warn!(
-                            request_id = %append_ctx.request_id,
-                            session_id = %append_ctx.session_id,
-                            error = %err,
-                            "failed to persist streamed conversation into memory"
+                        append_state.memory_fail_open.log_fail_open(
+                            MemoryFailOpenOperation::AppendMemory,
+                            &append_ctx.request_id,
+                            &append_ctx.session_id,
+                            &err,
                         );
                     }
                 };
@@ -740,14 +747,22 @@ async fn prepare_memory_context(
     state: &Arc<AppState>,
     request: &ChatRequest,
     ctx: &MemoryRpcContext,
-) -> Result<MemoryContextSnapshot, AppError> {
+) -> MemoryContextSnapshot {
     let session = match memory::get_session(state, ctx).await {
         Ok(session) => Some(session),
         Err(err) if err.code == ErrorCode::ResourceNotFound => None,
-        Err(err) => return Err(err),
+        Err(err) => {
+            state.memory_fail_open.log_fail_open(
+                MemoryFailOpenOperation::GetSession,
+                &ctx.request_id,
+                &ctx.session_id,
+                &err,
+            );
+            None
+        }
     };
 
-    memory::upsert_session_meta(
+    if let Err(err) = memory::upsert_session_meta(
         state,
         ctx,
         SessionUpsertInput {
@@ -759,9 +774,17 @@ async fn prepare_memory_context(
             last_message_at: Utc::now().timestamp_millis(),
         },
     )
-    .await?;
+    .await
+    {
+        state.memory_fail_open.log_fail_open(
+            MemoryFailOpenOperation::UpsertSessionMeta,
+            &ctx.request_id,
+            &ctx.session_id,
+            &err,
+        );
+    }
 
-    let hits = memory::query_memory(
+    let hits = match memory::query_memory(
         state,
         ctx,
         QueryMemoryInput {
@@ -772,9 +795,21 @@ async fn prepare_memory_context(
             page_size: MEMORY_QUERY_PAGE_SIZE,
         },
     )
-    .await?;
+    .await
+    {
+        Ok(hits) => hits,
+        Err(err) => {
+            state.memory_fail_open.log_fail_open(
+                MemoryFailOpenOperation::QueryMemory,
+                &ctx.request_id,
+                &ctx.session_id,
+                &err,
+            );
+            vec![]
+        }
+    };
 
-    Ok(MemoryContextSnapshot { session, hits })
+    MemoryContextSnapshot { session, hits }
 }
 
 async fn append_chat_turn(

--- a/koduck-ai/src/app/mod.rs
+++ b/koduck-ai/src/app/mod.rs
@@ -18,6 +18,7 @@ use crate::config::{Config, LlmMode};
 use crate::reliability::error::{AppError, UpstreamService};
 use crate::llm::{build_provider_router, LlmProvider};
 use crate::reliability::degrade::DegradePolicy;
+use crate::reliability::memory_fail_open::MemoryFailOpenTracker;
 use crate::reliability::retry_budget::RetryBudgetPolicy;
 use crate::stream::sse::StreamRegistry;
 
@@ -30,6 +31,7 @@ pub struct AppState {
     pub lifecycle: Arc<lifecycle::LifecycleManager>,
     pub degrade_policy: Arc<DegradePolicy>,
     pub retry_budget_policy: Arc<RetryBudgetPolicy>,
+    pub memory_fail_open: Arc<MemoryFailOpenTracker>,
     pub llm_provider: Arc<dyn LlmProvider>,
     pub capability_cache: Arc<CapabilityCache>,
 }
@@ -58,6 +60,7 @@ pub fn build_state(config: Config) -> Arc<AppState> {
         degrade_policy: Arc::new(DegradePolicy::new(config.reliability.degrade.clone())),
         llm_provider: build_provider_router(&config)
             .expect("failed to build llm provider router from config"),
+        memory_fail_open: Arc::new(MemoryFailOpenTracker::new()),
         retry_budget_policy: Arc::new(RetryBudgetPolicy::new(config.reliability.retry.clone())),
         capability_cache: Arc::new(CapabilityCache::new(config.capabilities.clone())),
         config,
@@ -153,5 +156,6 @@ async fn degrade_metrics_handler(
     axum::Json(serde_json::json!({
         "degrade": state.degrade_policy.snapshot(),
         "retry_budget": state.retry_budget_policy.snapshot(),
+        "memory_fail_open": state.memory_fail_open.snapshot(),
     }))
 }

--- a/koduck-ai/src/reliability/memory_fail_open.rs
+++ b/koduck-ai/src/reliability/memory_fail_open.rs
@@ -1,0 +1,132 @@
+//! Memory fail-open tracking.
+//!
+//! Records and exposes metrics for memory service calls that failed
+//! but were handled gracefully (fail-open) so the main chat flow continues.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use serde::Serialize;
+use strum::{Display, IntoStaticStr};
+use tracing::warn;
+
+use crate::reliability::error::AppError;
+
+/// The four memory RPC operations that can trigger fail-open.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Display, IntoStaticStr)]
+#[strum(serialize_all = "snake_case")]
+pub enum MemoryFailOpenOperation {
+    GetSession,
+    UpsertSessionMeta,
+    QueryMemory,
+    AppendMemory,
+}
+
+/// Serializable snapshot of memory fail-open counters, exposed via `/metrics`.
+#[derive(Debug, Serialize)]
+pub struct MemoryFailOpenSnapshot {
+    pub get_session_errors: u64,
+    pub upsert_session_meta_errors: u64,
+    pub query_memory_errors: u64,
+    pub append_memory_errors: u64,
+}
+
+/// Tracks memory fail-open events using atomic counters.
+///
+/// Fail-open is unconditional (no config toggle) per the design doc principle.
+pub struct MemoryFailOpenTracker {
+    get_session_errors: AtomicU64,
+    upsert_session_meta_errors: AtomicU64,
+    query_memory_errors: AtomicU64,
+    append_memory_errors: AtomicU64,
+}
+
+impl MemoryFailOpenTracker {
+    pub fn new() -> Self {
+        Self {
+            get_session_errors: AtomicU64::new(0),
+            upsert_session_meta_errors: AtomicU64::new(0),
+            query_memory_errors: AtomicU64::new(0),
+            append_memory_errors: AtomicU64::new(0),
+        }
+    }
+
+    /// Increment the counter for the given operation.
+    pub fn record(&self, operation: MemoryFailOpenOperation) {
+        self.counter_for(operation).fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Return a snapshot of all counters for the `/metrics` endpoint.
+    pub fn snapshot(&self) -> MemoryFailOpenSnapshot {
+        MemoryFailOpenSnapshot {
+            get_session_errors: self.get_session_errors.load(Ordering::Relaxed),
+            upsert_session_meta_errors: self
+                .upsert_session_meta_errors
+                .load(Ordering::Relaxed),
+            query_memory_errors: self.query_memory_errors.load(Ordering::Relaxed),
+            append_memory_errors: self.append_memory_errors.load(Ordering::Relaxed),
+        }
+    }
+
+    /// Record the fail-open event and emit a structured warning log.
+    pub fn log_fail_open(
+        &self,
+        operation: MemoryFailOpenOperation,
+        request_id: &str,
+        session_id: &str,
+        err: &AppError,
+    ) {
+        self.record(operation);
+        warn!(
+            request_id = %request_id,
+            session_id = %session_id,
+            memory_fail_open.operation = %operation,
+            error.code = %err.code,
+            error.message = %err.message,
+            "memory service call failed; continuing without memory (fail-open)"
+        );
+    }
+
+    fn counter_for(&self, operation: MemoryFailOpenOperation) -> &AtomicU64 {
+        match operation {
+            MemoryFailOpenOperation::GetSession => &self.get_session_errors,
+            MemoryFailOpenOperation::UpsertSessionMeta => &self.upsert_session_meta_errors,
+            MemoryFailOpenOperation::QueryMemory => &self.query_memory_errors,
+            MemoryFailOpenOperation::AppendMemory => &self.append_memory_errors,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{MemoryFailOpenOperation, MemoryFailOpenTracker};
+
+    #[test]
+    fn snapshot_starts_at_zero() {
+        let tracker = MemoryFailOpenTracker::new();
+        let snapshot = tracker.snapshot();
+
+        assert_eq!(snapshot.get_session_errors, 0);
+        assert_eq!(snapshot.upsert_session_meta_errors, 0);
+        assert_eq!(snapshot.query_memory_errors, 0);
+        assert_eq!(snapshot.append_memory_errors, 0);
+    }
+
+    #[test]
+    fn record_and_snapshot() {
+        let tracker = MemoryFailOpenTracker::new();
+
+        tracker.record(MemoryFailOpenOperation::GetSession);
+        tracker.record(MemoryFailOpenOperation::GetSession);
+        tracker.record(MemoryFailOpenOperation::UpsertSessionMeta);
+        tracker.record(MemoryFailOpenOperation::QueryMemory);
+        tracker.record(MemoryFailOpenOperation::QueryMemory);
+        tracker.record(MemoryFailOpenOperation::QueryMemory);
+        tracker.record(MemoryFailOpenOperation::AppendMemory);
+
+        let snapshot = tracker.snapshot();
+        assert_eq!(snapshot.get_session_errors, 2);
+        assert_eq!(snapshot.upsert_session_meta_errors, 1);
+        assert_eq!(snapshot.query_memory_errors, 3);
+        assert_eq!(snapshot.append_memory_errors, 1);
+    }
+}

--- a/koduck-ai/src/reliability/mod.rs
+++ b/koduck-ai/src/reliability/mod.rs
@@ -3,4 +3,5 @@
 pub mod degrade;
 pub mod error;
 pub mod error_mapper;
+pub mod memory_fail_open;
 pub mod retry_budget;

--- a/koduck-memory/docs/adr/0020-memory-fail-open-strategy.md
+++ b/koduck-memory/docs/adr/0020-memory-fail-open-strategy.md
@@ -1,0 +1,91 @@
+# ADR-0020: Koduck AI Memory Fail-Open 策略落地
+
+- Status: Accepted
+- Date: 2026-04-12
+- Issue: #827
+
+## Context
+
+Task 6.1 (#825) 完成后，`koduck-ai` 已经通过 APISIX gRPC route 接入了 `koduck-memory` 的
+`GetSession`、`UpsertSessionMeta`、`QueryMemory`、`AppendMemory` 四个 RPC。
+
+但当前实现中，memory 服务故障会直接阻断主 chat 流程：
+
+1. `prepare_memory_context()` 中的 `get_session`、`upsert_session_meta`、`query_memory`
+   任一失败都会返回错误响应，用户无法得到回答。
+2. 同步 chat 模式下 `append_chat_turn` 失败也会阻断已生成的回答返回给用户。
+3. 缺少 memory 失败的结构化指标，运维无法从 `/metrics` 端点观测 fail-open 事件。
+
+设计文档 §7 明确要求 fail-open 原则：memory 故障不应阻塞主 chat。
+
+## Decision
+
+我们决定在 `koduck-ai` 的 `reliability` 模块中新增 `MemoryFailOpenTracker`，
+并改造所有 memory 调用点为 fail-open 模式：
+
+1. **新增 `MemoryFailOpenTracker`**（`reliability/memory_fail_open.rs`）：
+   - 使用 `AtomicU64` 计数器跟踪四种操作的失败次数。
+   - 暴露 `snapshot()` 方法供 `/metrics` 端点消费。
+   - 提供 `log_fail_open()` 方法同时记录指标和结构化 `warn!` 日志。
+   - 无配置开关 — fail-open 是无条件原则，不是可选功能。
+
+2. **`prepare_memory_context()` 改为 fail-open**：
+   - `get_session` 失败（非 `ResourceNotFound`）：记录指标，视为新会话继续。
+   - `upsert_session_meta` 失败：记录指标，跳过 session 元数据更新继续。
+   - `query_memory` 失败：记录指标，以空 hits 继续主 chat。
+   - 函数返回类型从 `Result<MemoryContextSnapshot, AppError>` 改为 `MemoryContextSnapshot`。
+
+3. **同步 chat `append_chat_turn` 改为 fail-open**：
+   - 回答已生成后 append 失败，仅记录指标和日志，不阻断响应返回。
+
+4. **Stub stream `append_chat_turn` 改为 fail-open**：
+   - 与同步 chat 相同策略，stub stream 继续推送。
+
+5. **`/metrics` 端点新增 `memory_fail_open` 字段**：
+   - 返回四种操作的累计失败次数 JSON。
+
+## Consequences
+
+正面影响：
+
+1. koduck-memory 任何故障都不会阻断用户对话，用户体验显著提升。
+2. 每次 fail-open 事件都有结构化日志（`request_id`、`session_id`、`operation`、`error.code`），
+   方便排障和告警。
+3. `/metrics` 端点提供累计计数，可接入 Grafana 面板和告警规则。
+
+代价与约束：
+
+1. `append_memory` 失败意味着对话 turn 不会被持久化。这是 fail-open 的固有代价，
+   可通过后续补偿机制（重试队列）缓解。
+2. 没有引入 circuit breaker — 每次 request 仍会尝试 gRPC 调用并在超时后降级。
+   如果 memory 服务完全宕机，每个请求会增加最多 3 秒的连接超时延迟。
+   Circuit breaker 可在后续版本中按需引入。
+3. fail-open 是无条件的，没有配置开关。如果未来需要强制 fail-close（例如调试场景），
+   需要额外扩展。
+
+## Compatibility Impact
+
+1. 不修改 `memory.v1` protobuf 契约，不引入 breaking change。
+2. `koduck-ai` 的 northbound HTTP API 完全兼容 — 用户看到的响应格式不变。
+3. `/metrics` 端点新增 `memory_fail_open` 字段，属于向后兼容增强。
+4. 日志中新增 `memory_fail_open.operation` 字段，不影响现有日志解析。
+
+## Alternatives Considered
+
+### Alternative A: 仅对 `QueryMemory` 做 fail-open，其余保持 fail-close
+
+未采用。
+设计文档 §7 明确要求所有 memory 操作都要 fail-open。
+`GetSession` / `UpsertSessionMeta` 失败阻断 chat 同样不可接受。
+
+### Alternative B: 引入 circuit breaker 跳过已知的不可用 memory 服务
+
+未采用（本次）。
+Circuit breaker 是有价值的增强，但增加复杂度且不属于 Task 6.2 的范围。
+当前 3 秒连接超时在 dev 环境下可接受，circuit breaker 可作为后续优化。
+
+### Alternative C: fail-open 通过配置开关控制
+
+未采用。
+设计文档将 fail-open 定义为原则而非功能。无条件 fail-open 更简单、更安全，
+避免因配置错误导致意外的 fail-close 行为。


### PR DESCRIPTION
## Summary

- `prepare_memory_context()` 不再因 memory 服务故障返回错误，改为 fail-open：`GetSession`/`UpsertSessionMeta`/`QueryMemory` 失败时记录指标和日志，以空上下文继续主 chat
- 同步 chat 和 stub stream 中的 `append_chat_turn` 失败不再阻断响应返回
- 新增 `MemoryFailOpenTracker`（`reliability/memory_fail_open.rs`），使用 AtomicU64 计数器跟踪四种操作的失败次数
- `/metrics` 端点新增 `memory_fail_open` 字段，暴露累计失败计数
- 新增 ADR-0020 记录 fail-open 设计决策

## Test plan

- [x] `docker build -t koduck-ai:dev` 编译通过
- [x] `docker build -t koduck-memory:dev` 编译通过
- [x] `kubectl rollout restart deployment dev-koduck-ai -n koduck-dev` 成功
- [ ] 手动验证：停止 koduck-memory 后 chat 仍能返回响应
- [ ] 手动验证：`curl /metrics` 返回 `memory_fail_open` 字段
- [ ] 新增单元测试 `MemoryFailOpenTracker` 通过

Closes #827

🤖 Generated with [Claude Code](https://claude.com/claude-code)