### PR TITLE
feat(memory): materialize memory units from entries

### DIFF
--- a/docs/implementation/adr-0025-anchor-based-memory-retrieval-tasks.md
+++ b/docs/implementation/adr-0025-anchor-based-memory-retrieval-tasks.md
@@ -173,10 +173,10 @@ kubectl rollout status deployment/dev-koduck-memory -n koduck-dev --timeout=180s
    - 或由 L0 / summary 派生
 
 **验收标准:**
-- [ ] 单 entry / 多 entry 物化规则可复现
-- [ ] `memory_kind` 的写入时机一致
-- [ ] `snippet` 对外返回稳定可用
-- [ ] `docker build -t koduck-memory:dev ./koduck-memory` 成功
+- [x] 单 entry / 多 entry 物化规则可复现
+- [x] `memory_kind` 的写入时机一致
+- [x] `snippet` 对外返回稳定可用
+- [x] `docker build -t koduck-memory:dev ./koduck-memory` 成功
 
 ---
 

--- a/koduck-memory/docs/adr/0030-memory-unit-materialization-rules.md
+++ b/koduck-memory/docs/adr/0030-memory-unit-materialization-rules.md
@@ -1,0 +1,114 @@
+# ADR-0030: `memory_entry -> memory_unit` Materialization Rules
+
+- Status: Accepted
+- Date: 2026-04-14
+- Issue: #853
+
+## Context
+
+Task 2.1 已经为 `memory_units` / `memory_unit_anchors` 建立了 typed model 与 repository，
+但当前 `koduck-memory` 的实际写入链路仍停留在：
+
+- `AppendMemory` 只写 `memory_entries`
+- `SummaryTaskRunner` 只写 `memory_summaries` / `memory_facts` / `memory_index_records`
+
+这意味着 anchor-based retrieval 所需的 `memory_unit` 真实物化还没有发生，尤其缺少：
+
+1. 单条 entry 到 generic conversation unit 的同步物化
+2. 多条连续 entry 聚合到 summary / fact unit 的稳定规则
+3. 一致的 `snippet` 生成策略
+
+Task 2.2 明确要求我们把这些规则落成可复现实现。
+
+## Decision
+
+### 1. 引入统一的 `MemoryUnitMaterializer`
+
+在 `memory_unit/` 模块中新增 `materializer.rs`，统一承接三类物化：
+
+- `materialize_appended_entries`
+- `upsert_summary_unit`
+- `replace_fact_units`
+
+这样可以把 `memory_kind` 的写入时机、`snippet` 生成规则、以及 anchor 附着逻辑集中在一个位置，而不是分散在
+`AppendMemory` 与 `SummaryTaskRunner` 的不同分支里。
+
+### 2. 单条 entry 直接形成 generic conversation unit
+
+`AppendMemory` 成功提交 `memory_entries` 后，按每条 entry 同步创建一个 `memory_unit`：
+
+- `memory_unit_id = entry_id`
+- `entry_range_start = entry_range_end = sequence_num`
+- `memory_kind = NULL`（映射为 generic conversation unit）
+- `summary_status = pending`
+- `snippet = truncate(entry.content)`
+- `source_uri = l0_uri`
+- `time_bucket = message_ts(%Y-%m)`
+
+这为后续 recall / anchor path 提供最细粒度的基线单元。
+
+### 3. 多条连续 entry 聚合形成 summary unit
+
+`SummaryTaskRunner` 在刷新 summary projection 时，同步 upsert 一个 session-scoped summary unit：
+
+- `memory_unit_id = session_id`
+- `memory_kind = summary`
+- `summary_status = ready`
+- `summary = stored_summary.summary`
+- `snippet = summary_snippet`
+- `source_uri = memory-summary://...`
+- `entry_range = [first_sequence_num, last_sequence_num]`
+
+同时写入一个 `domain` anchor，让 `domain_class_primary` 继续通过既有 trigger 投影得到。
+
+### 4. 多条连续 entry 聚合形成 fact units
+
+`SummaryTaskRunner` 在事实提取完成后，删除旧的 fact units，并为本轮 facts 逐条创建新的 fact unit：
+
+- `memory_unit_id = fact.id`
+- `memory_kind = fact`
+- `summary_status = pending`
+- `snippet = truncate(fact_text)`
+- `source_uri = memory-fact://...`
+- `entry_range = [first_sequence_num, last_sequence_num]`
+
+并补齐两个 anchors：
+
+- `domain`
+- `fact_type`
+
+这样既保持 `fact_type` 约束成立，也让后续 `recall_target_type = fact/preference` 有稳定锚点可用。
+
+## Consequences
+
+正面影响：
+
+1. `memory_unit` 从 schema 基线升级为真实写入产物，后续 retrieval 主路径可以直接复用。
+2. 单 entry 与多 entry 的物化边界在代码中清晰可复现。
+3. `snippet` 生成不再散落在不同调用方，generic/summary/fact 三类路径有统一规则。
+
+代价与权衡：
+
+1. `AppendMemory` 在提交后增加了一步同步 materialization，会多一次数据库写入。
+2. summary / facts 的物化仍然依赖异步任务完成，因此 generic units 会先于 summary/fact units 可见。
+3. 当前 generic units 还未附着 domain/entity anchors；更丰富的 anchor 填充留给后续 Phase 3/4。
+
+## Compatibility Impact
+
+1. 不修改 `memory.v1` 契约。
+2. 不移除 `memory_index_records`，继续保持旧读路径可用。
+3. 新增的 `memory_unit` 写入不会破坏现有 summary/fact/index 逻辑，只是补充并行物化产物。
+
+## Alternatives Considered
+
+### Alternative A: 只在异步 summary 完成后再创建所有 memory units
+
+未采用。这样会让最近对话片段在 summary 未完成前完全不可见，不符合 ADR-0025 对 recent memory 的要求。
+
+### Alternative B: 继续只维护 `memory_index_records`
+
+未采用。Task 2.2 的目标就是把检索基线从 session/index 粒度推进到 `memory_unit` 粒度。
+
+### Alternative C: 为 generic units 立即补全所有 anchors
+
+未采用。当前还没有 query analyzer / anchor extraction 组件，先把 unit 物化基线做稳，再在后续阶段补 anchor 丰富化。

--- a/koduck-memory/src/capability/service.rs
+++ b/koduck-memory/src/capability/service.rs
@@ -15,6 +15,7 @@ use crate::index::MemoryIndexRepository;
 use crate::memory::{
     metadata_to_jsonb, IdempotencyRepository, InsertMemoryEntry, MemoryEntryRepository,
 };
+use crate::memory_unit::{AppendedEntryUnit, MemoryUnitMaterializer};
 use crate::observe::{record_rpc_call, RpcMethod, RpcOutcome};
 use crate::observe::RpcGuard;
 use crate::observe::RpcMetrics;
@@ -558,6 +559,7 @@ impl MemoryService for MemoryGrpcService {
         // duplicate them into `memory_index_records`. Session-level retrieval should
         // happen through asynchronous summaries instead.
         let mut entries_to_insert: Vec<InsertMemoryEntry> = Vec::new();
+        let mut appended_units: Vec<AppendedEntryUnit> = Vec::new();
 
         for (i, entry) in req.entries.iter().enumerate() {
             let entry_id = uuid::Uuid::new_v4();
@@ -617,6 +619,15 @@ impl MemoryService for MemoryGrpcService {
                 l0_uri,
             };
 
+            appended_units.push(AppendedEntryUnit {
+                entry_id,
+                tenant_id: tenant_id.clone(),
+                session_id,
+                sequence_num,
+                content: entry.content.clone(),
+                source_uri: insert.l0_uri.clone(),
+                message_ts,
+            });
             entries_to_insert.push(insert);
         }
 
@@ -653,6 +664,13 @@ impl MemoryService for MemoryGrpcService {
         tx.commit()
             .await
             .map_err(|e| { guard.error(); Status::internal(format!("failed to commit transaction: {e}")) })?;
+
+        if appended > 0 {
+            MemoryUnitMaterializer::new(self.runtime.pool())
+                .materialize_appended_entries(&appended_units)
+                .await
+                .map_err(|e| { guard.error(); Status::internal(format!("failed to materialize memory units: {e}")) })?;
+        }
 
         tracing::info!(
             rpc = "append_memory",
@@ -829,6 +847,8 @@ mod tests {
     };
     use crate::facts::MemoryFactRepository;
     use crate::index::MemoryIndexRepository;
+    use crate::memory_anchor::MemoryUnitAnchorRepository;
+    use crate::memory_unit::{MemoryUnitKind, MemoryUnitRepository};
     use crate::reliability::TaskAttemptRepository;
     use crate::summary::MemorySummaryRepository;
     use crate::session::{SessionRepository, UpsertSession, extra_to_jsonb};
@@ -1230,6 +1250,22 @@ mod tests {
             tokio::time::sleep(Duration::from_millis(50)).await;
         }
         panic!("summary projection was not materialized in time");
+    }
+
+    async fn wait_for_memory_units(
+        repo: &MemoryUnitRepository,
+        tenant_id: &str,
+        session_id: Uuid,
+        expected_min: usize,
+    ) -> Vec<crate::memory_unit::MemoryUnit> {
+        for _ in 0..20 {
+            let units = repo.list_by_session(tenant_id, session_id, 50).await.unwrap();
+            if units.len() >= expected_min {
+                return units;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        panic!("memory units were not materialized in time");
     }
 
     async fn wait_for_failed_task(
@@ -1871,6 +1907,69 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn append_memory_materializes_generic_memory_units() {
+        let config = test_config();
+        let runtime = RuntimeState::initialize(&config).await.unwrap();
+        let unit_repo = MemoryUnitRepository::new(runtime.pool());
+        let (mut client, shutdown_tx, server) = start_test_server(config, runtime).await;
+
+        let session_id = Uuid::new_v4();
+        let sid_str = session_id.to_string();
+
+        client
+            .upsert_session_meta(UpsertSessionMetaRequest {
+                meta: Some(write_meta_with_idempotency("t53-session", &sid_str)),
+                session_id: sid_str.clone(),
+                title: "Generic units".to_string(),
+                status: "active".to_string(),
+                parent_session_id: String::new(),
+                forked_from_session_id: String::new(),
+                last_message_at: 1700000000000,
+                extra: [].into(),
+            })
+            .await
+            .unwrap();
+
+        client
+            .append_memory(AppendMemoryRequest {
+                meta: Some(write_meta_with_idempotency("t53-append", &sid_str)),
+                session_id: sid_str.clone(),
+                entries: vec![
+                    MemoryEntry {
+                        role: "user".to_string(),
+                        content: "Need a rollout checklist".to_string(),
+                        timestamp: 1700000000000,
+                        metadata: std::collections::HashMap::new(),
+                    },
+                    MemoryEntry {
+                        role: "assistant".to_string(),
+                        content: "I will prepare a concise checklist".to_string(),
+                        timestamp: 1700000001000,
+                        metadata: std::collections::HashMap::new(),
+                    },
+                ],
+            })
+            .await
+            .unwrap();
+
+        let mut units = wait_for_memory_units(&unit_repo, "tenant-t33", session_id, 2).await;
+        units.sort_by_key(|unit| unit.entry_range_start);
+
+        assert_eq!(units.len(), 2);
+        assert!(units.iter().all(|unit| unit.memory_kind == MemoryUnitKind::GenericConversation));
+        assert!(units.iter().all(|unit| unit.summary_state.summary_status == "pending"));
+        assert_eq!(units[0].entry_range_start, 1);
+        assert_eq!(units[0].entry_range_end, 1);
+        assert!(units[0].snippet.as_deref().is_some_and(|snippet| snippet.contains("rollout checklist")));
+        assert_eq!(units[1].entry_range_start, 2);
+        assert_eq!(units[1].entry_range_end, 2);
+        assert!(units[1].snippet.as_deref().is_some_and(|snippet| snippet.contains("concise checklist")));
+
+        let _ = shutdown_tx.send(());
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
     async fn summarize_memory_materializes_summary_and_domain_class() {
         let mut config = test_config();
         config.summary.async_enabled = true;
@@ -2110,6 +2209,113 @@ mod tests {
 
         assert!(response.ok);
         assert!(response.hits.iter().all(|hit| !hit.l0_uri.starts_with("memory-fact://")));
+
+        let _ = shutdown_tx.send(());
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn summarize_memory_materializes_summary_and_fact_units() {
+        let mut config = test_config();
+        config.summary.async_enabled = true;
+        let runtime = RuntimeState::initialize(&config).await.unwrap();
+        let summary_repo = MemorySummaryRepository::new(runtime.pool());
+        let fact_repo = MemoryFactRepository::new(runtime.pool());
+        let unit_repo = MemoryUnitRepository::new(runtime.pool());
+        let anchor_repo = MemoryUnitAnchorRepository::new(runtime.pool());
+        let (mut client, shutdown_tx, server) = start_test_server(config, runtime).await;
+
+        let session_id = Uuid::new_v4();
+        let sid_str = session_id.to_string();
+
+        client
+            .upsert_session_meta(UpsertSessionMetaRequest {
+                meta: Some(write_meta_with_idempotency("t73-session", &sid_str)),
+                session_id: sid_str.clone(),
+                title: "Fact units".to_string(),
+                status: "active".to_string(),
+                parent_session_id: String::new(),
+                forked_from_session_id: String::new(),
+                last_message_at: 1700000000000,
+                extra: [].into(),
+            })
+            .await
+            .unwrap();
+
+        client
+            .append_memory(AppendMemoryRequest {
+                meta: Some(write_meta_with_idempotency("t73-append", &sid_str)),
+                session_id: sid_str.clone(),
+                entries: vec![
+                    MemoryEntry {
+                        role: "user".to_string(),
+                        content: "I prefer concise rollout summaries".to_string(),
+                        timestamp: 1700000000000,
+                        metadata: std::collections::HashMap::new(),
+                    },
+                    MemoryEntry {
+                        role: "user".to_string(),
+                        content: "Do not include raw secrets in logs".to_string(),
+                        timestamp: 1700000001000,
+                        metadata: std::collections::HashMap::new(),
+                    },
+                ],
+            })
+            .await
+            .unwrap();
+
+        client
+            .summarize_memory(SummarizeMemoryRequest {
+                meta: Some(write_meta_with_idempotency("t73-summary", &sid_str)),
+                session_id: sid_str.clone(),
+                strategy: "session-rollup".to_string(),
+            })
+            .await
+            .unwrap();
+
+        let stored_summary = wait_for_summary(&summary_repo, "tenant-t33", session_id).await;
+        let facts = wait_for_facts(&fact_repo, "tenant-t33", session_id).await;
+        let units = wait_for_memory_units(&unit_repo, "tenant-t33", session_id, 3).await;
+
+        let summary_unit = units
+            .iter()
+            .find(|unit| unit.memory_kind == MemoryUnitKind::Summary)
+            .expect("summary unit should exist");
+        assert_eq!(summary_unit.entry_range_start, 1);
+        assert_eq!(summary_unit.entry_range_end, 2);
+        assert_eq!(summary_unit.memory_unit_id, session_id);
+        assert_eq!(summary_unit.summary_state.summary_status, "ready");
+        assert_eq!(
+            summary_unit.summary_state.summary.as_deref(),
+            Some(stored_summary.summary.as_str())
+        );
+        assert!(summary_unit
+            .snippet
+            .as_deref()
+            .is_some_and(|snippet| !snippet.trim().is_empty()));
+
+        let fact_units = units
+            .iter()
+            .filter(|unit| unit.memory_kind == MemoryUnitKind::Fact)
+            .collect::<Vec<_>>();
+        assert_eq!(fact_units.len(), facts.len());
+        assert!(fact_units.iter().all(|unit| unit.entry_range_start == 1 && unit.entry_range_end == 2));
+        assert!(fact_units.iter().all(|unit| unit.summary_state.summary_status == "pending"));
+
+        let summary_anchors = anchor_repo
+            .list_by_memory_unit("tenant-t33", summary_unit.memory_unit_id)
+            .await
+            .unwrap();
+        assert!(summary_anchors.iter().any(|anchor| anchor.anchor_key == stored_summary.domain_class));
+
+        for fact in &facts {
+            let anchors = anchor_repo
+                .list_by_memory_unit("tenant-t33", fact.id)
+                .await
+                .unwrap();
+            assert!(anchors.iter().any(|anchor| anchor.anchor_key == stored_summary.domain_class));
+            assert!(anchors.iter().any(|anchor| anchor.anchor_key == fact.fact_type));
+        }
 
         let _ = shutdown_tx.send(());
         server.await.unwrap();

--- a/koduck-memory/src/memory_anchor/repository.rs
+++ b/koduck-memory/src/memory_anchor/repository.rs
@@ -109,4 +109,19 @@ impl MemoryUnitAnchorRepository {
 
         rows.into_iter().map(MemoryUnitAnchor::try_from).collect()
     }
+
+    pub async fn delete_by_memory_unit(&self, tenant_id: &str, memory_unit_id: Uuid) -> Result<u64> {
+        let result = sqlx::query(
+            r#"
+            DELETE FROM memory_unit_anchors
+            WHERE tenant_id = $1 AND memory_unit_id = $2
+            "#,
+        )
+        .bind(tenant_id)
+        .bind(memory_unit_id)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected())
+    }
 }

--- a/koduck-memory/src/memory_unit/materializer.rs
+++ b/koduck-memory/src/memory_unit/materializer.rs
@@ -1,0 +1,197 @@
+use anyhow::Result;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use crate::facts::MemoryFact;
+use crate::memory_anchor::{
+    InsertMemoryUnitAnchor,
+    MemoryUnitAnchorRepository,
+    MemoryUnitAnchorType,
+};
+use crate::memory_unit::{
+    InsertMemoryUnit,
+    MemoryUnitKind,
+    MemoryUnitRepository,
+    MemoryUnitSummaryState,
+};
+
+const DEFAULT_SNIPPET_LIMIT: usize = 96;
+
+#[derive(Debug, Clone)]
+pub struct AppendedEntryUnit {
+    pub entry_id: Uuid,
+    pub tenant_id: String,
+    pub session_id: Uuid,
+    pub sequence_num: i64,
+    pub content: String,
+    pub source_uri: String,
+    pub message_ts: chrono::DateTime<chrono::Utc>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SummaryUnitInput {
+    pub tenant_id: String,
+    pub session_id: Uuid,
+    pub domain_class: String,
+    pub summary: String,
+    pub snippet: String,
+    pub source_uri: String,
+    pub entry_range_start: i64,
+    pub entry_range_end: i64,
+    pub time_bucket: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct FactUnitInput {
+    pub tenant_id: String,
+    pub session_id: Uuid,
+    pub domain_class: String,
+    pub fact: MemoryFact,
+    pub entry_range_start: i64,
+    pub entry_range_end: i64,
+    pub time_bucket: String,
+}
+
+#[derive(Clone)]
+pub struct MemoryUnitMaterializer {
+    unit_repo: MemoryUnitRepository,
+    anchor_repo: MemoryUnitAnchorRepository,
+}
+
+impl MemoryUnitMaterializer {
+    pub fn new(pool: &PgPool) -> Self {
+        Self {
+            unit_repo: MemoryUnitRepository::new(pool),
+            anchor_repo: MemoryUnitAnchorRepository::new(pool),
+        }
+    }
+
+    pub async fn materialize_appended_entries(&self, entries: &[AppendedEntryUnit]) -> Result<()> {
+        for entry in entries {
+            let insert = InsertMemoryUnit::new(
+                entry.tenant_id.clone(),
+                entry.session_id,
+                entry.sequence_num,
+                entry.sequence_num,
+                entry.source_uri.clone(),
+            )?
+            .with_memory_unit_id(entry.entry_id)
+            .with_snippet(truncate_text(&entry.content, DEFAULT_SNIPPET_LIMIT))
+            .with_time_bucket(build_time_bucket(entry.message_ts));
+
+            let _ = self.unit_repo.insert(&insert).await?;
+        }
+
+        Ok(())
+    }
+
+    pub async fn upsert_summary_unit(&self, input: &SummaryUnitInput) -> Result<()> {
+        let insert = InsertMemoryUnit::new(
+            input.tenant_id.clone(),
+            input.session_id,
+            input.entry_range_start,
+            input.entry_range_end,
+            input.source_uri.clone(),
+        )?
+        .with_memory_unit_id(input.session_id)
+        .with_memory_kind(MemoryUnitKind::Summary)
+        .with_summary_state(MemoryUnitSummaryState::ready(input.summary.clone())?)
+        .with_snippet(truncate_text(&input.snippet, DEFAULT_SNIPPET_LIMIT))
+        .with_time_bucket(input.time_bucket.clone());
+
+        let _ = self.unit_repo.upsert(&insert).await?;
+        self.anchor_repo
+            .delete_by_memory_unit(&input.tenant_id, input.session_id)
+            .await?;
+        self.anchor_repo
+            .insert(
+                &InsertMemoryUnitAnchor::new(
+                    input.tenant_id.clone(),
+                    input.session_id,
+                    MemoryUnitAnchorType::Domain,
+                    input.domain_class.clone(),
+                )?,
+            )
+            .await?;
+        Ok(())
+    }
+
+    pub async fn replace_fact_units(&self, inputs: &[FactUnitInput]) -> Result<()> {
+        if inputs.is_empty() {
+            return Ok(());
+        }
+
+        let tenant_id = &inputs[0].tenant_id;
+        let session_id = inputs[0].session_id;
+        let existing = self
+            .unit_repo
+            .list_by_session_and_kind(tenant_id, session_id, MemoryUnitKind::Fact)
+            .await?;
+
+        for unit in existing {
+            self.anchor_repo
+                .delete_by_memory_unit(tenant_id, unit.memory_unit_id)
+                .await?;
+            self.unit_repo.delete_by_id(tenant_id, unit.memory_unit_id).await?;
+        }
+
+        for input in inputs {
+            let insert = InsertMemoryUnit::new(
+                input.tenant_id.clone(),
+                input.session_id,
+                input.entry_range_start,
+                input.entry_range_end,
+                build_fact_uri(&input.tenant_id, input.session_id, input.fact.id),
+            )?
+            .with_memory_unit_id(input.fact.id)
+            .with_memory_kind(MemoryUnitKind::Fact)
+            .with_summary_state(MemoryUnitSummaryState::pending())
+            .with_snippet(truncate_text(&input.fact.fact_text, DEFAULT_SNIPPET_LIMIT))
+            .with_time_bucket(input.time_bucket.clone());
+
+            let unit = self.unit_repo.insert(&insert).await?;
+            self.anchor_repo
+                .insert(
+                    &InsertMemoryUnitAnchor::new(
+                        input.tenant_id.clone(),
+                        unit.memory_unit_id,
+                        MemoryUnitAnchorType::Domain,
+                        input.domain_class.clone(),
+                    )?,
+                )
+                .await?;
+            self.anchor_repo
+                .insert(
+                    &InsertMemoryUnitAnchor::new(
+                        input.tenant_id.clone(),
+                        unit.memory_unit_id,
+                        MemoryUnitAnchorType::FactType,
+                        input.fact.fact_type.clone(),
+                    )?
+                    .with_anchor_value(input.fact.fact_text.clone())
+                    .with_weight(input.fact.confidence)?,
+                )
+                .await?;
+        }
+
+        Ok(())
+    }
+}
+
+fn truncate_text(input: &str, limit: usize) -> String {
+    let trimmed = input.trim();
+    if trimmed.chars().count() <= limit {
+        return trimmed.to_string();
+    }
+
+    let truncated: String = trimmed.chars().take(limit.saturating_sub(3)).collect();
+    format!("{truncated}...")
+}
+
+fn build_time_bucket(timestamp: chrono::DateTime<chrono::Utc>) -> String {
+    timestamp.format("%Y-%m").to_string()
+}
+
+fn build_fact_uri(tenant_id: &str, session_id: Uuid, fact_id: Uuid) -> String {
+    format!("memory-fact://tenants/{tenant_id}/sessions/{session_id}/facts/{fact_id}")
+}

--- a/koduck-memory/src/memory_unit/mod.rs
+++ b/koduck-memory/src/memory_unit/mod.rs
@@ -1,8 +1,15 @@
 //! Typed model and repository for anchored memory units.
 
+mod materializer;
 pub mod model;
 pub mod repository;
 
+pub use materializer::{
+    AppendedEntryUnit,
+    FactUnitInput,
+    MemoryUnitMaterializer,
+    SummaryUnitInput,
+};
 pub use model::{
     InsertMemoryUnit,
     MemoryUnit,

--- a/koduck-memory/src/memory_unit/model.rs
+++ b/koduck-memory/src/memory_unit/model.rs
@@ -221,6 +221,11 @@ impl InsertMemoryUnit {
         self
     }
 
+    pub fn with_memory_unit_id(mut self, memory_unit_id: Uuid) -> Self {
+        self.memory_unit_id = memory_unit_id;
+        self
+    }
+
     pub fn with_domain_class_primary(mut self, domain_class_primary: impl Into<String>) -> Self {
         self.domain_class_primary = Some(domain_class_primary.into());
         self

--- a/koduck-memory/src/memory_unit/repository.rs
+++ b/koduck-memory/src/memory_unit/repository.rs
@@ -3,7 +3,7 @@ use tracing::info;
 use uuid::Uuid;
 
 use crate::Result;
-use crate::memory_unit::model::{InsertMemoryUnit, MemoryUnit, MemoryUnitRow};
+use crate::memory_unit::model::{InsertMemoryUnit, MemoryUnit, MemoryUnitKind, MemoryUnitRow};
 
 #[derive(Clone)]
 pub struct MemoryUnitRepository {
@@ -62,6 +62,60 @@ impl MemoryUnitRepository {
         Ok(model)
     }
 
+    pub async fn upsert(&self, params: &InsertMemoryUnit) -> Result<MemoryUnit> {
+        params.validate()?;
+
+        let row = sqlx::query_as::<_, MemoryUnitRow>(
+            r#"
+            INSERT INTO memory_units (
+                memory_unit_id, tenant_id, session_id, entry_range_start, entry_range_end,
+                memory_kind, domain_class_primary, summary, snippet, source_uri,
+                summary_status, salience_score, time_bucket, created_at, updated_at
+            ) VALUES (
+                $1, $2, $3, $4, $5,
+                $6, $7, $8, $9, $10,
+                $11, CAST($12 AS NUMERIC(5, 4)), $13, now(), now()
+            )
+            ON CONFLICT (memory_unit_id) DO UPDATE SET
+                tenant_id = EXCLUDED.tenant_id,
+                session_id = EXCLUDED.session_id,
+                entry_range_start = EXCLUDED.entry_range_start,
+                entry_range_end = EXCLUDED.entry_range_end,
+                memory_kind = EXCLUDED.memory_kind,
+                domain_class_primary = EXCLUDED.domain_class_primary,
+                summary = EXCLUDED.summary,
+                snippet = EXCLUDED.snippet,
+                source_uri = EXCLUDED.source_uri,
+                summary_status = EXCLUDED.summary_status,
+                salience_score = EXCLUDED.salience_score,
+                time_bucket = EXCLUDED.time_bucket,
+                updated_at = now()
+            RETURNING
+                memory_unit_id, tenant_id, session_id, entry_range_start, entry_range_end,
+                memory_kind, domain_class_primary, summary, snippet, source_uri,
+                summary_status, salience_score::DOUBLE PRECISION AS salience_score,
+                time_bucket, created_at, updated_at
+            "#,
+        )
+        .bind(params.memory_unit_id)
+        .bind(&params.tenant_id)
+        .bind(params.session_id)
+        .bind(params.entry_range_start)
+        .bind(params.entry_range_end)
+        .bind(params.memory_kind.as_db_value())
+        .bind(&params.domain_class_primary)
+        .bind(&params.summary_state.summary)
+        .bind(&params.snippet)
+        .bind(&params.source_uri)
+        .bind(&params.summary_state.summary_status)
+        .bind(params.salience_score)
+        .bind(&params.time_bucket)
+        .fetch_one(&self.pool)
+        .await?;
+
+        MemoryUnit::try_from(row)
+    }
+
     pub async fn get_by_id(&self, tenant_id: &str, memory_unit_id: Uuid) -> Result<Option<MemoryUnit>> {
         let row = sqlx::query_as::<_, MemoryUnitRow>(
             r#"
@@ -108,5 +162,69 @@ impl MemoryUnitRepository {
         .await?;
 
         rows.into_iter().map(MemoryUnit::try_from).collect()
+    }
+
+    pub async fn list_by_session_and_kind(
+        &self,
+        tenant_id: &str,
+        session_id: Uuid,
+        memory_kind: MemoryUnitKind,
+    ) -> Result<Vec<MemoryUnit>> {
+        let rows = match memory_kind {
+            MemoryUnitKind::GenericConversation => {
+                sqlx::query_as::<_, MemoryUnitRow>(
+                    r#"
+                    SELECT
+                        memory_unit_id, tenant_id, session_id, entry_range_start, entry_range_end,
+                        memory_kind, domain_class_primary, summary, snippet, source_uri,
+                        summary_status, salience_score::DOUBLE PRECISION AS salience_score,
+                        time_bucket, created_at, updated_at
+                    FROM memory_units
+                    WHERE tenant_id = $1 AND session_id = $2 AND memory_kind IS NULL
+                    ORDER BY created_at DESC
+                    "#,
+                )
+                .bind(tenant_id)
+                .bind(session_id)
+                .fetch_all(&self.pool)
+                .await?
+            }
+            _ => {
+                sqlx::query_as::<_, MemoryUnitRow>(
+                    r#"
+                    SELECT
+                        memory_unit_id, tenant_id, session_id, entry_range_start, entry_range_end,
+                        memory_kind, domain_class_primary, summary, snippet, source_uri,
+                        summary_status, salience_score::DOUBLE PRECISION AS salience_score,
+                        time_bucket, created_at, updated_at
+                    FROM memory_units
+                    WHERE tenant_id = $1 AND session_id = $2 AND memory_kind = $3
+                    ORDER BY created_at DESC
+                    "#,
+                )
+                .bind(tenant_id)
+                .bind(session_id)
+                .bind(memory_kind.as_db_value())
+                .fetch_all(&self.pool)
+                .await?
+            }
+        };
+
+        rows.into_iter().map(MemoryUnit::try_from).collect()
+    }
+
+    pub async fn delete_by_id(&self, tenant_id: &str, memory_unit_id: Uuid) -> Result<u64> {
+        let result = sqlx::query(
+            r#"
+            DELETE FROM memory_units
+            WHERE tenant_id = $1 AND memory_unit_id = $2
+            "#,
+        )
+        .bind(tenant_id)
+        .bind(memory_unit_id)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected())
     }
 }

--- a/koduck-memory/src/summary/runner.rs
+++ b/koduck-memory/src/summary/runner.rs
@@ -13,6 +13,7 @@ use crate::config::{RetrySection, SummarySection};
 use crate::facts::{InsertMemoryFact, MemoryFact, MemoryFactRepository};
 use crate::index::{InsertMemoryIndexRecord, MemoryIndexRepository};
 use crate::memory::MemoryEntryRepository;
+use crate::memory_unit::{FactUnitInput, MemoryUnitMaterializer, SummaryUnitInput};
 use crate::reliability::{TaskAttemptRepository, with_retry};
 use crate::retrieve::domain_class;
 use crate::session::SessionRepository;
@@ -58,6 +59,7 @@ pub struct SummaryTaskRunner {
     fact_repo: MemoryFactRepository,
     attempt_repo: TaskAttemptRepository,
     index_repo: MemoryIndexRepository,
+    unit_materializer: MemoryUnitMaterializer,
     object_store: Option<ObjectStoreClient>,
     retry_config: RetrySection,
     summary_config: SummarySection,
@@ -78,6 +80,7 @@ impl SummaryTaskRunner {
             fact_repo: MemoryFactRepository::new(pool),
             attempt_repo: TaskAttemptRepository::new(pool),
             index_repo: MemoryIndexRepository::new(pool),
+            unit_materializer: MemoryUnitMaterializer::new(pool),
             object_store,
             retry_config,
             llm_gate: Arc::new(Semaphore::new(summary_config.llm_max_concurrency.max(1))),
@@ -217,6 +220,13 @@ impl SummaryTaskRunner {
             stored_summary: stored,
             summary_snippet: summary_artifact.snippet,
             fact_candidates,
+            entry_sequence_range: entries
+                .first()
+                .zip(entries.last())
+                .map(|(first, last)| (first.sequence_num, last.sequence_num)),
+            time_bucket: entries
+                .last()
+                .map(|entry| entry.message_ts.format("%Y-%m").to_string()),
             request_id: job.request_id,
             test_strategy: job.strategy,
         })
@@ -240,11 +250,26 @@ impl SummaryTaskRunner {
             "summary",
             stored.domain_class.clone(),
             stored.summary.clone(),
-            summary_uri,
+            summary_uri.clone(),
         )
         .with_snippet(materialized.summary_snippet.clone())
         .with_score_hint("0.95");
         self.index_repo.insert(&index_record).await?;
+        if let Some((entry_range_start, entry_range_end, time_bucket)) = materialized.entry_range() {
+            self.unit_materializer
+                .upsert_summary_unit(&SummaryUnitInput {
+                    tenant_id: stored.tenant_id.clone(),
+                    session_id: stored.session_id,
+                    domain_class: stored.domain_class.clone(),
+                    summary: stored.summary.clone(),
+                    snippet: materialized.summary_snippet.clone(),
+                    source_uri: summary_uri,
+                    entry_range_start,
+                    entry_range_end,
+                    time_bucket,
+                })
+                .await?;
+        }
         Ok(())
     }
 
@@ -276,6 +301,22 @@ impl SummaryTaskRunner {
                 candidate.confidence,
             );
             facts.push(self.fact_repo.insert(&insert_fact).await?);
+        }
+        if let Some((entry_range_start, entry_range_end, time_bucket)) = materialized.entry_range() {
+            let inputs = facts
+                .iter()
+                .cloned()
+                .map(|fact| FactUnitInput {
+                    tenant_id: materialized.stored_summary.tenant_id.clone(),
+                    session_id: materialized.stored_summary.session_id,
+                    domain_class: materialized.stored_summary.domain_class.clone(),
+                    fact,
+                    entry_range_start,
+                    entry_range_end,
+                    time_bucket: time_bucket.clone(),
+                })
+                .collect::<Vec<_>>();
+            self.unit_materializer.replace_fact_units(&inputs).await?;
         }
         Ok(facts)
     }
@@ -323,6 +364,8 @@ struct SummaryMaterialization {
     stored_summary: MemorySummary,
     summary_snippet: String,
     fact_candidates: Vec<FactCandidate>,
+    entry_sequence_range: Option<(i64, i64)>,
+    time_bucket: Option<String>,
     request_id: String,
     test_strategy: String,
 }
@@ -390,6 +433,12 @@ struct DomainClassArtifact {
 impl SummaryMaterialization {
     fn has_fact_candidates(&self) -> bool {
         !self.fact_candidates.is_empty()
+    }
+
+    fn entry_range(&self) -> Option<(i64, i64, String)> {
+        self.entry_sequence_range
+            .zip(self.time_bucket.clone())
+            .map(|((start, end), time_bucket)| (start, end, time_bucket))
     }
 }
 


### PR DESCRIPTION
## Summary
- materialize generic memory units synchronously for appended entries
- materialize summary and fact memory units from the async summary pipeline with anchor updates
- add ADR-0030 and mark Task 2.2 complete in the adr-0025 implementation checklist

## Verification
- docker build -t koduck-memory:dev ./koduck-memory
- docker build -t koduck-ai:dev ./koduck-ai

Closes #853