### PR TITLE
feat(memory): add canary drill and rollback runbook

### DIFF
--- a/docs/implementation/koduck-memory-koduck-ai-tasks.md
+++ b/docs/implementation/koduck-memory-koduck-ai-tasks.md
@@ -371,5 +371,5 @@
 3. 演练 route 回滚与版本回滚
 
 **验收标准:**
-- [ ] 新版本 memory-service 可灰度接入 `koduck-ai`
-- [ ] 故障时 `koduck-ai` 主链路仍可继续
+- [x] 新版本 memory-service 可灰度接入 `koduck-ai`
+- [x] 故障时 `koduck-ai` 主链路仍可继续

--- a/docs/releases/drills/2026-04-13-koduck-memory-canary-drill.md
+++ b/docs/releases/drills/2026-04-13-koduck-memory-canary-drill.md
@@ -1,0 +1,133 @@
+# koduck-memory Task 8.4 灰度与回滚演练记录
+
+## 演练基本信息
+
+- **演练日期**: 2026-04-13
+- **演练类型**: southbound canary + fail-open + route rollback
+- **演练人员**: @hailingu
+- **对应任务**: `docs/implementation/koduck-memory-koduck-ai-tasks.md` Task 8.4
+- **对应 Issue**: #843
+
+---
+
+## 演练目标
+
+本次演练按确认后的 Task 8.4 范围执行：
+
+- [x] 新版本 `koduck-memory` canary 实例可被 `koduck-ai` 通过 APISIX southbound 路由命中
+- [x] memory upstream 故障时，`koduck-ai` 主 chat 链路继续返回成功响应
+- [x] APISIX `ai-memory-grpc` upstream 可回滚到原始稳定配置
+- [ ] image version rollback
+
+说明：
+本次明确不把 image version rollback 作为 Task 8.4 的验收动作。
+
+---
+
+## 演练环境
+
+| 检查项 | 状态 | 备注 |
+|--------|------|------|
+| `dev-koduck-memory` Ready | ✅ | `1/1 Available` |
+| `dev-koduck-ai` Ready | ✅ | drill 过程中临时切 `LLM_STUB_ENABLED=true` |
+| APISIX Admin API 可访问 | ✅ | 通过本地 `kubectl port-forward` 到 `19180` |
+| `koduck-auth` / `koduck-user` | ⚠️ | 处于 `CrashLoopBackOff`，因此 drill 不依赖 northbound 登录链路 |
+
+---
+
+## 执行入口
+
+本次演练使用新增脚本：
+
+```bash
+./k8s/drills/koduck-memory-canary-drill.sh
+```
+
+脚本实际执行内容：
+
+1. 备份 APISIX `ai-memory-grpc` upstream
+2. 临时开启 `koduck-ai` stub 模式
+3. 创建 `dev-koduck-memory-canary` / `dev-koduck-memory-canary-grpc`
+4. 切换 canary-only upstream 做 smoke
+5. 切换 weighted upstream（stable=9, canary=1）
+6. 切坏 upstream 验证 fail-open
+7. 恢复原始 upstream 验证 route rollback
+8. 自动清理 canary 与临时配置
+
+---
+
+## 演练结果
+
+### 1. Canary smoke
+
+- 结果: ✅ 通过
+- 方式: upstream 暂时切到 `{"dev-koduck-memory-canary-grpc:50051":1}`
+- 证据:
+  - 脚本输出 `Canary-only smoke passed`
+  - canary pod 日志中出现真实 memory RPC 访问
+
+### 2. Weighted canary
+
+- 结果: ✅ 通过
+- 方式: upstream 切到 stable/canary 双节点
+- 目标权重:
+
+```json
+{
+  "dev-koduck-memory-grpc:50051": 9,
+  "dev-koduck-memory-canary-grpc:50051": 1
+}
+```
+
+- 证据:
+  - 脚本输出 `Weighted canary configuration verified`
+  - APISIX Admin API 返回的 `nodes` 权重符合预期
+
+### 3. Fail-open
+
+- 结果: ✅ 通过
+- 方式: upstream 临时切到不存在的 `dev-koduck-memory-drill-fault:50051`
+- 观察结果:
+  - `/api/v1/ai/chat` 仍返回成功响应
+  - `koduck-ai` 日志中出现 memory 失败后的 warning：
+    - `get_session failed; continuing with empty session snapshot`
+    - `upsert_session_meta failed; continuing with request-local session context`
+    - `query_memory failed; continuing without retrieved memory hits`
+    - `append_memory failed after chat response; continuing with successful answer`
+
+### 4. Route rollback
+
+- 结果: ✅ 通过
+- 方式: 将 APISIX `ai-memory-grpc` upstream 恢复为演练前备份 payload
+- 证据:
+  - 脚本输出 `Route rollback verified`
+  - 恢复后 chat 请求继续返回成功
+
+---
+
+## 环境噪音与发现
+
+本次演练暴露了两个与 Task 8.4 本身无关、但值得后续单独处理的环境问题：
+
+1. `koduck-auth` / `koduck-user` 当前在 `koduck-dev` 中处于 `CrashLoopBackOff`，导致 drill 不能依赖 northbound 登录链路，只能直接对 `koduck-ai` 做本地 port-forward + APISIX OIDC header 模式验证。
+2. 当前 `koduck-memory` 的 session / append 路径存在既有 schema / SQL 错误：
+   - `column "extra" does not exist`
+   - advisory lock 解码类型不匹配
+
+这些问题不会否定 Task 8.4 的灰度与 fail-open 验证结论，因为：
+
+- canary smoke 已证明新版本 memory 实例能被 APISIX + `koduck-ai` 命中
+- fail-open 演练故意把 upstream 切坏后，主 chat 仍成功返回
+
+但建议在后续任务里单独修复这些环境与 schema 噪音。
+
+---
+
+## 演练结论
+
+- [x] 新版本 `koduck-memory` 可灰度接入 `koduck-ai`
+- [x] 故障时 `koduck-ai` 主链路仍可继续
+- [x] route rollback 已演练
+- [ ] image version rollback 未纳入本次 Task 8.4 验收范围
+
+因此，按当前 agreed scope，Task 8.4 可视为完成。

--- a/k8s/drills/koduck-memory-canary-drill.sh
+++ b/k8s/drills/koduck-memory-canary-drill.sh
@@ -1,0 +1,489 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if ! command -v kubectl >/dev/null 2>&1; then
+  echo "ERROR: kubectl is required." >&2
+  exit 1
+fi
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "ERROR: curl is required." >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq is required." >&2
+  exit 1
+fi
+
+readonly NAMESPACE="${NAMESPACE:-koduck-dev}"
+readonly APISIX_ADMIN_URL="${APISIX_ADMIN_URL:-http://127.0.0.1:19180/apisix/admin}"
+readonly APISIX_ADMIN_KEY="${APISIX_ADMIN_KEY:-edd1c9f034335f136f87ad84b625c8f1}"
+readonly APISIX_GATEWAY_SERVICE="${APISIX_GATEWAY_SERVICE:-dev-apisix-gateway}"
+readonly APISIX_ADMIN_FORWARD_PORT="${APISIX_ADMIN_FORWARD_PORT:-19180}"
+readonly AI_DEPLOYMENT="${AI_DEPLOYMENT:-dev-koduck-ai}"
+readonly AI_HTTP_URL="${AI_HTTP_URL:-http://127.0.0.1:18083}"
+readonly AI_HTTP_FORWARD_PORT="${AI_HTTP_FORWARD_PORT:-18083}"
+readonly MEMORY_DEPLOYMENT="${MEMORY_DEPLOYMENT:-dev-koduck-memory}"
+readonly MEMORY_CANARY_DEPLOYMENT="${MEMORY_CANARY_DEPLOYMENT:-dev-koduck-memory-canary}"
+readonly MEMORY_STABLE_UPSTREAM="${MEMORY_STABLE_UPSTREAM:-dev-koduck-memory-grpc:50051}"
+readonly MEMORY_CANARY_UPSTREAM="${MEMORY_CANARY_UPSTREAM:-dev-koduck-memory-canary-grpc:50051}"
+readonly MEMORY_CANARY_IMAGE="${MEMORY_CANARY_IMAGE:-koduck-memory:dev}"
+readonly TENANT_ID="${E2E_TENANT_ID:-tenant_demo}"
+readonly USER_ID="${E2E_USER_ID:-task8-drill-user}"
+readonly USERNAME="${E2E_USERNAME:-task8-drill-user}"
+TMP_DIR="$(mktemp -d -t koduck-memory-task84-XXXXXX)"
+ORIGINAL_UPSTREAM_FILE="${TMP_DIR}/ai-memory-grpc-original.json"
+PORT_FORWARD_LOG="${TMP_DIR}/apisix-admin-port-forward.log"
+AI_FORWARD_LOG="${TMP_DIR}/koduck-ai-port-forward.log"
+PORT_FORWARD_PID=""
+AI_FORWARD_PID=""
+ORIGINAL_STUB_VALUE=""
+AI_STUB_WAS_PRESENT=0
+
+log() {
+  printf '[task8-4-drill] %s\n' "$*"
+}
+
+cleanup() {
+  set +e
+
+  if [[ -f "${ORIGINAL_UPSTREAM_FILE}" ]]; then
+    log "Restoring original ai-memory-grpc upstream"
+    curl --noproxy '*' -fsS -X PUT "${APISIX_ADMIN_URL}/upstreams/ai-memory-grpc" \
+      -H "X-API-KEY: ${APISIX_ADMIN_KEY}" \
+      -H 'Content-Type: application/json' \
+      --data "@${ORIGINAL_UPSTREAM_FILE}" >/dev/null || true
+  fi
+
+  if [[ -n "${ORIGINAL_STUB_VALUE}" ]]; then
+    log "Restoring koduck-ai stub mode to ${ORIGINAL_STUB_VALUE}"
+    kubectl -n "${NAMESPACE}" set env deployment/"${AI_DEPLOYMENT}" \
+      KODUCK_AI__LLM__STUB_ENABLED="${ORIGINAL_STUB_VALUE}" >/dev/null || true
+    kubectl -n "${NAMESPACE}" rollout status deployment/"${AI_DEPLOYMENT}" --timeout=180s >/dev/null || true
+  elif [[ "${AI_STUB_WAS_PRESENT}" -eq 0 ]]; then
+    log "Removing temporary koduck-ai stub mode env"
+    kubectl -n "${NAMESPACE}" set env deployment/"${AI_DEPLOYMENT}" KODUCK_AI__LLM__STUB_ENABLED- >/dev/null || true
+    kubectl -n "${NAMESPACE}" rollout status deployment/"${AI_DEPLOYMENT}" --timeout=180s >/dev/null || true
+  fi
+
+  log "Cleaning up canary deployment and service"
+  kubectl -n "${NAMESPACE}" delete deployment/"${MEMORY_CANARY_DEPLOYMENT}" --ignore-not-found=true >/dev/null || true
+  kubectl -n "${NAMESPACE}" delete service/dev-koduck-memory-canary --ignore-not-found=true >/dev/null || true
+  kubectl -n "${NAMESPACE}" delete service/dev-koduck-memory-canary-grpc --ignore-not-found=true >/dev/null || true
+
+  if [[ -n "${PORT_FORWARD_PID}" ]]; then
+    kill "${PORT_FORWARD_PID}" >/dev/null 2>&1 || true
+    wait "${PORT_FORWARD_PID}" >/dev/null 2>&1 || true
+  fi
+  if [[ -n "${AI_FORWARD_PID}" ]]; then
+    kill "${AI_FORWARD_PID}" >/dev/null 2>&1 || true
+    wait "${AI_FORWARD_PID}" >/dev/null 2>&1 || true
+  fi
+
+  rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
+
+start_apisix_admin_port_forward() {
+  log "Starting APISIX admin port-forward on localhost:${APISIX_ADMIN_FORWARD_PORT}"
+  kubectl -n "${NAMESPACE}" port-forward service/"${APISIX_GATEWAY_SERVICE}" \
+    "${APISIX_ADMIN_FORWARD_PORT}:9180" >"${PORT_FORWARD_LOG}" 2>&1 &
+  PORT_FORWARD_PID=$!
+
+  for _ in $(seq 1 30); do
+    if curl --noproxy '*' -fsS -H "X-API-KEY: ${APISIX_ADMIN_KEY}" \
+      "${APISIX_ADMIN_URL}/routes" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+
+  echo "ERROR: APISIX admin port-forward did not become ready." >&2
+  cat "${PORT_FORWARD_LOG}" >&2 || true
+  exit 1
+}
+
+start_ai_port_forward() {
+  local ai_pod
+  ai_pod="$(latest_ai_pod)"
+  if [[ -z "${ai_pod}" ]]; then
+    echo "ERROR: unable to resolve latest running koduck-ai pod" >&2
+    exit 1
+  fi
+
+  log "Starting koduck-ai HTTP port-forward on localhost:${AI_HTTP_FORWARD_PORT}"
+  kubectl -n "${NAMESPACE}" port-forward pod/"${ai_pod}" \
+    "${AI_HTTP_FORWARD_PORT}:8083" >"${AI_FORWARD_LOG}" 2>&1 &
+  AI_FORWARD_PID=$!
+
+  for _ in $(seq 1 30); do
+    if curl --noproxy '*' -fsS "${AI_HTTP_URL}/healthz" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+
+  echo "ERROR: koduck-ai port-forward did not become ready." >&2
+  cat "${AI_FORWARD_LOG}" >&2 || true
+  exit 1
+}
+
+latest_ai_pod() {
+  kubectl -n "${NAMESPACE}" get pods -l app=koduck-ai -o json \
+    | jq -r '
+      .items
+      | map(select(.status.phase == "Running"))
+      | sort_by(.metadata.creationTimestamp)
+      | last
+      | .metadata.name // empty
+    '
+}
+
+backup_upstream() {
+  log "Backing up ai-memory-grpc upstream"
+  curl --noproxy '*' -fsS -H "X-API-KEY: ${APISIX_ADMIN_KEY}" \
+    "${APISIX_ADMIN_URL}/upstreams/ai-memory-grpc" \
+    | jq '.value | del(.create_time, .update_time)' >"${ORIGINAL_UPSTREAM_FILE}"
+}
+
+write_upstream_nodes() {
+  local nodes_json="$1"
+  local output_file="$2"
+  jq --argjson nodes "${nodes_json}" '.nodes = $nodes' \
+    "${ORIGINAL_UPSTREAM_FILE}" >"${output_file}"
+}
+
+apply_upstream_payload() {
+  local payload_file="$1"
+  curl --noproxy '*' -fsS -X PUT "${APISIX_ADMIN_URL}/upstreams/ai-memory-grpc" \
+    -H "X-API-KEY: ${APISIX_ADMIN_KEY}" \
+    -H 'Content-Type: application/json' \
+    --data "@${payload_file}" >/dev/null
+}
+
+capture_ai_stub_setting() {
+  ORIGINAL_STUB_VALUE="$(
+    kubectl -n "${NAMESPACE}" get deployment "${AI_DEPLOYMENT}" -o json \
+      | jq -r '
+        .spec.template.spec.containers[]
+        | select(.name == "koduck-ai")
+        | [.env[]? | select(.name == "KODUCK_AI__LLM__STUB_ENABLED")][0].value // empty
+      '
+  )"
+
+  if [[ -n "${ORIGINAL_STUB_VALUE}" ]]; then
+    AI_STUB_WAS_PRESENT=1
+  fi
+}
+
+enable_stub_mode() {
+  capture_ai_stub_setting
+  log "Enabling koduck-ai stub mode for deterministic drill traffic"
+  kubectl -n "${NAMESPACE}" set env deployment/"${AI_DEPLOYMENT}" \
+    KODUCK_AI__LLM__STUB_ENABLED=true >/dev/null
+  kubectl -n "${NAMESPACE}" rollout status deployment/"${AI_DEPLOYMENT}" --timeout=180s >/dev/null
+}
+
+apply_canary_resources() {
+  log "Applying temporary canary deployment/service"
+  kubectl apply -n "${NAMESPACE}" -f - <<EOF >/dev/null
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${MEMORY_CANARY_DEPLOYMENT}
+  labels:
+    app: koduck-memory-canary
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: koduck-memory-canary
+  template:
+    metadata:
+      labels:
+        app: koduck-memory-canary
+        rollout: canary
+    spec:
+      initContainers:
+        - name: wait-for-object-store
+          image: minio/mc:latest
+          imagePullPolicy: IfNotPresent
+          envFrom:
+            - secretRef:
+                name: dev-koduck-memory-secrets
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              until mc alias set objectstore "\${OBJECT_STORE__ENDPOINT}" "\${OBJECT_STORE__ACCESS_KEY}" "\${OBJECT_STORE__SECRET_KEY}"; do
+                echo "waiting for object store endpoint \${OBJECT_STORE__ENDPOINT}"
+                sleep 2
+              done
+              until mc stat "objectstore/\${OBJECT_STORE__BUCKET}"; do
+                echo "waiting for bucket \${OBJECT_STORE__BUCKET}"
+                sleep 2
+              done
+      containers:
+        - name: koduck-memory
+          image: ${MEMORY_CANARY_IMAGE}
+          imagePullPolicy: Never
+          ports:
+            - name: grpc
+              containerPort: 50051
+              protocol: TCP
+            - name: metrics
+              containerPort: 9090
+              protocol: TCP
+          env:
+            - name: SERVER__GRPC_ADDR
+              value: "0.0.0.0:50051"
+            - name: SERVER__METRICS_ADDR
+              value: "0.0.0.0:9090"
+            - name: RUST_LOG
+              value: "info,koduck_memory=info,tower_http=warn"
+          envFrom:
+            - secretRef:
+                name: dev-koduck-memory-secrets
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          livenessProbe:
+            httpGet:
+              path: /livez
+              port: metrics
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: metrics
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 3
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dev-koduck-memory-canary
+  labels:
+    app: koduck-memory-canary
+spec:
+  type: ClusterIP
+  selector:
+    app: koduck-memory-canary
+  ports:
+    - name: grpc
+      port: 50051
+      targetPort: grpc
+      protocol: TCP
+    - name: metrics
+      port: 9090
+      targetPort: metrics
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dev-koduck-memory-canary-grpc
+  labels:
+    app: koduck-memory-canary
+spec:
+  type: ClusterIP
+  clusterIP: None
+  selector:
+    app: koduck-memory-canary
+  ports:
+    - name: grpc
+      port: 50051
+      targetPort: grpc
+      protocol: TCP
+EOF
+
+  kubectl -n "${NAMESPACE}" rollout status deployment/"${MEMORY_CANARY_DEPLOYMENT}" --timeout=180s >/dev/null
+}
+
+b64url() {
+  printf '%s' "$1" | base64 | tr -d '\n=' | tr '+/' '-_'
+}
+
+build_fake_jwt() {
+  local header payload_json payload
+  header="$(b64url '{"alg":"RS256","typ":"JWT"}')"
+  payload_json="$(
+    jq -cn \
+      --arg sub "${USER_ID}" \
+      --arg tenant "${TENANT_ID}" \
+      --arg username "${USERNAME}" \
+      '{sub:$sub,tenant_id:$tenant,username:$username,roles:["user"],exp:4102444800}'
+  )"
+  payload="$(b64url "${payload_json}")"
+  printf '%s.%s.%s' "${header}" "${payload}" "task8drill"
+}
+
+chat_once() {
+  local token="$1"
+  local session_id="$2"
+  local output_file="$3"
+  curl --noproxy '*' -sS -o "${output_file}" -w '%{http_code}' \
+    -H "Authorization: Bearer ${token}" \
+    -H "X-Auth-Provider: apisix-oidc" \
+    -H "X-Tenant-Id: ${TENANT_ID}" \
+    -H "X-Session-Id: ${session_id}" \
+    -H 'Content-Type: application/json' \
+    -X POST "${AI_HTTP_URL}/api/v1/ai/chat" \
+    -d "{\"session_id\":\"${session_id}\",\"message\":\"Task 8.4 drill message for ${session_id}\"}"
+}
+
+assert_chat_success() {
+  local token="$1"
+  local session_id="$2"
+  local output_file="${TMP_DIR}/${session_id}.json"
+  local code
+
+  code="$(chat_once "${token}" "${session_id}" "${output_file}")"
+  if [[ "${code}" != "200" ]]; then
+    echo "ERROR: chat request failed, session=${session_id}, http=${code}" >&2
+    cat "${output_file}" >&2 || true
+    exit 1
+  fi
+
+  if [[ "$(jq -r '.success' "${output_file}")" != "true" ]]; then
+    echo "ERROR: chat response is not successful, session=${session_id}" >&2
+    cat "${output_file}" >&2 || true
+    exit 1
+  fi
+
+  if [[ -z "$(jq -r '.data.answer // empty' "${output_file}")" ]]; then
+    echo "ERROR: chat response missing answer, session=${session_id}" >&2
+    cat "${output_file}" >&2 || true
+    exit 1
+  fi
+}
+
+verify_canary_logs() {
+  local canary_pod
+  canary_pod="$(
+    kubectl -n "${NAMESPACE}" get pods -l app=koduck-memory-canary \
+      -o jsonpath='{.items[0].metadata.name}'
+  )"
+
+  if [[ -z "${canary_pod}" ]]; then
+    echo "ERROR: unable to resolve canary pod name" >&2
+    exit 1
+  fi
+
+  if ! kubectl -n "${NAMESPACE}" logs "${canary_pod}" --since=5m \
+    | grep -q "memory rpc completed"; then
+    echo "ERROR: canary pod did not receive memory RPC traffic" >&2
+    kubectl -n "${NAMESPACE}" logs "${canary_pod}" --since=5m >&2 || true
+    exit 1
+  fi
+}
+
+verify_fail_open_log() {
+  local ai_pod
+  local log_file
+  ai_pod="$(latest_ai_pod)"
+  if [[ -z "${ai_pod}" ]]; then
+    echo "ERROR: unable to resolve latest running koduck-ai pod for log verification" >&2
+    exit 1
+  fi
+
+  log_file="${TMP_DIR}/koduck-ai-fail-open.log"
+  kubectl -n "${NAMESPACE}" logs "${ai_pod}" --since=5m >"${log_file}"
+
+  if ! grep -Eq "get_session failed; continuing with empty session snapshot|upsert_session_meta failed; continuing with request-local session context|query_memory failed; continuing without retrieved memory hits|append_memory failed after chat response; continuing with successful answer" "${log_file}"; then
+    echo "ERROR: fail-open warning log not found in koduck-ai logs" >&2
+    cat "${log_file}" >&2 || true
+    exit 1
+  fi
+}
+
+verify_weighted_config() {
+  local stable_weight canary_weight
+  stable_weight="$(
+    curl --noproxy '*' -fsS -H "X-API-KEY: ${APISIX_ADMIN_KEY}" \
+      "${APISIX_ADMIN_URL}/upstreams/ai-memory-grpc" \
+      | jq -r --arg stable "${MEMORY_STABLE_UPSTREAM}" '.value.nodes[$stable]'
+  )"
+  canary_weight="$(
+    curl --noproxy '*' -fsS -H "X-API-KEY: ${APISIX_ADMIN_KEY}" \
+      "${APISIX_ADMIN_URL}/upstreams/ai-memory-grpc" \
+      | jq -r --arg canary "${MEMORY_CANARY_UPSTREAM}" '.value.nodes[$canary]'
+  )"
+  if [[ "${stable_weight}" != "9" || "${canary_weight}" != "1" ]]; then
+    echo "ERROR: weighted canary nodes were not applied as expected" >&2
+    echo "stable weight: ${stable_weight}, canary weight: ${canary_weight}" >&2
+    exit 1
+  fi
+}
+
+exercise_canary_smoke() {
+  local token="$1"
+  local canary_file="${TMP_DIR}/upstream-canary-only.json"
+  log "Switching ai-memory-grpc upstream to canary-only for smoke validation"
+  write_upstream_nodes "{\"${MEMORY_CANARY_UPSTREAM}\":1}" "${canary_file}"
+  apply_upstream_payload "${canary_file}"
+  assert_chat_success "${token}" "00000000-0000-4000-8000-000000000001"
+  verify_canary_logs
+  log "Canary-only smoke passed"
+}
+
+exercise_weighted_canary() {
+  local token="$1"
+  local weighted_file="${TMP_DIR}/upstream-weighted.json"
+  log "Switching ai-memory-grpc upstream to weighted stable/canary nodes"
+  write_upstream_nodes "{\"${MEMORY_STABLE_UPSTREAM}\":9,\"${MEMORY_CANARY_UPSTREAM}\":1}" "${weighted_file}"
+  apply_upstream_payload "${weighted_file}"
+  verify_weighted_config
+  assert_chat_success "${token}" "00000000-0000-4000-8000-000000000002"
+  log "Weighted canary configuration verified"
+}
+
+exercise_fail_open() {
+  local token="$1"
+  local fault_file="${TMP_DIR}/upstream-fault.json"
+  log "Simulating southbound memory outage through APISIX upstream fault"
+  write_upstream_nodes '{"dev-koduck-memory-drill-fault:50051":1}' "${fault_file}"
+  apply_upstream_payload "${fault_file}"
+
+  assert_chat_success "${token}" "00000000-0000-4000-8000-000000000003"
+  verify_fail_open_log
+  log "Fail-open verified: chat kept working while memory upstream was broken"
+}
+
+exercise_route_rollback() {
+  local token="$1"
+  log "Rolling route back to the original stable upstream"
+  apply_upstream_payload "${ORIGINAL_UPSTREAM_FILE}"
+  assert_chat_success "${token}" "00000000-0000-4000-8000-000000000004"
+  log "Route rollback verified"
+}
+
+main() {
+  start_apisix_admin_port_forward
+  backup_upstream
+  enable_stub_mode
+  start_ai_port_forward
+  apply_canary_resources
+
+  local token
+  token="$(build_fake_jwt)"
+
+  exercise_canary_smoke "${token}"
+  exercise_weighted_canary "${token}"
+  exercise_fail_open "${token}"
+  exercise_route_rollback "${token}"
+
+  log "Task 8.4 drill completed successfully"
+}
+
+main "$@"

--- a/koduck-memory/docs/adr/0024-canary-and-rollback-drill.md
+++ b/koduck-memory/docs/adr/0024-canary-and-rollback-drill.md
@@ -1,0 +1,104 @@
+# ADR-0024: 灰度接入与回滚演练闭环
+
+- Status: Accepted
+- Date: 2026-04-13
+- Issue: #843
+
+## Context
+
+Task 8.4 要求我们在 `koduck-dev` 中完成三件事：
+
+1. 验证 `koduck-ai -> APISIX -> koduck-memory` 的 southbound 链路在新版本 memory-service 接入时可继续工作。
+2. 验证 memory 故障时，`koduck-ai` 仍然遵循 fail-open 原则，主 chat 链路继续返回成功响应。
+3. 演练 route rollback，而不是只在文档中静态描述回滚原则。
+
+前序任务已经提供了必要基础：
+
+- Task 6.1 / ADR-0019 打通了 `koduck-ai -> koduck-memory` 主链路。
+- Task 6.2 / ADR-0020 已将 memory 调用改为 fail-open。
+- Task 8.1 / ADR-0023 已将 southbound gRPC 治理收敛到 APISIX，并为 upstream / route 提供了可回滚的 Admin API 更新逻辑。
+
+但在 Task 8.4 之前，仓库里仍缺两样关键资产：
+
+1. **可重复执行的 drill 脚本**：运维没有一条命令可以在 dev 真正跑完“灰度 + 故障 + 回滚”闭环。
+2. **真实演练记录**：没有证据表明当前 southbound 链路已经在故障与回滚场景下被验证过。
+
+## Decision
+
+我们将 Task 8.4 落地为“脚本 + 演练记录”的双重交付：
+
+### 1. 新增可执行 drill 脚本
+
+新增 [`k8s/drills/koduck-memory-canary-drill.sh`](../../../k8s/drills/koduck-memory-canary-drill.sh)，
+作为 dev 环境的标准演练入口。脚本负责：
+
+1. 启动 APISIX Admin API 本地 port-forward，并备份 `ai-memory-grpc` upstream 原始配置。
+2. 临时把 `koduck-ai` 切到 `LLM_STUB_ENABLED=true`，让 drill 聚焦 memory southbound，而不依赖外部 LLM 可用性。
+3. 创建临时 canary deployment/service：`dev-koduck-memory-canary` / `dev-koduck-memory-canary-grpc`。
+4. 将 APISIX upstream 切为 weighted stable/canary 节点，验证新版本 memory-service 已能接入 `koduck-ai`。
+5. 将 APISIX upstream 临时切到坏地址，验证 `koduck-ai` 仍按 fail-open 返回成功 chat，并记录 warning 日志。
+6. 恢复原始 upstream，验证 route rollback。
+7. 退出时自动恢复 upstream、恢复 `koduck-ai` stub 设置、清理 canary 资源。
+
+### 2. 固化演练记录
+
+新增一次真实执行记录到 [`docs/releases/drills/2026-04-13-koduck-memory-canary-drill.md`](../../../docs/releases/drills/2026-04-13-koduck-memory-canary-drill.md)，
+沉淀本次 drill 的：
+
+- 演练步骤
+- 验证结果
+- 回滚动作
+- 风险与后续建议
+
+### 3. 验收口径
+
+Task 8.4 的两个验收标准按以下口径视为完成：
+
+1. **“新版本 memory-service 可灰度接入 `koduck-ai`”**：
+   - canary deployment 在 dev 成功 rollout；
+   - APISIX upstream 能同时持有 stable/canary 节点；
+   - canary pod 日志观察到真实 memory RPC 流量。
+
+2. **“故障时 `koduck-ai` 主链路仍可继续”**：
+   - APISIX upstream 指向故障地址时，`/api/v1/ai/chat` 仍返回成功响应；
+   - `koduck-ai` 日志中出现 fail-open warning。
+
+## Consequences
+
+正面影响：
+
+1. Task 8.4 从“原则描述”变成了可重复执行的运维闭环。
+2. southbound route rollback 有了明确脚本路径。
+3. 以后升级 `koduck-memory` 时，可以先在 dev 复用同一脚本做演练。
+4. 通过将 AI 切到 stub 模式，drill 的失败面被收敛到 memory / APISIX，而不会被外部 LLM 波动污染。
+
+代价与权衡：
+
+1. drill 脚本默认依赖本地 `kubectl`、`curl`、`jq`，并要求开发机能访问 `koduck-dev`。
+2. 将 `koduck-ai` 临时切到 stub 模式意味着 drill 聚焦 southbound 路径，而不是外部 LLM 的端到端链路。
+3. canary deployment 是临时资源，不纳入常驻 Kustomize overlay；脚本退出后会清理。
+
+## Compatibility Impact
+
+1. 不修改 `memory.v1` protobuf，不引入 southbound breaking change。
+2. 不改变 `k8s/overlays/dev` 的常驻部署拓扑；canary 资源只在 drill 期间存在。
+3. 对 `koduck-ai` 的 `LLM_STUB_ENABLED` 修改是临时性的，脚本退出后会恢复原值。
+
+## Alternatives Considered
+
+### Alternative A: 只写 runbook，不提供脚本
+
+未采用。
+Task 8.4 明确要求“演练”，单纯 runbook 仍然依赖人工步骤，难以稳定复现。
+
+### Alternative B: 让 canary 资源常驻在 Kustomize overlay 中
+
+未采用。
+Task 8.4 的目标是演练能力，不是把 dev 长期改成双 deployment 拓扑。
+常驻 canary 会增加运维噪音与资源开销。
+
+### Alternative C: 使用真实 LLM 流量做 fail-open 演练
+
+未采用。
+Task 8.4 要验证的是 memory southbound 故障不阻塞主 chat。
+如果 drill 同时依赖外部 LLM，可重复性会被外部网络和厂商可用性显著影响。


### PR DESCRIPTION
## Summary
- add a reusable Task 8.4 canary/fail-open/route-rollback drill script for koduck-dev
- add ADR-0024 and a dated drill record for the verified scope
- mark Task 8.4 checklist complete for the agreed acceptance range

## Verification
- docker build -t koduck-memory:dev ./koduck-memory
- ./k8s/drills/koduck-memory-canary-drill.sh
- kubectl get deploy dev-koduck-memory -n koduck-dev

Closes #843