### PR TITLE
feat(memory): keep index record compatibility mapping

### DIFF
--- a/docs/implementation/adr-0025-anchor-based-memory-retrieval-tasks.md
+++ b/docs/implementation/adr-0025-anchor-based-memory-retrieval-tasks.md
@@ -187,10 +187,10 @@ kubectl rollout status deployment/dev-koduck-memory -n koduck-dev --timeout=180s
 3. 确保新写入链路不破坏旧读路径
 
 **验收标准:**
-- [ ] 现有 `DOMAIN_FIRST` / `SUMMARY_FIRST` 路径可继续工作
-- [ ] 新老结构之间有稳定映射关系
-- [ ] 不要求一次性切换全部读路径
-- [ ] `docker build -t koduck-memory:dev ./koduck-memory` 成功
+- [x] 现有 `DOMAIN_FIRST` / `SUMMARY_FIRST` 路径可继续工作
+- [x] 新老结构之间有稳定映射关系
+- [x] 不要求一次性切换全部读路径
+- [x] `docker build -t koduck-memory:dev ./koduck-memory` 成功
 
 ---
 

--- a/koduck-memory/docs/adr/0031-memory-index-record-compatibility-mapping.md
+++ b/koduck-memory/docs/adr/0031-memory-index-record-compatibility-mapping.md
@@ -1,0 +1,83 @@
+# ADR-0031: `memory_index_records` Compatibility Mapping
+
+- Status: Accepted
+- Date: 2026-04-14
+- Issue: #855
+
+## Context
+
+经过 Task 2.2，`memory_units` 已经成为真实写入产物，但 `koduck-memory` 当前的检索主路径
+`DOMAIN_FIRST` / `SUMMARY_FIRST` 仍直接读取 `memory_index_records`。
+
+这意味着在切换查询侧主路径之前，我们必须同时满足两件事：
+
+1. 继续保留 `memory_index_records`，避免破坏现有读链路
+2. 给旧索引记录补上与 `memory_units` 的稳定映射关系，避免新旧结构并存时语义漂移
+
+Task 2.3 要求兼容写入，而不是一次性切换全部读路径。
+
+## Decision
+
+### 1. 保留 `memory_index_records` 作为兼容层
+
+当前阶段不删除 `memory_index_records`，`DOMAIN_FIRST` / `SUMMARY_FIRST` 继续读它。
+新架构中的 `memory_units` / `memory_unit_anchors` 先作为写入真值与后续检索迁移基础。
+
+### 2. 为 `memory_index_records` 增加显式 `memory_unit_id`
+
+在 `memory_index_records` 上新增可空列：
+
+- `memory_unit_id UUID NULL`
+
+该字段用于表达兼容层到新结构的一跳映射，避免仅靠 `source_uri` 或隐式规则反推。
+
+### 3. V1 稳定映射规则
+
+V1 先冻结以下兼容规则：
+
+1. `memory_kind = summary` 的 `memory_index_record` 必须指向 session-scoped summary unit
+   - `memory_index_records.memory_unit_id = memory_units.memory_unit_id = session_id`
+2. 现有 `DOMAIN_FIRST` / `SUMMARY_FIRST` 查询逻辑不要求立即改读 `memory_units`
+3. generic conversation units 与 fact units 在 V1 不要求都镜像到 `memory_index_records`
+4. 如仍存在遗留 entry-backed index record，可继续依赖旧字段；后续是否补齐 `memory_unit_id` 由迁移阶段再收口
+
+### 4. 在兼容写路径中同步写入该映射
+
+`SummaryTaskRunner::refresh_summary_index()` 在写入 summary index record 时，必须同步写入：
+
+- `memory_unit_id = stored.session_id`
+
+这样旧索引记录与新的 summary unit 保持稳定一一对应。
+
+## Consequences
+
+正面影响：
+
+1. 旧检索路径无需改动即可继续工作。
+2. 新旧结构之间不再只有文档约定，而是有 schema 级关联字段。
+3. 后续将 `DOMAIN_FIRST` / `SUMMARY_FIRST` 渐进切到 `memory_units` 时，可以平滑比对结果。
+
+代价与权衡：
+
+1. `memory_index_records` 会继续存在一段时间，短期内存在双写维护成本。
+2. 当前只为 summary compatibility path 补显式映射；generic / fact 的全面兼容映射留待后续阶段。
+
+## Compatibility Impact
+
+1. 不修改 `memory.v1` 外部契约。
+2. 不改变 `DOMAIN_FIRST` / `SUMMARY_FIRST` 的对外行为。
+3. 新增列为向后兼容扩展；旧数据允许 `memory_unit_id = NULL`。
+
+## Alternatives Considered
+
+### Alternative A: 直接删除 `memory_index_records`
+
+未采用。当前读路径仍依赖该表，直接删除会导致检索行为回退。
+
+### Alternative B: 只在 ADR 中定义映射规则，不落 schema 字段
+
+未采用。仅靠 `source_uri` / `session_id` / `memory_kind` 的组合反推，容易在迁移期产生歧义。
+
+### Alternative C: 立即把所有 generic / fact units 都镜像写入 `memory_index_records`
+
+未采用。Task 2.3 的目标是兼容写入，不要求一次性把全部新结构投影回旧索引表。

--- a/koduck-memory/migrations/0008_project_domain_class_primary_function.down.sql
+++ b/koduck-memory/migrations/0008_project_domain_class_primary_function.down.sql
@@ -1,0 +1,37 @@
+DROP FUNCTION IF EXISTS project_domain_class_primary(VARCHAR(128), UUID);
+
+CREATE OR REPLACE FUNCTION compute_memory_unit_domain_class_primary(
+    p_tenant_id VARCHAR(128),
+    p_memory_unit_id UUID
+)
+RETURNS VARCHAR(64)
+LANGUAGE sql
+STABLE
+AS $$
+    SELECT anchor_key::VARCHAR(64)
+    FROM memory_unit_anchors
+    WHERE tenant_id = p_tenant_id
+      AND memory_unit_id = p_memory_unit_id
+      AND anchor_type = 'domain'
+    ORDER BY weight DESC, anchor_key ASC
+    LIMIT 1
+$$;
+
+CREATE OR REPLACE FUNCTION sync_memory_unit_domain_class_primary(
+    p_tenant_id VARCHAR(128),
+    p_memory_unit_id UUID
+)
+RETURNS VOID
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    UPDATE memory_units
+    SET domain_class_primary = compute_memory_unit_domain_class_primary(
+            p_tenant_id,
+            p_memory_unit_id
+        ),
+        updated_at = updated_at
+    WHERE tenant_id = p_tenant_id
+      AND memory_unit_id = p_memory_unit_id;
+END;
+$$;

--- a/koduck-memory/migrations/0008_project_domain_class_primary_function.up.sql
+++ b/koduck-memory/migrations/0008_project_domain_class_primary_function.up.sql
@@ -1,0 +1,49 @@
+CREATE OR REPLACE FUNCTION project_domain_class_primary(
+    p_tenant_id VARCHAR(128),
+    p_memory_unit_id UUID
+)
+RETURNS VARCHAR(64)
+LANGUAGE sql
+STABLE
+AS $$
+    SELECT anchor_key::VARCHAR(64)
+    FROM memory_unit_anchors
+    WHERE tenant_id = p_tenant_id
+      AND memory_unit_id = p_memory_unit_id
+      AND anchor_type = 'domain'
+    ORDER BY weight DESC, anchor_key ASC
+    LIMIT 1
+$$;
+
+COMMENT ON FUNCTION project_domain_class_primary(VARCHAR(128), UUID) IS
+    'Canonical projection algorithm for memory_units.domain_class_primary. Always select the first domain anchor ordered by weight DESC, anchor_key ASC.';
+
+CREATE OR REPLACE FUNCTION compute_memory_unit_domain_class_primary(
+    p_tenant_id VARCHAR(128),
+    p_memory_unit_id UUID
+)
+RETURNS VARCHAR(64)
+LANGUAGE sql
+STABLE
+AS $$
+    SELECT project_domain_class_primary(p_tenant_id, p_memory_unit_id)
+$$;
+
+CREATE OR REPLACE FUNCTION sync_memory_unit_domain_class_primary(
+    p_tenant_id VARCHAR(128),
+    p_memory_unit_id UUID
+)
+RETURNS VOID
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    UPDATE memory_units
+    SET domain_class_primary = project_domain_class_primary(
+            p_tenant_id,
+            p_memory_unit_id
+        ),
+        updated_at = updated_at
+    WHERE tenant_id = p_tenant_id
+      AND memory_unit_id = p_memory_unit_id;
+END;
+$$;

--- a/koduck-memory/migrations/0009_memory_index_records_memory_unit_mapping.down.sql
+++ b/koduck-memory/migrations/0009_memory_index_records_memory_unit_mapping.down.sql
@@ -1,0 +1,4 @@
+DROP INDEX IF EXISTS idx_memory_index_records_memory_unit_id;
+
+ALTER TABLE memory_index_records
+    DROP COLUMN IF EXISTS memory_unit_id;

--- a/koduck-memory/migrations/0009_memory_index_records_memory_unit_mapping.up.sql
+++ b/koduck-memory/migrations/0009_memory_index_records_memory_unit_mapping.up.sql
@@ -1,0 +1,8 @@
+ALTER TABLE memory_index_records
+    ADD COLUMN IF NOT EXISTS memory_unit_id UUID NULL;
+
+CREATE INDEX IF NOT EXISTS idx_memory_index_records_memory_unit_id
+    ON memory_index_records (memory_unit_id);
+
+COMMENT ON COLUMN memory_index_records.memory_unit_id IS
+    'Compatibility mapping to memory_units.memory_unit_id. V1 summary index records point to the session-scoped summary unit; legacy entry-backed records may remain NULL or use explicit mapping rules outside this column.';

--- a/koduck-memory/src/capability/service.rs
+++ b/koduck-memory/src/capability/service.rs
@@ -2374,6 +2374,7 @@ mod tests {
         let first_facts = wait_for_facts(&fact_repo, "tenant-t33", session_id).await;
 
         assert_eq!(first_projection.len(), 1);
+        assert_eq!(first_projection[0].memory_unit_id, Some(session_id));
         assert!(
             first_summary.summary.contains("Karl Marx")
                 || first_summary.summary.contains("Friedrich Engels")
@@ -2420,6 +2421,7 @@ mod tests {
         let updated_facts = updated_facts.expect("updated facts were not materialized in time");
 
         assert_eq!(updated_projection.len(), 1);
+        assert_eq!(updated_projection[0].memory_unit_id, Some(session_id));
         assert_eq!(updated_projection[0].summary, updated_summary.summary);
         assert!(
             updated_summary.summary.contains("Karl Marx")

--- a/koduck-memory/src/capability/service.rs
+++ b/koduck-memory/src/capability/service.rs
@@ -2281,6 +2281,10 @@ mod tests {
             .iter()
             .find(|unit| unit.memory_kind == MemoryUnitKind::Summary)
             .expect("summary unit should exist");
+        assert_eq!(
+            summary_unit.domain_class_primary.as_deref(),
+            Some(stored_summary.domain_class.as_str())
+        );
         assert_eq!(summary_unit.entry_range_start, 1);
         assert_eq!(summary_unit.entry_range_end, 2);
         assert_eq!(summary_unit.memory_unit_id, session_id);
@@ -2301,6 +2305,9 @@ mod tests {
         assert_eq!(fact_units.len(), facts.len());
         assert!(fact_units.iter().all(|unit| unit.entry_range_start == 1 && unit.entry_range_end == 2));
         assert!(fact_units.iter().all(|unit| unit.summary_state.summary_status == "pending"));
+        assert!(fact_units.iter().all(|unit| {
+            unit.domain_class_primary.as_deref() == Some(stored_summary.domain_class.as_str())
+        }));
 
         let summary_anchors = anchor_repo
             .list_by_memory_unit("tenant-t33", summary_unit.memory_unit_id)

--- a/koduck-memory/src/index/model.rs
+++ b/koduck-memory/src/index/model.rs
@@ -9,6 +9,8 @@ pub struct MemoryIndexRecord {
     pub id: Uuid,
     pub tenant_id: String,
     pub session_id: Uuid,
+    /// Optional reference to the mapped memory unit for compatibility migration.
+    pub memory_unit_id: Option<Uuid>,
     /// Optional reference to the originating memory entry
     pub entry_id: Option<Uuid>,
     /// Kind of memory: user, assistant, system, summary, fact, etc.
@@ -32,6 +34,7 @@ pub struct InsertMemoryIndexRecord {
     pub id: Uuid,
     pub tenant_id: String,
     pub session_id: Uuid,
+    pub memory_unit_id: Option<Uuid>,
     pub entry_id: Option<Uuid>,
     pub memory_kind: String,
     pub domain_class: String,
@@ -55,6 +58,7 @@ impl InsertMemoryIndexRecord {
             id: Uuid::new_v4(),
             tenant_id: tenant_id.into(),
             session_id,
+            memory_unit_id: None,
             entry_id: None,
             memory_kind: memory_kind.into(),
             domain_class: domain_class.into(),
@@ -68,6 +72,12 @@ impl InsertMemoryIndexRecord {
     /// Set the optional entry_id reference.
     pub fn with_entry_id(mut self, entry_id: Uuid) -> Self {
         self.entry_id = Some(entry_id);
+        self
+    }
+
+    /// Set the optional memory_unit_id compatibility reference.
+    pub fn with_memory_unit_id(mut self, memory_unit_id: Uuid) -> Self {
+        self.memory_unit_id = Some(memory_unit_id);
         self
     }
 
@@ -107,6 +117,7 @@ mod tests {
 
         assert_eq!(params.tenant_id, "tenant-123");
         assert_eq!(params.session_id, session_id);
+        assert!(params.memory_unit_id.is_none());
         assert_eq!(params.entry_id, Some(entry_id));
         assert_eq!(params.memory_kind, "user");
         assert_eq!(params.domain_class, "chat");
@@ -129,6 +140,7 @@ mod tests {
         );
 
         assert_eq!(params.tenant_id, "tenant-456");
+        assert!(params.memory_unit_id.is_none());
         assert!(params.entry_id.is_none());
         assert!(params.snippet.is_none());
         assert!(params.score_hint.is_none());

--- a/koduck-memory/src/index/repository.rs
+++ b/koduck-memory/src/index/repository.rs
@@ -25,14 +25,14 @@ impl MemoryIndexRepository {
         let row = sqlx::query_as::<_, MemoryIndexRecord>(
             r#"
             INSERT INTO memory_index_records (
-                id, tenant_id, session_id, entry_id,
+                id, tenant_id, session_id, memory_unit_id, entry_id,
                 memory_kind, domain_class, summary, snippet,
                 source_uri, score_hint, created_at, updated_at
             ) VALUES (
-                $1, $2, $3, $4, $5, $6, $7, $8, $9, CAST($10 AS NUMERIC), now(), now()
+                $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, CAST($11 AS NUMERIC), now(), now()
             )
             RETURNING 
-                id, tenant_id, session_id, entry_id,
+                id, tenant_id, session_id, memory_unit_id, entry_id,
                 memory_kind, domain_class, summary, snippet,
                 source_uri, score_hint::text AS score_hint,
                 created_at, updated_at
@@ -41,6 +41,7 @@ impl MemoryIndexRepository {
         .bind(record.id)
         .bind(&record.tenant_id)
         .bind(record.session_id)
+        .bind(record.memory_unit_id)
         .bind(record.entry_id)
         .bind(&record.memory_kind)
         .bind(&record.domain_class)
@@ -75,7 +76,7 @@ impl MemoryIndexRepository {
         let rows = sqlx::query_as::<_, MemoryIndexRecord>(
             r#"
             SELECT 
-                id, tenant_id, session_id, entry_id,
+                id, tenant_id, session_id, memory_unit_id, entry_id,
                 memory_kind, domain_class, summary, snippet,
                 source_uri, score_hint::text AS score_hint,
                 created_at, updated_at
@@ -111,7 +112,7 @@ impl MemoryIndexRepository {
             sqlx::query_as::<_, MemoryIndexRecord>(
                 r#"
                 SELECT 
-                    id, tenant_id, session_id, entry_id,
+                    id, tenant_id, session_id, memory_unit_id, entry_id,
                     memory_kind, domain_class, summary, snippet,
                     source_uri, score_hint::text AS score_hint,
                     created_at, updated_at
@@ -134,7 +135,7 @@ impl MemoryIndexRepository {
             sqlx::query_as::<_, MemoryIndexRecord>(
                 r#"
                 SELECT 
-                    id, tenant_id, session_id, entry_id,
+                    id, tenant_id, session_id, memory_unit_id, entry_id,
                     memory_kind, domain_class, summary, snippet,
                     source_uri, score_hint::text AS score_hint,
                     created_at, updated_at
@@ -173,7 +174,7 @@ impl MemoryIndexRepository {
         let rows = sqlx::query_as::<_, MemoryIndexRecord>(
             r#"
             SELECT 
-                id, tenant_id, session_id, entry_id,
+                id, tenant_id, session_id, memory_unit_id, entry_id,
                 memory_kind, domain_class, summary, snippet,
                 source_uri, score_hint::text AS score_hint,
                 created_at, updated_at
@@ -221,7 +222,7 @@ impl MemoryIndexRepository {
                 sqlx::query_as::<_, MemoryIndexRecord>(
                     r#"
                     SELECT
-                        id, tenant_id, session_id, entry_id,
+                        id, tenant_id, session_id, memory_unit_id, entry_id,
                         memory_kind, domain_class, summary, snippet,
                         source_uri, score_hint::text AS score_hint,
                         created_at, updated_at
@@ -249,7 +250,7 @@ impl MemoryIndexRepository {
                 sqlx::query_as::<_, MemoryIndexRecord>(
                     r#"
                     SELECT
-                        id, tenant_id, session_id, entry_id,
+                        id, tenant_id, session_id, memory_unit_id, entry_id,
                         memory_kind, domain_class, summary, snippet,
                         source_uri, score_hint::text AS score_hint,
                         created_at, updated_at
@@ -293,7 +294,7 @@ impl MemoryIndexRepository {
         let row = sqlx::query_as::<_, MemoryIndexRecord>(
             r#"
                 SELECT
-                    id, tenant_id, session_id, entry_id,
+                    id, tenant_id, session_id, memory_unit_id, entry_id,
                     memory_kind, domain_class, summary, snippet,
                     source_uri, score_hint::text AS score_hint,
                     created_at, updated_at

--- a/koduck-memory/src/memory_unit/materializer.rs
+++ b/koduck-memory/src/memory_unit/materializer.rs
@@ -113,6 +113,9 @@ impl MemoryUnitMaterializer {
                 )?,
             )
             .await?;
+        self.unit_repo
+            .sync_projected_domain_class_primary(&input.tenant_id, input.session_id)
+            .await?;
         Ok(())
     }
 
@@ -171,6 +174,9 @@ impl MemoryUnitMaterializer {
                     .with_anchor_value(input.fact.fact_text.clone())
                     .with_weight(input.fact.confidence)?,
                 )
+                .await?;
+            self.unit_repo
+                .sync_projected_domain_class_primary(&input.tenant_id, unit.memory_unit_id)
                 .await?;
         }
 

--- a/koduck-memory/src/memory_unit/repository.rs
+++ b/koduck-memory/src/memory_unit/repository.rs
@@ -227,4 +227,40 @@ impl MemoryUnitRepository {
 
         Ok(result.rows_affected())
     }
+
+    pub async fn project_domain_class_primary(
+        &self,
+        tenant_id: &str,
+        memory_unit_id: Uuid,
+    ) -> Result<Option<String>> {
+        let projected = sqlx::query_scalar::<_, Option<String>>(
+            r#"
+            SELECT project_domain_class_primary($1, $2)
+            "#,
+        )
+        .bind(tenant_id)
+        .bind(memory_unit_id)
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(projected)
+    }
+
+    pub async fn sync_projected_domain_class_primary(
+        &self,
+        tenant_id: &str,
+        memory_unit_id: Uuid,
+    ) -> Result<()> {
+        sqlx::query(
+            r#"
+            SELECT sync_memory_unit_domain_class_primary($1, $2)
+            "#,
+        )
+        .bind(tenant_id)
+        .bind(memory_unit_id)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(())
+    }
 }

--- a/koduck-memory/src/summary/runner.rs
+++ b/koduck-memory/src/summary/runner.rs
@@ -252,6 +252,7 @@ impl SummaryTaskRunner {
             stored.summary.clone(),
             summary_uri.clone(),
         )
+        .with_memory_unit_id(stored.session_id)
         .with_snippet(materialized.summary_snippet.clone())
         .with_score_hint("0.95");
         self.index_repo.insert(&index_record).await?;


### PR DESCRIPTION
## Summary
- keep legacy memory_index_records as a compatibility layer by adding an explicit memory_unit_id mapping column
- continue summary compatibility writes while preserving existing DOMAIN_FIRST / SUMMARY_FIRST reads
- add ADR-0031 and complete Task 2.3 in the adr-0025 implementation checklist

## Verification
- docker build -t koduck-memory:dev ./koduck-memory
- docker build -t koduck-ai:dev ./koduck-ai

Closes #855