### PR TITLE
feat(memory): add RPC observability and SLO for key gRPC methods (Task 8.3)

### DIFF
--- a/docs/implementation/koduck-memory-koduck-ai-tasks.md
+++ b/docs/implementation/koduck-memory-koduck-ai-tasks.md
@@ -361,8 +361,8 @@
 3. 定义基础 SLO 与错误预算
 
 **验收标准:**
-- [ ] `GetSession / QueryMemory / AppendMemory` 可观察
-- [ ] latency / error rate 可统计
+- [x] `GetSession / QueryMemory / AppendMemory` 可观察
+- [x] latency / error rate 可统计
 
 ### Task 8.4: 灰度与回滚演练
 **详细要求:**

--- a/koduck-memory/docs/adr/0024-observability-and-slo.md
+++ b/koduck-memory/docs/adr/0024-observability-and-slo.md
@@ -1,0 +1,109 @@
+# ADR-0024: RPC 可观测性与 SLO
+
+- Status: Accepted
+- Date: 2026-04-12
+- Issue: #841
+
+## Context
+
+设计文档（Section 13.4）明确要求为关键 RPC 增加可观测性能力：
+
+- **指标**：`memory_rpc_requests_total`、`memory_rpc_latency_ms`、`memory_query_hits_count` 等
+- **维度**：`rpc`、`status`、`retrieve_policy`、`domain_class`、`tenant`
+- **日志**：必须包含 `request_id`、`session_id`、`trace_id`、`user_id`、`tenant_id`、`rpc`、`latency_ms`
+- **SLO**：定义基础 SLO 与错误预算
+
+当前实现状态：
+
+- 已有 `/metrics` 端点暴露 Prometheus 格式的指标（build_info、postgres pool、retry/failure counters）
+- 已有 `tracing-subscriber` JSON 日志输出
+- 缺少 **per-RPC 维度的请求计数和延迟指标**
+- 缺少 **RPC handler 中的结构化日志字段**
+- 缺少 **SLO 定义**
+
+## Decision
+
+### 1. 指标方案
+
+在现有手写 Prometheus 格式的基础上，增加 per-RPC 指标：
+
+```
+memory_rpc_requests_total{rpc="get_session",status="ok"} 42
+memory_rpc_requests_total{rpc="get_session",status="error"} 1
+memory_rpc_duration_ms_bucket{rpc="get_session",le="1"} 10
+memory_rpc_duration_ms_bucket{rpc="get_session",le="5"} 38
+...
+memory_rpc_duration_ms_sum{rpc="get_session"} 230.5
+memory_rpc_duration_ms_count{rpc="get_session"} 42
+```
+
+**实现方式**：
+
+- 使用 `std::sync::Mutex<HashMap>` 实现轻量级 histogram buckets，保持与现有方案一致（不引入 Prometheus client 库）
+- 提供 `RpcMetrics` 结构体，封装 `record()` 方法，在 RPC handler 的入口和出口调用
+- 指标通过现有 `metrics_handler` 的 `/metrics` 端点暴露
+
+**Histogram buckets**: `[1, 5, 10, 25, 50, 100, 250, 500, 1000, +Inf]` ms
+
+### 2. 结构化日志
+
+在每个 RPC handler 中使用 `tracing::info!` / `tracing::warn!` 记录结构化字段：
+
+```rust
+tracing::info!(
+    rpc = "get_session",
+    request_id = %meta.request_id,
+    session_id = %meta.session_id,
+    tenant_id = %meta.tenant_id,
+    user_id = %meta.user_id,
+    trace_id = %meta.trace_id,
+    latency_ms = elapsed.as_millis() as u64,
+    status = "ok",
+    "rpc completed"
+);
+```
+
+### 3. SLO 定义
+
+| SLO | 目标 | 说明 |
+|-----|------|------|
+| Availability | >= 99.9% | 月度可用性 |
+| p50 latency (GetSession) | <= 10ms | 读取类 RPC |
+| p99 latency (GetSession) | <= 50ms | |
+| p50 latency (QueryMemory) | <= 50ms | 检索类 RPC |
+| p99 latency (QueryMemory) | <= 500ms | |
+| p50 latency (AppendMemory) | <= 100ms | 写入类 RPC |
+| p99 latency (AppendMemory) | <= 2000ms | |
+| Error rate | <= 0.1% | 非客户端错误 |
+
+SLO 仅作文档记录，不引入 alerting 代码。
+
+## Consequences
+
+正面影响：
+
+1. 运维可通过 `/metrics` 端点实时监控 RPC 延迟和错误率
+2. 结构化日志支持按 request_id / trace_id 快速排障
+3. SLO 定义为后续告警规则提供基线
+4. 不引入外部依赖，保持现有 Prometheus 手写格式的一致性
+
+代价与权衡：
+
+1. 手写 histogram 不如 Prometheus client 库精确（无分位计算），但满足 V1 需求
+2. Metrics 数据存储在内存中，进程重启后清零，但符合 Prometheus pull 模型的预期
+
+## Compatibility Impact
+
+1. 不修改 `memory.v1` protobuf，不增加 breaking change
+2. `/metrics` 端点新增指标行，不影响现有 Prometheus scrape 配置
+3. 日志新增字段为向后兼容增强（JSON 格式新增 key，不删除现有 key）
+
+## Alternatives Considered
+
+### Alternative A: 引入 prometheus-client Rust 库
+
+未采用。现有项目已使用手写 Prometheus 格式，保持一致性优先。后续可迁移。
+
+### Alternative B: 使用 tonic gRPC interceptor 自动采集 metrics
+
+未采用。tonic 0.11 的 interceptor 功能有限，手动在 handler 中采集更灵活，可携带业务语义标签。

--- a/koduck-memory/src/app/lifecycle.rs
+++ b/koduck-memory/src/app/lifecycle.rs
@@ -1,4 +1,5 @@
 use std::net::SocketAddr;
+use std::sync::Arc;
 
 use tokio::net::TcpListener;
 use tokio::sync::broadcast;
@@ -8,7 +9,7 @@ use tracing::{error, info, warn};
 use crate::api::{MemoryServiceServer, FILE_DESCRIPTOR_SET};
 use crate::capability::MemoryGrpcService;
 use crate::config::AppConfig;
-use crate::observe;
+use crate::observe::{self, RpcMetrics};
 use crate::store::{ObjectStoreClient, RuntimeState};
 use crate::Result;
 
@@ -36,7 +37,9 @@ pub async fn run(config: AppConfig) -> Result<()> {
         }
     };
 
-    let grpc_service = MemoryGrpcService::new(config.clone(), runtime.clone(), object_store);
+    let rpc_metrics = Arc::new(RpcMetrics::new());
+    let grpc_service =
+        MemoryGrpcService::new(config.clone(), runtime.clone(), object_store, rpc_metrics.clone());
     let reflection = tonic_reflection::server::Builder::configure()
         .register_encoded_file_descriptor_set(FILE_DESCRIPTOR_SET)
         .build()?;
@@ -46,7 +49,8 @@ pub async fn run(config: AppConfig) -> Result<()> {
         .await;
 
     let metrics_listener = TcpListener::bind(metrics_addr).await?;
-    let metrics_router = observe::build_metrics_router(config.clone(), runtime.clone());
+    let metrics_router =
+        observe::build_metrics_router(config.clone(), runtime.clone(), rpc_metrics);
 
     let (shutdown_tx, _) = broadcast::channel::<()>(1);
     let mut metrics_shutdown_rx = shutdown_tx.subscribe();

--- a/koduck-memory/src/capability/service.rs
+++ b/koduck-memory/src/capability/service.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use tonic::{Request, Response, Status};
 use uuid::Uuid;
@@ -14,6 +15,8 @@ use crate::index::{InsertMemoryIndexRecord, MemoryIndexRepository};
 use crate::memory::{
     metadata_to_jsonb, IdempotencyRepository, InsertMemoryEntry, MemoryEntryRepository,
 };
+use crate::observe::RpcGuard;
+use crate::observe::RpcMetrics;
 use crate::retrieve::{domain_class, DomainFirstRetriever, RetrieveContext, SummaryFirstRetriever};
 use crate::reliability::{with_retry, TaskAttemptRepository};
 use crate::summary::{SummaryJob, SummaryTaskRunner};
@@ -31,6 +34,7 @@ pub struct MemoryGrpcService {
     config: AppConfig,
     runtime: RuntimeState,
     object_store: Option<ObjectStoreClient>,
+    rpc_metrics: Arc<RpcMetrics>,
 }
 
 impl MemoryGrpcService {
@@ -38,11 +42,13 @@ impl MemoryGrpcService {
         config: AppConfig,
         runtime: RuntimeState,
         object_store: Option<ObjectStoreClient>,
+        rpc_metrics: Arc<RpcMetrics>,
     ) -> Self {
         Self {
             config,
             runtime,
             object_store,
+            rpc_metrics,
         }
     }
 
@@ -294,39 +300,68 @@ impl MemoryService for MemoryGrpcService {
         &self,
         request: Request<GetSessionRequest>,
     ) -> Result<Response<GetSessionResponse>, Status> {
+        let mut guard = RpcGuard::new(&self.rpc_metrics, "get_session");
         let req = request.get_ref();
         let meta = req
             .meta
             .as_ref()
-            .ok_or_else(|| Status::invalid_argument("meta is required"))?;
-        Self::validate_meta(meta)?;
+            .ok_or_else(|| { guard.error(); Status::invalid_argument("meta is required") })?;
+        Self::validate_meta(meta).map_err(|e| { guard.error(); e })?;
 
         let session_id =
-            parse_uuid(&req.session_id).map_err(|e| Status::invalid_argument(format!("invalid session_id: {e}")))?;
+            parse_uuid(&req.session_id).map_err(|e| { guard.error(); Status::invalid_argument(format!("invalid session_id: {e}")) })?;
 
         match self
             .session_repo()
             .get_by_id(&meta.tenant_id, session_id)
             .await
-            .map_err(|e| Status::internal(format!("failed to get session: {e}")))?
+            .map_err(|e| { guard.error(); Status::internal(format!("failed to get session: {e}")) })?
         {
-            Some(session) => Ok(Response::new(GetSessionResponse {
-                ok: true,
-                session: Some(session.to_proto()),
-                error: None,
-            })),
-            None => Ok(Response::new(GetSessionResponse {
-                ok: false,
-                session: None,
-                error: Some(ErrorDetail {
-                    code: "RESOURCE_NOT_FOUND".to_string(),
-                    message: "session not found".to_string(),
-                    retryable: false,
-                    degraded: false,
-                    upstream: "koduck-memory".to_string(),
-                    retry_after_ms: 0,
-                }),
-            })),
+            Some(session) => {
+                tracing::info!(
+                    rpc = "get_session",
+                    request_id = %meta.request_id,
+                    session_id = %meta.session_id,
+                    tenant_id = %meta.tenant_id,
+                    user_id = %meta.user_id,
+                    trace_id = %meta.trace_id,
+                    latency_ms = guard.elapsed_ms(),
+                    status = "ok",
+                    found = true,
+                    "rpc completed"
+                );
+                Ok(Response::new(GetSessionResponse {
+                    ok: true,
+                    session: Some(session.to_proto()),
+                    error: None,
+                }))
+            }
+            None => {
+                tracing::info!(
+                    rpc = "get_session",
+                    request_id = %meta.request_id,
+                    session_id = %meta.session_id,
+                    tenant_id = %meta.tenant_id,
+                    user_id = %meta.user_id,
+                    trace_id = %meta.trace_id,
+                    latency_ms = guard.elapsed_ms(),
+                    status = "ok",
+                    found = false,
+                    "rpc completed"
+                );
+                Ok(Response::new(GetSessionResponse {
+                    ok: false,
+                    session: None,
+                    error: Some(ErrorDetail {
+                        code: "RESOURCE_NOT_FOUND".to_string(),
+                        message: "session not found".to_string(),
+                        retryable: false,
+                        degraded: false,
+                        upstream: "koduck-memory".to_string(),
+                        retry_after_ms: 0,
+                    }),
+                }))
+            }
         }
     }
 
@@ -334,12 +369,13 @@ impl MemoryService for MemoryGrpcService {
         &self,
         request: Request<QueryMemoryRequest>,
     ) -> Result<Response<QueryMemoryResponse>, Status> {
+        let mut guard = RpcGuard::new(&self.rpc_metrics, "query_memory");
         let req = request.get_ref();
         let meta = req
             .meta
             .as_ref()
-            .ok_or_else(|| Status::invalid_argument("meta is required"))?;
-        Self::validate_meta(meta)?;
+            .ok_or_else(|| { guard.error(); Status::invalid_argument("meta is required") })?;
+        Self::validate_meta(meta).map_err(|e| { guard.error(); e })?;
 
         // Build retrieve context
         let domain_class = if req.domain_class.is_empty() {
@@ -360,6 +396,13 @@ impl MemoryService for MemoryGrpcService {
         }
 
         // Execute retrieval based on policy
+        let retrieve_policy_name = match req.retrieve_policy {
+            1 => "domain_first",
+            2 => "summary_first",
+            3 => "hybrid",
+            _ => "unspecified",
+        };
+
         let results = match req.retrieve_policy {
             1 | 0 => {
                 // DOMAIN_FIRST (1) or UNSPECIFIED (0, default to DOMAIN_FIRST)
@@ -367,7 +410,7 @@ impl MemoryService for MemoryGrpcService {
                 retriever
                     .retrieve(&ctx)
                     .await
-                    .map_err(|e| Status::internal(format!("retrieval failed: {e}")))?
+                    .map_err(|e| { guard.error(); Status::internal(format!("retrieval failed: {e}")) })?
             }
             2 => {
                 // SUMMARY_FIRST (2)
@@ -375,7 +418,7 @@ impl MemoryService for MemoryGrpcService {
                 retriever
                     .retrieve(&ctx)
                     .await
-                    .map_err(|e| Status::internal(format!("retrieval failed: {e}")))?
+                    .map_err(|e| { guard.error(); Status::internal(format!("retrieval failed: {e}")) })?
             }
             3 => {
                 // HYBRID (3) - reserved for V2, fall back to DOMAIN_FIRST
@@ -387,7 +430,7 @@ impl MemoryService for MemoryGrpcService {
                 retriever
                     .retrieve(&ctx)
                     .await
-                    .map_err(|e| Status::internal(format!("retrieval failed: {e}")))?
+                    .map_err(|e| { guard.error(); Status::internal(format!("retrieval failed: {e}")) })?
             }
             _ => {
                 // Other policies not yet implemented, fall back to DOMAIN_FIRST
@@ -399,9 +442,11 @@ impl MemoryService for MemoryGrpcService {
                 retriever
                     .retrieve(&ctx)
                     .await
-                    .map_err(|e| Status::internal(format!("retrieval failed: {e}")))?
+                    .map_err(|e| { guard.error(); Status::internal(format!("retrieval failed: {e}")) })?
             }
         };
+
+        let hit_count = results.len();
 
         // Convert results to MemoryHit
         let hits: Vec<crate::api::MemoryHit> = results
@@ -415,6 +460,21 @@ impl MemoryService for MemoryGrpcService {
             })
             .collect();
 
+        tracing::info!(
+            rpc = "query_memory",
+            request_id = %meta.request_id,
+            session_id = %meta.session_id,
+            tenant_id = %meta.tenant_id,
+            user_id = %meta.user_id,
+            trace_id = %meta.trace_id,
+            latency_ms = guard.elapsed_ms(),
+            status = "ok",
+            hit_count = hit_count,
+            domain_class = %domain_class,
+            retrieve_policy = retrieve_policy_name,
+            "rpc completed"
+        );
+
         Ok(Response::new(QueryMemoryResponse {
             ok: true,
             hits,
@@ -427,12 +487,13 @@ impl MemoryService for MemoryGrpcService {
         &self,
         request: Request<AppendMemoryRequest>,
     ) -> Result<Response<AppendMemoryResponse>, Status> {
+        let mut guard = RpcGuard::new(&self.rpc_metrics, "append_memory");
         let req = request.get_ref();
         let meta = req
             .meta
             .as_ref()
-            .ok_or_else(|| Status::invalid_argument("meta is required"))?;
-        Self::validate_write_meta(meta)?;
+            .ok_or_else(|| { guard.error(); Status::invalid_argument("meta is required") })?;
+        Self::validate_write_meta(meta).map_err(|e| { guard.error(); e })?;
 
         if req.entries.is_empty() {
             return Ok(Response::new(AppendMemoryResponse {
@@ -443,7 +504,7 @@ impl MemoryService for MemoryGrpcService {
         }
 
         let session_id =
-            parse_uuid(&req.session_id).map_err(|e| Status::invalid_argument(format!("invalid session_id: {e}")))?;
+            parse_uuid(&req.session_id).map_err(|e| { guard.error(); Status::invalid_argument(format!("invalid session_id: {e}")) })?;
 
         // Step 1: Idempotency check
         let is_new = self
@@ -456,7 +517,7 @@ impl MemoryService for MemoryGrpcService {
                 &meta.request_id,
             )
             .await
-            .map_err(|e| Status::internal(format!("idempotency check failed: {e}")))?;
+            .map_err(|e| { guard.error(); Status::internal(format!("idempotency check failed: {e}")) })?;
 
         if !is_new {
             // Duplicate request — nothing new to append
@@ -475,7 +536,7 @@ impl MemoryService for MemoryGrpcService {
         let mut tx = pool
             .begin()
             .await
-            .map_err(|e| Status::internal(format!("failed to begin transaction: {e}")))?;
+            .map_err(|e| { guard.error(); Status::internal(format!("failed to begin transaction: {e}")) })?;
 
         // Serialize sequence allocation per tenant/session so concurrent appends
         // cannot observe the same base sequence number.
@@ -484,7 +545,7 @@ impl MemoryService for MemoryGrpcService {
             .bind(&sequence_lock_key)
             .fetch_one(&mut *tx)
             .await
-            .map_err(|e| Status::internal(format!("failed to acquire sequence lock: {e}")))?;
+            .map_err(|e| { guard.error(); Status::internal(format!("failed to acquire sequence lock: {e}")) })?;
 
         let base_seq = sqlx::query_scalar::<_, i64>(
             r#"
@@ -497,7 +558,7 @@ impl MemoryService for MemoryGrpcService {
         .bind(session_id)
         .fetch_one(&mut *tx)
         .await
-        .map_err(|e| Status::internal(format!("failed to query max sequence_num: {e}")))?;
+        .map_err(|e| { guard.error(); Status::internal(format!("failed to query max sequence_num: {e}")) })?;
 
         // Step 3: Prepare entries with L0 content and write to object storage first
         let mut entries_to_insert: Vec<(InsertMemoryEntry, InsertMemoryIndexRecord)> =
@@ -597,7 +658,7 @@ impl MemoryService for MemoryGrpcService {
             .bind(&insert.l0_uri)
             .execute(&mut *tx)
             .await
-            .map_err(|e| Status::internal(format!("failed to insert memory entry: {e}")))?;
+            .map_err(|e| { guard.error(); Status::internal(format!("failed to insert memory entry: {e}")) })?;
 
             if result.rows_affected() > 0 {
                 appended += 1;
@@ -626,19 +687,25 @@ impl MemoryService for MemoryGrpcService {
             .bind(&index_record.score_hint)
             .execute(&mut *tx)
             .await
-            .map_err(|e| Status::internal(format!("failed to insert memory index record: {e}")))?;
+            .map_err(|e| { guard.error(); Status::internal(format!("failed to insert memory index record: {e}")) })?;
         }
 
         tx.commit()
             .await
-            .map_err(|e| Status::internal(format!("failed to commit transaction: {e}")))?;
+            .map_err(|e| { guard.error(); Status::internal(format!("failed to commit transaction: {e}")) })?;
 
         tracing::info!(
-            session_id = %session_id,
+            rpc = "append_memory",
+            request_id = %meta.request_id,
+            session_id = %meta.session_id,
             tenant_id = %tenant_id,
+            user_id = %meta.user_id,
+            trace_id = %meta.trace_id,
+            latency_ms = guard.elapsed_ms(),
+            status = "ok",
             appended_count = appended,
             requested_count = entries_count,
-            "append_memory completed"
+            "rpc completed"
         );
 
         Ok(Response::new(AppendMemoryResponse {
@@ -727,6 +794,7 @@ mod tests {
     use std::time::Duration;
 
     use super::MemoryGrpcService;
+    use crate::observe::RpcMetrics;
     use crate::api::{
         AppendMemoryRequest, GetSessionRequest, MemoryEntry, MemoryServiceClient,
         MemoryServiceServer, QueryMemoryRequest, RequestMeta, RetrievePolicy,
@@ -823,7 +891,7 @@ mod tests {
         let incoming = TcpListenerStream::new(listener);
 
         let runtime = RuntimeState::initialize(&test_config()).await.unwrap();
-        let service = MemoryGrpcService::new(test_config(), runtime, None);
+        let service = MemoryGrpcService::new(test_config(), runtime, None, Arc::new(RpcMetrics::new()));
         let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
 
         let server = tokio::spawn(async move {
@@ -920,7 +988,7 @@ mod tests {
         .await
         .unwrap();
 
-        let service = MemoryGrpcService::new(config, runtime, None);
+        let service = MemoryGrpcService::new(config, runtime, None, Arc::new(RpcMetrics::new()));
         let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
 
         let server = tokio::spawn(async move {
@@ -984,7 +1052,7 @@ mod tests {
 
         let config = test_config();
         let runtime = RuntimeState::initialize(&config).await.unwrap();
-        let service = MemoryGrpcService::new(config, runtime, None);
+        let service = MemoryGrpcService::new(config, runtime, None, Arc::new(RpcMetrics::new()));
         let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
 
         let server = tokio::spawn(async move {
@@ -1049,7 +1117,7 @@ mod tests {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         let incoming = TcpListenerStream::new(listener);
-        let service = MemoryGrpcService::new(config, runtime, None);
+        let service = MemoryGrpcService::new(config, runtime, None, Arc::new(RpcMetrics::new()));
         let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
 
         let server = tokio::spawn(async move {
@@ -1578,7 +1646,7 @@ mod tests {
     async fn append_memory_concurrent_requests_keep_sequence_order() {
         let config = test_config();
         let runtime = RuntimeState::initialize(&config).await.unwrap();
-        let service = MemoryGrpcService::new(config, runtime.clone(), None);
+        let service = MemoryGrpcService::new(config, runtime.clone(), None, Arc::new(RpcMetrics::new()));
 
         let session_id = Uuid::new_v4();
         let sid_str = session_id.to_string();
@@ -1666,7 +1734,7 @@ mod tests {
     async fn append_memory_populates_l1_index_and_query_memory_reads_it() {
         let config = test_config();
         let runtime = RuntimeState::initialize(&config).await.unwrap();
-        let service = MemoryGrpcService::new(config, runtime.clone(), None);
+        let service = MemoryGrpcService::new(config, runtime.clone(), None, Arc::new(RpcMetrics::new()));
 
         let session_id = Uuid::new_v4();
         let sid_str = session_id.to_string();
@@ -2003,7 +2071,7 @@ mod tests {
     async fn query_memory_summary_first_filters_candidates_with_session_scope() {
         let config = test_config();
         let runtime = RuntimeState::initialize(&config).await.unwrap();
-        let service = MemoryGrpcService::new(config, runtime, None);
+        let service = MemoryGrpcService::new(config, runtime, None, Arc::new(RpcMetrics::new()));
 
         let session_id = Uuid::new_v4();
         let sid_str = session_id.to_string();

--- a/koduck-memory/src/observe/mod.rs
+++ b/koduck-memory/src/observe/mod.rs
@@ -1,11 +1,15 @@
 use axum::{http::StatusCode, response::IntoResponse, routing::get, Json, Router};
 use serde_json::json;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 use tracing_subscriber::EnvFilter;
 
 use crate::config::AppConfig;
 use crate::store::RuntimeState;
 use crate::Result;
+
+mod rpc_metrics;
+pub use rpc_metrics::{RpcGuard, RpcMetrics};
 
 /// Global counters for retry/failure metrics.
 static TASK_RETRY_TOTAL: AtomicU64 = AtomicU64::new(0);
@@ -37,7 +41,11 @@ pub fn init_tracing() -> Result<()> {
     Ok(())
 }
 
-pub fn build_metrics_router(config: AppConfig, runtime: RuntimeState) -> Router {
+pub fn build_metrics_router(
+    config: AppConfig,
+    runtime: RuntimeState,
+    rpc_metrics: Arc<RpcMetrics>,
+) -> Router {
     let metrics_config = config.clone();
     let ready_config = config.clone();
     let health_config = config.clone();
@@ -75,7 +83,8 @@ pub fn build_metrics_router(config: AppConfig, runtime: RuntimeState) -> Router 
             get(move || {
                 let metrics_config = metrics_config.clone();
                 let metrics_runtime = metrics_runtime.clone();
-                async move { metrics_handler(metrics_config, metrics_runtime).await }
+                let rpc_metrics = rpc_metrics.clone();
+                async move { metrics_handler(metrics_config, metrics_runtime, rpc_metrics).await }
             }),
         )
 }
@@ -116,10 +125,15 @@ async fn health_handler(config: AppConfig, runtime: RuntimeState) -> impl IntoRe
     ready_handler(config, runtime).await
 }
 
-async fn metrics_handler(config: AppConfig, runtime: RuntimeState) -> impl IntoResponse {
+async fn metrics_handler(
+    config: AppConfig,
+    runtime: RuntimeState,
+    rpc_metrics: Arc<RpcMetrics>,
+) -> impl IntoResponse {
     let snapshot = runtime.snapshot().await;
     let retry_total = TASK_RETRY_TOTAL.load(Ordering::Relaxed);
     let failure_total = TASK_FAILURE_TOTAL.load(Ordering::Relaxed);
+    let rpc_output = rpc_metrics.render();
     let body = format!(
         "# HELP koduck_memory_build_info Static build information.\n\
          # TYPE koduck_memory_build_info gauge\n\
@@ -144,7 +158,8 @@ async fn metrics_handler(config: AppConfig, runtime: RuntimeState) -> impl IntoR
          koduck_memory_task_retry_total {} \n\
          # HELP koduck_memory_task_failure_total Total number of tasks that failed after all retries.\n\
          # TYPE koduck_memory_task_failure_total counter\n\
-         koduck_memory_task_failure_total {} \n",
+         koduck_memory_task_failure_total {} \n\
+         {}\n",
         config.app.name,
         config.app.version,
         config.app.env,
@@ -154,6 +169,7 @@ async fn metrics_handler(config: AppConfig, runtime: RuntimeState) -> impl IntoR
         snapshot.pool_idle,
         retry_total,
         failure_total,
+        rpc_output,
     );
     (StatusCode::OK, body)
 }

--- a/koduck-memory/src/observe/rpc_metrics.rs
+++ b/koduck-memory/src/observe/rpc_metrics.rs
@@ -1,0 +1,255 @@
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::time::Instant;
+
+/// Histogram buckets for RPC latency (milliseconds).
+const BUCKET_BOUNDS: &[u64] = &[1, 5, 10, 25, 50, 100, 250, 500, 1000];
+
+/// Per-RPC histogram state.
+#[derive(Default)]
+struct RpcHistogram {
+    buckets: Vec<u64>,
+    count: u64,
+    sum: u64,
+}
+
+impl RpcHistogram {
+    fn new() -> Self {
+        Self {
+            buckets: vec![0; BUCKET_BOUNDS.len() + 1], // +1 for +Inf
+            count: 0,
+            sum: 0,
+        }
+    }
+
+    fn record(&mut self, duration_ms: u64) {
+        self.count += 1;
+        self.sum += duration_ms;
+        for (i, &bound) in BUCKET_BOUNDS.iter().enumerate() {
+            if duration_ms <= bound {
+                self.buckets[i] += 1;
+                return;
+            }
+        }
+        // Falls into +Inf bucket
+        self.buckets[BUCKET_BOUNDS.len()] += 1;
+    }
+}
+
+/// Per-RPC request counter keyed by (rpc, status).
+#[derive(Default)]
+struct RpcCounter {
+    ok: u64,
+    error: u64,
+}
+
+/// Global RPC metrics registry.
+///
+/// Thread-safe via `Mutex`. For V1 the contention overhead is acceptable
+/// given the request volume through koduck-memory.
+pub struct RpcMetrics {
+    histograms: Mutex<HashMap<String, RpcHistogram>>,
+    counters: Mutex<HashMap<String, RpcCounter>>,
+}
+
+impl RpcMetrics {
+    pub fn new() -> Self {
+        Self {
+            histograms: Mutex::new(HashMap::new()),
+            counters: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Record a completed RPC call.
+    ///
+    /// `rpc` is the method name (e.g. "get_session", "query_memory").
+    /// `status` is "ok" or "error".
+    /// `start` is the `Instant` captured at the beginning of the RPC handler.
+    pub fn record(&self, rpc: &str, status: &str, start: Instant) {
+        let duration_ms = start.elapsed().as_millis() as u64;
+
+        // Record histogram
+        if let Ok(mut hist) = self.histograms.lock() {
+            hist.entry(rpc.to_string())
+                .or_insert_with(RpcHistogram::new)
+                .record(duration_ms);
+        }
+
+        // Record counter
+        if let Ok(mut ctr) = self.counters.lock() {
+            let entry = ctr.entry(rpc.to_string()).or_default();
+            if status == "ok" {
+                entry.ok += 1;
+            } else {
+                entry.error += 1;
+            }
+        }
+    }
+
+    /// Render all RPC metrics in Prometheus text format.
+    pub fn render(&self) -> String {
+        let mut output = String::new();
+
+        // Render counters
+        if let Ok(counters) = self.counters.lock() {
+            output.push_str("# HELP koduck_memory_rpc_requests_total Total number of RPC requests.\n");
+            output.push_str("# TYPE koduck_memory_rpc_requests_total counter\n");
+            for (rpc, counter) in counters.iter() {
+                if counter.ok > 0 {
+                    output.push_str(&format!(
+                        "koduck_memory_rpc_requests_total{{rpc=\"{}\",status=\"ok\"}} {}\n",
+                        rpc, counter.ok
+                    ));
+                }
+                if counter.error > 0 {
+                    output.push_str(&format!(
+                        "koduck_memory_rpc_requests_total{{rpc=\"{}\",status=\"error\"}} {}\n",
+                        rpc, counter.error
+                    ));
+                }
+            }
+        }
+
+        // Render histograms
+        if let Ok(histograms) = self.histograms.lock() {
+            output.push_str("# HELP koduck_memory_rpc_duration_ms RPC duration in milliseconds.\n");
+            output.push_str("# TYPE koduck_memory_rpc_duration_ms histogram\n");
+            for (rpc, hist) in histograms.iter() {
+                // Cumulative bucket counts
+                let mut cumulative = 0u64;
+                for (i, &bound) in BUCKET_BOUNDS.iter().enumerate() {
+                    cumulative += hist.buckets[i];
+                    output.push_str(&format!(
+                        "koduck_memory_rpc_duration_ms_bucket{{rpc=\"{}\",le=\"{}\"}} {}\n",
+                        rpc, bound, cumulative
+                    ));
+                }
+                // +Inf bucket
+                cumulative += hist.buckets[BUCKET_BOUNDS.len()];
+                output.push_str(&format!(
+                    "koduck_memory_rpc_duration_ms_bucket{{rpc=\"{}\",le=\"+Inf\"}} {}\n",
+                    rpc, cumulative
+                ));
+                output.push_str(&format!(
+                    "koduck_memory_rpc_duration_ms_sum{{rpc=\"{}\"}} {}\n",
+                    rpc, hist.sum
+                ));
+                output.push_str(&format!(
+                    "koduck_memory_rpc_duration_ms_count{{rpc=\"{}\"}} {}\n",
+                    rpc, hist.count
+                ));
+            }
+        }
+
+        output
+    }
+}
+
+/// A guard that records RPC metrics on drop.
+///
+/// Usage:
+/// ```ignore
+/// let _guard = RpcGuard::new(&metrics, "get_session", start);
+/// // ... handle RPC ...
+/// // on drop, records "ok" status
+/// ```
+///
+/// If the RPC returns an error, call `guard.error()` before dropping.
+pub struct RpcGuard<'a> {
+    metrics: &'a RpcMetrics,
+    rpc: &'static str,
+    start: Instant,
+    status: &'static str,
+}
+
+impl<'a> RpcGuard<'a> {
+    pub fn new(metrics: &'a RpcMetrics, rpc: &'static str) -> Self {
+        Self {
+            metrics,
+            rpc,
+            start: Instant::now(),
+            status: "ok",
+        }
+    }
+
+    /// Mark this RPC as errored before dropping.
+    pub fn error(&mut self) {
+        self.status = "error";
+    }
+
+    /// Return elapsed milliseconds since the guard was created.
+    pub fn elapsed_ms(&self) -> u64 {
+        self.start.elapsed().as_millis() as u64
+    }
+}
+
+impl Drop for RpcGuard<'_> {
+    fn drop(&mut self) {
+        self.metrics.record(self.rpc, self.status, self.start);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn histogram_records_into_correct_bucket() {
+        let mut hist = RpcHistogram::new();
+        hist.record(0); // <= 1ms
+        hist.record(3); // <= 5ms
+        hist.record(7); // <= 10ms
+        hist.record(30); // <= 50ms
+        hist.record(2000); // +Inf
+
+        assert_eq!(hist.buckets[0], 1); // le=1
+        assert_eq!(hist.buckets[1], 1); // le=5
+        assert_eq!(hist.buckets[2], 1); // le=10
+        assert_eq!(hist.buckets[3], 1); // le=25 -> 0 (30 > 25)
+        assert_eq!(hist.buckets[4], 1); // le=50
+        assert_eq!(hist.buckets[8], 0); // le=1000 -> 0 (2000 > 1000)
+        assert_eq!(hist.buckets[9], 1); // +Inf
+        assert_eq!(hist.count, 5);
+        assert_eq!(hist.sum, 2040);
+    }
+
+    #[test]
+    fn rpc_metrics_record_and_render() {
+        let metrics = RpcMetrics::new();
+        let start = Instant::now() - Duration::from_millis(5);
+
+        metrics.record("get_session", "ok", start);
+        metrics.record("get_session", "ok", start);
+        metrics.record("get_session", "error", start);
+
+        let output = metrics.render();
+        assert!(output.contains("koduck_memory_rpc_requests_total{rpc=\"get_session\",status=\"ok\"} 2"));
+        assert!(output.contains("koduck_memory_rpc_requests_total{rpc=\"get_session\",status=\"error\"} 1"));
+        assert!(output.contains("koduck_memory_rpc_duration_ms_bucket{rpc=\"get_session\",le=\"5\"} 3"));
+        assert!(output.contains("koduck_memory_rpc_duration_ms_count{rpc=\"get_session\"} 3"));
+    }
+
+    #[test]
+    fn rpc_guard_records_ok_by_default() {
+        let metrics = RpcMetrics::new();
+        {
+            let _guard = RpcGuard::new(&metrics, "query_memory");
+            // dropped without calling error()
+        }
+        let output = metrics.render();
+        assert!(output.contains("status=\"ok\""));
+        assert!(!output.contains("status=\"error\""));
+    }
+
+    #[test]
+    fn rpc_guard_records_error_when_explicit() {
+        let metrics = RpcMetrics::new();
+        {
+            let mut guard = RpcGuard::new(&metrics, "append_memory");
+            guard.error();
+        }
+        let output = metrics.render();
+        assert!(output.contains("status=\"error\""));
+    }
+}


### PR DESCRIPTION
## Summary

- Add per-RPC Prometheus metrics (`koduck_memory_rpc_requests_total`, `koduck_memory_rpc_duration_ms` histogram) for `GetSession`, `QueryMemory`, `AppendMemory`
- Add structured JSON logging with `request_id`, `session_id`, `trace_id`, `user_id`, `tenant_id`, `rpc`, `latency_ms`, `status` fields
- Define SLO targets and error budget in ADR-0024
- Metrics exposed via existing `/metrics` endpoint, no new dependencies

Closes #841

## Test plan

- [x] `docker build -t koduck-memory:dev .` passes
- [x] `kubectl rollout restart deployment dev-koduck-memory -n koduck-dev` succeeds
- [x] `/metrics` endpoint returns RPC metric definitions
- [ ] Verify RPC metrics populate after exercising GetSession/QueryMemory/AppendMemory

🤖 Generated with [Claude Code](https://claude.com/claude-code)