### PR TITLE
feat(memory): add async summarize task

### DIFF
--- a/docs/implementation/koduck-memory-koduck-ai-tasks.md
+++ b/docs/implementation/koduck-memory-koduck-ai-tasks.md
@@ -309,8 +309,8 @@
 3. 输出 `summary` 与 `domain_class`
 
 **验收标准:**
-- [ ] summary 可生成并持久化
-- [ ] `domain_class` 可被 `DOMAIN_FIRST` 消费
+- [x] summary 可生成并持久化
+- [x] `domain_class` 可被 `DOMAIN_FIRST` 消费
 
 ### Task 7.2: 实现 facts 提炼
 **详细要求:**

--- a/k8s/base/koduck-memory.yaml
+++ b/k8s/base/koduck-memory.yaml
@@ -114,4 +114,4 @@ stringData:
   OBJECT_STORE__REGION: "ap-east-1"
   INDEX__MODE: "domain-first"
   CAPABILITIES__TTL_SECS: "60"
-  SUMMARY__ASYNC_ENABLED: "false"
+  SUMMARY__ASYNC_ENABLED: "true"

--- a/k8s/overlays/dev/koduck-memory.yaml
+++ b/k8s/overlays/dev/koduck-memory.yaml
@@ -50,4 +50,4 @@ stringData:
   OBJECT_STORE__REGION: "ap-east-1"
   INDEX__MODE: "domain-first"
   CAPABILITIES__TTL_SECS: "60"
-  SUMMARY__ASYNC_ENABLED: "false"
+  SUMMARY__ASYNC_ENABLED: "true"

--- a/koduck-memory/config/default.toml
+++ b/koduck-memory/config/default.toml
@@ -24,4 +24,4 @@ mode = "domain-first"
 ttl_secs = 60
 
 [summary]
-async_enabled = false
+async_enabled = true

--- a/koduck-memory/docs/adr/0020-async-summary-task-materialization.md
+++ b/koduck-memory/docs/adr/0020-async-summary-task-materialization.md
@@ -1,0 +1,78 @@
+# ADR-0020: 异步摘要任务与摘要物化
+
+- Status: Accepted
+- Date: 2026-04-12
+- Issue: #831
+
+## Context
+
+`koduck-memory` 之前已经完成了会话元数据、原始记忆写入和基础检索路径，
+但 `SummarizeMemory` 仍然只是占位实现。按照设计文档，
+Task 7.1 需要满足三件事：
+
+1. `SummarizeMemory` 只负责投递任务，不阻塞主链路。
+2. 摘要结果要落到 `memory_summaries`。
+3. 生成出来的 `domain_class` 需要能被 `DOMAIN_FIRST` 检索消费。
+
+如果只把摘要文本写入 `memory_summaries`，而不把它物化进当前检索路径，
+那么 session 级摘要就无法参与现有 `QueryMemory`。反过来，如果把摘要同步生成，
+又会违背“主链路 fail-open、摘要异步化”的要求。
+
+## Decision
+
+我们决定采用“异步投递 + 双写物化”的最小闭环：
+
+1. `SummarizeMemory` RPC 只负责：
+   - 校验 `RequestMeta`
+   - 基于 `idempotency_key` 去重
+   - 投递后台 `tokio::spawn` 任务
+   - 立即返回 accepted 响应
+2. 后台任务通过 `SummaryTaskRunner` 执行：
+   - 读取 `memory_entries`
+   - 结合 session 标题与最近消息生成确定性摘要文本
+   - 推断粗粒度 `domain_class`
+   - 将结果写入 `memory_summaries`
+3. 每次摘要完成后，再额外生成一条 `memory_index_records`：
+   - `memory_kind = "summary"`
+   - `domain_class =` 推断结果
+   - `summary/snippet =` 生成的摘要文本
+   - `source_uri = memory-summary://...`
+
+## Consequences
+
+正面影响：
+
+1. `SummarizeMemory` 真正变成任务投递接口，不再阻塞主链路。
+2. `memory_summaries` 成为摘要真值表，后续 facts / retry / compensation 可以继续叠加。
+3. `DOMAIN_FIRST` 不需要改协议和主逻辑，就能直接消费摘要物化结果。
+
+代价与权衡：
+
+1. 当前摘要生成仍是规则化实现，不依赖 LLM，因此质量优先保证稳定和可解释，而不是语义最优。
+2. 摘要会同时存在于 `memory_summaries` 和 `memory_index_records`，带来可接受的冗余。
+3. 失败处理目前先靠日志告警；系统化重试和补偿留给 Task 7.3。
+
+## Compatibility Impact
+
+1. 不修改 `memory.v1` protobuf tag，也不引入 breaking change。
+2. `SummarizeMemoryResponse.summary` 现在返回 accepted 文案，而不是占位错误，属于向前兼容增强。
+3. `QueryMemory` 继续走既有的 `memory_index_records`，不需要额外 northbound 适配。
+
+## Alternatives Considered
+
+### Alternative A: 直接同步生成摘要并在 RPC 中返回结果
+
+未采用。  
+这会直接把摘要生成延迟暴露到主链路，违背设计文档对异步任务化的约束。
+
+### Alternative B: 只写 `memory_summaries`，不写 `memory_index_records`
+
+未采用。  
+这样虽然有了摘要真值，但现有 `DOMAIN_FIRST` 路径无法消费 `domain_class` 结果，
+Task 7.1 的第二条验收标准无法成立。
+
+### Alternative C: 引入独立任务表/队列系统
+
+本阶段未采用。  
+这是更完整的长期方向，但会把 Task 7.1 扩大成任务系统建设。
+当前先用进程内后台任务完成“最小可运行闭环”，后续在 Task 7.3 再补重试与补偿。

--- a/koduck-memory/src/capability/service.rs
+++ b/koduck-memory/src/capability/service.rs
@@ -12,6 +12,7 @@ use crate::config::AppConfig;
 use crate::index::MemoryIndexRepository;
 use crate::memory::{IdempotencyRepository, InsertMemoryEntry, MemoryEntryRepository, metadata_to_jsonb};
 use crate::retrieve::{DomainFirstRetriever, RetrieveContext, SummaryFirstRetriever};
+use crate::summary::{SummaryJob, SummaryTaskRunner};
 use crate::session::{SessionRepository, UpsertSession, extra_to_jsonb, parse_optional_uuid, parse_uuid};
 use crate::store::{L0EntryContent, ObjectStoreClient, RuntimeState};
 
@@ -97,17 +98,6 @@ impl MemoryGrpcService {
             features,
             limits,
         }
-    }
-
-    fn not_implemented_error(method: &str) -> Option<ErrorDetail> {
-        Some(ErrorDetail {
-            code: "NOT_IMPLEMENTED".to_string(),
-            message: format!("{method} is not implemented yet"),
-            retryable: false,
-            degraded: false,
-            upstream: "koduck-memory".to_string(),
-            retry_after_ms: 0,
-        })
     }
 
     fn validate_meta(meta: &RequestMeta) -> Result<(), Status> {
@@ -526,16 +516,68 @@ impl MemoryService for MemoryGrpcService {
         &self,
         request: Request<SummarizeMemoryRequest>,
     ) -> Result<Response<SummarizeMemoryResponse>, Status> {
-        Self::validate_write_meta(request.get_ref().meta.as_ref().ok_or_else(|| {
-            Status::invalid_argument("meta is required")
-        })?)?;
+        let req = request.get_ref();
+        let meta = req
+            .meta
+            .as_ref()
+            .ok_or_else(|| Status::invalid_argument("meta is required"))?;
+        Self::validate_write_meta(meta)?;
+
+        let session_id =
+            parse_uuid(&req.session_id).map_err(|e| Status::invalid_argument(format!("invalid session_id: {e}")))?;
+
+        if !self.config.summary.async_enabled {
+            return Ok(Response::new(SummarizeMemoryResponse {
+                ok: false,
+                summary: String::new(),
+                error: Some(ErrorDetail {
+                    code: "SUMMARY_ASYNC_DISABLED".to_string(),
+                    message: "summary.async_enabled is disabled".to_string(),
+                    retryable: false,
+                    degraded: false,
+                    upstream: "koduck-memory".to_string(),
+                    retry_after_ms: 0,
+                }),
+            }));
+        }
+
+        let accepted = self
+            .idempotency_repo()
+            .try_record(
+                &meta.idempotency_key,
+                &meta.tenant_id,
+                session_id,
+                "summarize_memory",
+                &meta.request_id,
+            )
+            .await
+            .map_err(|e| Status::internal(format!("summary idempotency check failed: {e}")))?;
+
+        if !accepted {
+            return Ok(Response::new(SummarizeMemoryResponse {
+                ok: true,
+                summary: format!("summary task already accepted for session {}", req.session_id),
+                error: None,
+            }));
+        }
+
+        let runner = SummaryTaskRunner::new(self.runtime.pool(), self.object_store.clone());
+        let job = SummaryJob::new(
+            meta.tenant_id.clone(),
+            session_id,
+            req.strategy.clone(),
+            meta.request_id.clone(),
+        );
+        tokio::spawn(async move {
+            if let Err(error) = runner.run(job).await {
+                tracing::warn!(error = %error, "summary task failed");
+            }
+        });
+
         Ok(Response::new(SummarizeMemoryResponse {
-            ok: false,
-            summary: format!(
-                "{} skeleton is ready; summarization will arrive in later phases",
-                self.config.app.name
-            ),
-            error: Self::not_implemented_error("SummarizeMemory"),
+            ok: true,
+            summary: format!("summary task accepted for session {}", req.session_id),
+            error: None,
         }))
     }
 }
@@ -547,12 +589,14 @@ mod tests {
     use super::MemoryGrpcService;
     use crate::api::{
         AppendMemoryRequest, GetSessionRequest, MemoryEntry, MemoryServiceClient,
-        MemoryServiceServer, RequestMeta, UpsertSessionMetaRequest,
+        MemoryServiceServer, QueryMemoryRequest, RequestMeta, SummarizeMemoryRequest,
+        UpsertSessionMetaRequest,
     };
     use crate::config::{
         AppConfig, AppSection, CapabilitiesSection, IndexSection, ObjectStoreSection,
         PostgresSection, ServerSection, SummarySection,
     };
+    use crate::summary::MemorySummaryRepository;
     use crate::session::{SessionRepository, UpsertSession, extra_to_jsonb};
     use crate::store::RuntimeState;
     use tokio::net::TcpListener;
@@ -893,6 +937,20 @@ mod tests {
             deadline_ms: 5000,
             api_version: "memory.v1".to_string(),
         }
+    }
+
+    async fn wait_for_summary(
+        repo: &MemorySummaryRepository,
+        tenant_id: &str,
+        session_id: Uuid,
+    ) -> crate::summary::MemorySummary {
+        for _ in 0..20 {
+            if let Some(summary) = repo.latest_by_session(tenant_id, session_id).await.unwrap() {
+                return summary;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        panic!("summary was not materialized in time");
     }
 
     #[tokio::test]
@@ -1330,6 +1388,159 @@ mod tests {
         assert!(resp.ok);
         assert_eq!(resp.appended_count, 0);
         assert!(resp.error.is_none());
+
+        let _ = shutdown_tx.send(());
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn summarize_memory_materializes_summary_and_domain_class() {
+        let mut config = test_config();
+        config.summary.async_enabled = true;
+        let runtime = RuntimeState::initialize(&config).await.unwrap();
+        let summary_repo = MemorySummaryRepository::new(runtime.pool());
+        let (mut client, shutdown_tx, server) = start_test_server(config, runtime).await;
+
+        let session_id = Uuid::new_v4();
+        let sid_str = session_id.to_string();
+
+        client
+            .upsert_session_meta(UpsertSessionMetaRequest {
+                meta: Some(write_meta_with_idempotency("t71-seed-session", &sid_str)),
+                session_id: sid_str.clone(),
+                title: "Task follow-up session".to_string(),
+                status: "active".to_string(),
+                parent_session_id: String::new(),
+                forked_from_session_id: String::new(),
+                last_message_at: 1700000000000,
+                extra: [].into(),
+            })
+            .await
+            .unwrap();
+
+        client
+            .append_memory(AppendMemoryRequest {
+                meta: Some(write_meta_with_idempotency("t71-append", &sid_str)),
+                session_id: sid_str.clone(),
+                entries: vec![
+                    MemoryEntry {
+                        role: "user".to_string(),
+                        content: "Please track the rollout task".to_string(),
+                        timestamp: 1700000000000,
+                        metadata: std::collections::HashMap::new(),
+                    },
+                    MemoryEntry {
+                        role: "assistant".to_string(),
+                        content: "I will prepare the follow-up steps".to_string(),
+                        timestamp: 1700000001000,
+                        metadata: std::collections::HashMap::new(),
+                    },
+                ],
+            })
+            .await
+            .unwrap();
+
+        let summarize = client
+            .summarize_memory(SummarizeMemoryRequest {
+                meta: Some(write_meta_with_idempotency("t71-summary", &sid_str)),
+                session_id: sid_str.clone(),
+                strategy: "session-rollup".to_string(),
+            })
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert!(summarize.ok);
+        assert!(summarize.error.is_none());
+        assert!(summarize.summary.contains("accepted"));
+
+        let stored = wait_for_summary(&summary_repo, "tenant-t33", session_id).await;
+        assert_eq!(stored.domain_class, "task");
+        assert_eq!(stored.strategy, "session-rollup");
+        assert!(stored.summary.contains("Task follow-up session"));
+
+        let _ = shutdown_tx.send(());
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn summarize_memory_domain_class_is_queryable_via_domain_first() {
+        let mut config = test_config();
+        config.summary.async_enabled = true;
+        let runtime = RuntimeState::initialize(&config).await.unwrap();
+        let summary_repo = MemorySummaryRepository::new(runtime.pool());
+        let (mut client, shutdown_tx, server) = start_test_server(config, runtime).await;
+
+        let session_id = Uuid::new_v4();
+        let sid_str = session_id.to_string();
+
+        client
+            .upsert_session_meta(UpsertSessionMetaRequest {
+                meta: Some(write_meta_with_idempotency("t71-query-session", &sid_str)),
+                session_id: sid_str.clone(),
+                title: "Task board".to_string(),
+                status: "active".to_string(),
+                parent_session_id: String::new(),
+                forked_from_session_id: String::new(),
+                last_message_at: 1700000000000,
+                extra: [].into(),
+            })
+            .await
+            .unwrap();
+
+        client
+            .append_memory(AppendMemoryRequest {
+                meta: Some(write_meta_with_idempotency("t71-query-append", &sid_str)),
+                session_id: sid_str.clone(),
+                entries: vec![MemoryEntry {
+                    role: "user".to_string(),
+                    content: "Need a task summary".to_string(),
+                    timestamp: 1700000002000,
+                    metadata: std::collections::HashMap::new(),
+                }],
+            })
+            .await
+            .unwrap();
+
+        client
+            .summarize_memory(SummarizeMemoryRequest {
+                meta: Some(write_meta_with_idempotency("t71-query-summary", &sid_str)),
+                session_id: sid_str.clone(),
+                strategy: String::new(),
+            })
+            .await
+            .unwrap();
+
+        let stored = wait_for_summary(&summary_repo, "tenant-t33", session_id).await;
+        assert_eq!(stored.domain_class, "task");
+
+        let response = client
+            .query_memory(QueryMemoryRequest {
+                meta: Some(write_meta_with_idempotency("t71-query-memory", &sid_str)),
+                session_id: sid_str.clone(),
+                query_text: "task".to_string(),
+                domain_class: "task".to_string(),
+                top_k: 5,
+                retrieve_policy: 1,
+                page_token: String::new(),
+            })
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert!(response.ok);
+        assert!(
+            response
+                .hits
+                .iter()
+                .any(|hit| hit.l0_uri.starts_with("memory-summary://"))
+        );
+        assert!(
+            response
+                .hits
+                .iter()
+                .any(|hit| hit.match_reasons.contains(&"domain_class_hit".to_string()))
+        );
 
         let _ = shutdown_tx.send(());
         server.await.unwrap();

--- a/koduck-memory/src/store/object_store.rs
+++ b/koduck-memory/src/store/object_store.rs
@@ -128,6 +128,27 @@ impl ObjectStoreClient {
         Ok(uri)
     }
 
+    /// Fetch and deserialize a previously stored L0 entry.
+    pub async fn get_l0_entry(&self, uri: &str) -> Result<L0EntryContent> {
+        let (bucket, key) = parse_l0_uri(uri)?;
+        let response = self
+            .client
+            .get_object()
+            .bucket(bucket)
+            .key(key)
+            .send()
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to fetch L0 entry: {e}"))?;
+        let bytes = response
+            .body
+            .collect()
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to read L0 entry body: {e}"))?
+            .into_bytes();
+
+        Ok(serde_json::from_slice::<L0EntryContent>(&bytes)?)
+    }
+
     /// Get the bucket name.
     pub fn bucket(&self) -> &str {
         &self.bucket
@@ -167,10 +188,22 @@ impl ObjectStoreClient {
     }
 }
 
+fn parse_l0_uri(uri: &str) -> Result<(&str, &str)> {
+    let without_scheme = uri
+        .strip_prefix("s3://")
+        .ok_or_else(|| anyhow::anyhow!("invalid L0 uri: {uri}"))?;
+    let (bucket, key) = without_scheme
+        .split_once('/')
+        .ok_or_else(|| anyhow::anyhow!("invalid L0 uri: {uri}"))?;
+    if bucket.trim().is_empty() || key.trim().is_empty() {
+        anyhow::bail!("invalid L0 uri: {uri}");
+    }
+    Ok((bucket, key))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde_json::json;
 
     fn test_config() -> ObjectStoreSection {
         ObjectStoreSection {
@@ -204,5 +237,12 @@ mod tests {
     fn l0_uri_format_is_correct() {
         let uri = build_l0_uri("my-bucket", "path/to/object.json");
         assert_eq!(uri, "s3://my-bucket/path/to/object.json");
+    }
+
+    #[test]
+    fn parse_l0_uri_extracts_bucket_and_key() {
+        let (bucket, key) = parse_l0_uri("s3://my-bucket/path/to/object.json").unwrap();
+        assert_eq!(bucket, "my-bucket");
+        assert_eq!(key, "path/to/object.json");
     }
 }

--- a/koduck-memory/src/summary/mod.rs
+++ b/koduck-memory/src/summary/mod.rs
@@ -1,1 +1,9 @@
-//! Summary module placeholder for asynchronous summarization and fact extraction.
+//! Summary materialization for asynchronous session summarization.
+
+mod model;
+mod repository;
+mod runner;
+
+pub use model::{InsertMemorySummary, MemorySummary};
+pub use repository::MemorySummaryRepository;
+pub use runner::{SummaryJob, SummaryTaskRunner};

--- a/koduck-memory/src/summary/model.rs
+++ b/koduck-memory/src/summary/model.rs
@@ -1,0 +1,74 @@
+use serde::{Deserialize, Serialize};
+use sqlx::FromRow;
+use uuid::Uuid;
+
+/// Domain model for `memory_summaries`.
+#[derive(Debug, Clone, FromRow, Serialize, Deserialize)]
+pub struct MemorySummary {
+    pub id: Uuid,
+    pub tenant_id: String,
+    pub session_id: Uuid,
+    pub domain_class: String,
+    pub summary: String,
+    pub strategy: String,
+    pub version: i32,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// Insert parameters for `memory_summaries`.
+#[derive(Debug, Clone)]
+pub struct InsertMemorySummary {
+    pub id: Uuid,
+    pub tenant_id: String,
+    pub session_id: Uuid,
+    pub domain_class: String,
+    pub summary: String,
+    pub strategy: String,
+    pub version: i32,
+}
+
+impl InsertMemorySummary {
+    pub fn new(
+        tenant_id: impl Into<String>,
+        session_id: Uuid,
+        domain_class: impl Into<String>,
+        summary: impl Into<String>,
+        strategy: impl Into<String>,
+        version: i32,
+    ) -> Self {
+        Self {
+            id: Uuid::new_v4(),
+            tenant_id: tenant_id.into(),
+            session_id,
+            domain_class: domain_class.into(),
+            summary: summary.into(),
+            strategy: strategy.into(),
+            version,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn insert_summary_builder_works() {
+        let session_id = Uuid::new_v4();
+        let params = InsertMemorySummary::new(
+            "tenant-1",
+            session_id,
+            "task",
+            "summary text",
+            "session-rollup",
+            2,
+        );
+
+        assert_eq!(params.tenant_id, "tenant-1");
+        assert_eq!(params.session_id, session_id);
+        assert_eq!(params.domain_class, "task");
+        assert_eq!(params.summary, "summary text");
+        assert_eq!(params.strategy, "session-rollup");
+        assert_eq!(params.version, 2);
+    }
+}

--- a/koduck-memory/src/summary/repository.rs
+++ b/koduck-memory/src/summary/repository.rs
@@ -1,0 +1,90 @@
+use sqlx::PgPool;
+use tracing::info;
+use uuid::Uuid;
+
+use crate::summary::model::{InsertMemorySummary, MemorySummary};
+use crate::Result;
+
+/// DAO for `memory_summaries`.
+#[derive(Clone)]
+pub struct MemorySummaryRepository {
+    pool: PgPool,
+}
+
+impl MemorySummaryRepository {
+    pub fn new(pool: &PgPool) -> Self {
+        Self { pool: pool.clone() }
+    }
+
+    pub async fn next_version(&self, tenant_id: &str, session_id: Uuid) -> Result<i32> {
+        let version = sqlx::query_scalar::<_, i32>(
+            r#"
+            SELECT COALESCE(MAX(version), 0) + 1
+            FROM memory_summaries
+            WHERE tenant_id = $1 AND session_id = $2
+            "#,
+        )
+        .bind(tenant_id)
+        .bind(session_id)
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(version)
+    }
+
+    pub async fn insert(&self, params: &InsertMemorySummary) -> Result<MemorySummary> {
+        let row = sqlx::query_as::<_, MemorySummary>(
+            r#"
+            INSERT INTO memory_summaries (
+                id, tenant_id, session_id, domain_class, summary, strategy, version, created_at
+            ) VALUES (
+                $1, $2, $3, $4, $5, $6, $7, now()
+            )
+            RETURNING
+                id, tenant_id, session_id, domain_class, summary, strategy, version, created_at
+            "#,
+        )
+        .bind(params.id)
+        .bind(&params.tenant_id)
+        .bind(params.session_id)
+        .bind(&params.domain_class)
+        .bind(&params.summary)
+        .bind(&params.strategy)
+        .bind(params.version)
+        .fetch_one(&self.pool)
+        .await?;
+
+        info!(
+            summary_id = %row.id,
+            session_id = %row.session_id,
+            version = row.version,
+            domain_class = %row.domain_class,
+            "memory summary inserted"
+        );
+
+        Ok(row)
+    }
+
+    pub async fn latest_by_session(
+        &self,
+        tenant_id: &str,
+        session_id: Uuid,
+    ) -> Result<Option<MemorySummary>> {
+        let row = sqlx::query_as::<_, MemorySummary>(
+            r#"
+            SELECT
+                id, tenant_id, session_id, domain_class, summary, strategy, version, created_at
+            FROM memory_summaries
+            WHERE tenant_id = $1 AND session_id = $2
+            ORDER BY version DESC
+            LIMIT 1
+            "#,
+        )
+        .bind(tenant_id)
+        .bind(session_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row)
+    }
+}

--- a/koduck-memory/src/summary/runner.rs
+++ b/koduck-memory/src/summary/runner.rs
@@ -1,0 +1,274 @@
+use sqlx::PgPool;
+use tracing::{info, instrument};
+use uuid::Uuid;
+
+use crate::index::{InsertMemoryIndexRecord, MemoryIndexRepository};
+use crate::memory::MemoryEntryRepository;
+use crate::retrieve::domain_class;
+use crate::session::SessionRepository;
+use crate::store::ObjectStoreClient;
+use crate::summary::{InsertMemorySummary, MemorySummary, MemorySummaryRepository};
+use crate::Result;
+
+const DEFAULT_STRATEGY: &str = "session-rollup";
+const MAX_SUMMARY_INPUTS: usize = 6;
+const MAX_SNIPPET_CHARS: usize = 220;
+const MAX_SUMMARY_CHARS: usize = 1_200;
+
+#[derive(Debug, Clone)]
+pub struct SummaryJob {
+    pub tenant_id: String,
+    pub session_id: Uuid,
+    pub strategy: String,
+    pub request_id: String,
+}
+
+impl SummaryJob {
+    pub fn new(
+        tenant_id: impl Into<String>,
+        session_id: Uuid,
+        strategy: impl Into<String>,
+        request_id: impl Into<String>,
+    ) -> Self {
+        Self {
+            tenant_id: tenant_id.into(),
+            session_id,
+            strategy: normalize_strategy(strategy.into()),
+            request_id: request_id.into(),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct SummaryTaskRunner {
+    entry_repo: MemoryEntryRepository,
+    session_repo: SessionRepository,
+    summary_repo: MemorySummaryRepository,
+    index_repo: MemoryIndexRepository,
+    object_store: Option<ObjectStoreClient>,
+}
+
+impl SummaryTaskRunner {
+    pub fn new(pool: &PgPool, object_store: Option<ObjectStoreClient>) -> Self {
+        Self {
+            entry_repo: MemoryEntryRepository::new(pool),
+            session_repo: SessionRepository::new(pool),
+            summary_repo: MemorySummaryRepository::new(pool),
+            index_repo: MemoryIndexRepository::new(pool),
+            object_store,
+        }
+    }
+
+    #[instrument(skip(self), fields(tenant_id = %job.tenant_id, session_id = %job.session_id, strategy = %job.strategy, request_id = %job.request_id))]
+    pub async fn run(&self, job: SummaryJob) -> Result<MemorySummary> {
+        let mut entries = self
+            .entry_repo
+            .list_by_session(&job.tenant_id, job.session_id, None)
+            .await?;
+        entries.sort_by_key(|entry| entry.sequence_num);
+
+        let session = self
+            .session_repo
+            .get_by_id(&job.tenant_id, job.session_id)
+            .await?;
+
+        let transcript = build_transcript_fragments(&entries, self.object_store.as_ref()).await;
+        let inferred_domain_class =
+            infer_domain_class(&transcript, session.as_ref().map(|s| s.title.as_str()));
+        let summary_text = build_summary_text(
+            &transcript,
+            entries.len(),
+            session.as_ref().map(|s| s.title.as_str()),
+            &inferred_domain_class,
+        );
+        let version = self.summary_repo.next_version(&job.tenant_id, job.session_id).await?;
+
+        let insert_summary = InsertMemorySummary::new(
+            job.tenant_id.clone(),
+            job.session_id,
+            inferred_domain_class.clone(),
+            summary_text.clone(),
+            job.strategy.clone(),
+            version,
+        );
+        let stored = self.summary_repo.insert(&insert_summary).await?;
+
+        let summary_uri = build_summary_uri(&stored.tenant_id, stored.session_id, stored.version);
+        let index_record = InsertMemoryIndexRecord::new(
+            stored.tenant_id.clone(),
+            stored.session_id,
+            "summary",
+            stored.domain_class.clone(),
+            stored.summary.clone(),
+            summary_uri,
+        )
+        .with_snippet(build_snippet(&stored.summary))
+        .with_score_hint("0.95");
+        self.index_repo.insert(&index_record).await?;
+
+        info!(
+            summary_id = %stored.id,
+            version = stored.version,
+            domain_class = %stored.domain_class,
+            "summary task completed"
+        );
+
+        Ok(stored)
+    }
+}
+
+async fn build_transcript_fragments(
+    entries: &[crate::memory::MemoryEntry],
+    object_store: Option<&ObjectStoreClient>,
+) -> Vec<String> {
+    let start = entries.len().saturating_sub(MAX_SUMMARY_INPUTS);
+    let mut fragments = Vec::new();
+
+    for entry in &entries[start..] {
+        let maybe_content = match object_store {
+            Some(client) => client
+                .get_l0_entry(&entry.l0_uri)
+                .await
+                .ok()
+                .map(|content| content.content),
+            None => None,
+        };
+
+        let fragment = match maybe_content {
+            Some(content) if !content.trim().is_empty() => {
+                format!("{}: {}", entry.role, truncate_text(&content, 140))
+            }
+            _ => format!("{} message #{}", entry.role, entry.sequence_num),
+        };
+        fragments.push(fragment);
+    }
+
+    fragments
+}
+
+fn build_summary_text(
+    transcript: &[String],
+    entry_count: usize,
+    session_title: Option<&str>,
+    inferred_domain_class: &str,
+) -> String {
+    let title_prefix = session_title
+        .filter(|title| !title.trim().is_empty())
+        .map(|title| format!("Session '{title}'"))
+        .unwrap_or_else(|| "Session".to_string());
+
+    if transcript.is_empty() {
+        return format!(
+            "{title_prefix} produced an asynchronous summary with {entry_count} stored messages. The dominant domain class is {inferred_domain_class}."
+        );
+    }
+
+    let joined = transcript.join(" | ");
+    truncate_text(
+        &format!(
+            "{title_prefix} summary ({inferred_domain_class}, {entry_count} messages): {joined}"
+        ),
+        MAX_SUMMARY_CHARS,
+    )
+}
+
+fn infer_domain_class(transcript: &[String], session_title: Option<&str>) -> String {
+    let mut corpus = transcript.join(" ").to_lowercase();
+    if let Some(title) = session_title {
+        corpus.push(' ');
+        corpus.push_str(&title.to_lowercase());
+    }
+
+    if [
+        "task",
+        "todo",
+        "deadline",
+        "follow-up",
+        "fix",
+        "implement",
+        "任务",
+        "待办",
+        "修复",
+        "实现",
+    ]
+    .iter()
+    .any(|keyword| corpus.contains(keyword))
+    {
+        return domain_class::TASK.to_string();
+    }
+
+    if !transcript.is_empty()
+        && transcript
+            .iter()
+            .all(|line| line.starts_with("system:") || line.starts_with("system "))
+    {
+        return domain_class::SYSTEM.to_string();
+    }
+
+    domain_class::CHAT.to_string()
+}
+
+fn build_summary_uri(tenant_id: &str, session_id: Uuid, version: i32) -> String {
+    format!(
+        "memory-summary://tenants/{tenant_id}/sessions/{session_id}/versions/{version}"
+    )
+}
+
+fn build_snippet(summary: &str) -> String {
+    truncate_text(summary, MAX_SNIPPET_CHARS)
+}
+
+fn truncate_text(input: &str, limit: usize) -> String {
+    let trimmed = input.trim();
+    if trimmed.chars().count() <= limit {
+        return trimmed.to_string();
+    }
+
+    let truncated: String = trimmed.chars().take(limit.saturating_sub(3)).collect();
+    format!("{truncated}...")
+}
+
+fn normalize_strategy(strategy: String) -> String {
+    let trimmed = strategy.trim();
+    if trimmed.is_empty() {
+        DEFAULT_STRATEGY.to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn infer_domain_class_prefers_task_keywords() {
+        let transcript = vec!["user: please fix the deployment task".to_string()];
+        assert_eq!(infer_domain_class(&transcript, None), domain_class::TASK);
+    }
+
+    #[test]
+    fn infer_domain_class_falls_back_to_chat() {
+        let transcript = vec![
+            "user: hello there".to_string(),
+            "assistant: happy to help".to_string(),
+        ];
+        assert_eq!(
+            infer_domain_class(&transcript, Some("General chat")),
+            domain_class::CHAT
+        );
+    }
+
+    #[test]
+    fn build_summary_uri_formats_stably() {
+        let uri = build_summary_uri(
+            "tenant-1",
+            Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap(),
+            3,
+        );
+        assert_eq!(
+            uri,
+            "memory-summary://tenants/tenant-1/sessions/550e8400-e29b-41d4-a716-446655440000/versions/3"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- implement asynchronous `SummarizeMemory` task dispatch and background materialization
- persist generated summaries into `memory_summaries` and materialize a summary index record for `DOMAIN_FIRST`
- enable summary async in default/dev config and document the decision in ADR-0020

## Verification
- `docker build -t koduck-memory:dev ./koduck-memory`
- `kubectl rollout status deployment/dev-koduck-memory -n koduck-dev --timeout=240s`
- verified new pod startup logs show `summary.async_enabled=true`

Closes #831
