### PR TITLE
feat(memory): add query analyzer context

### DIFF
--- a/docs/implementation/adr-0025-anchor-based-memory-retrieval-tasks.md
+++ b/docs/implementation/adr-0025-anchor-based-memory-retrieval-tasks.md
@@ -215,10 +215,10 @@ kubectl rollout status deployment/dev-koduck-memory -n koduck-dev --timeout=180s
    - `recall_target_type`
 
 **验收标准:**
-- [ ] `query analyzer` 不再是隐含步骤
-- [ ] 输出字段与 ADR 定义一致
-- [ ] analyzer 失败时存在明确回退路径
-- [ ] `docker build -t koduck-memory:dev ./koduck-memory` 成功
+- [x] `query analyzer` 不再是隐含步骤
+- [x] 输出字段与 ADR 定义一致
+- [x] analyzer 失败时存在明确回退路径
+- [x] `docker build -t koduck-memory:dev ./koduck-memory` 成功
 - [ ] `kubectl rollout restart deployment/dev-koduck-memory -n koduck-dev` 后可成功完成 rollout
 
 ---

--- a/koduck-memory/docs/adr/0032-query-memory-internal-query-analyzer.md
+++ b/koduck-memory/docs/adr/0032-query-memory-internal-query-analyzer.md
@@ -1,0 +1,112 @@
+# ADR-0032: `QueryMemory` Internal Query Analyzer
+
+- Status: Accepted
+- Date: 2026-04-14
+- Issue: #857
+
+## Context
+
+在 Task 2.x 完成之后，`koduck-memory` 已经具备了：
+
+- `memory_units` / `memory_unit_anchors` 的物化基线
+- `memory_index_records` 的兼容层
+- `DOMAIN_FIRST` / `SUMMARY_FIRST` 的现有读路径
+
+但 `QueryMemory` 当前仍然只是直接拼装一个很薄的 `RetrieveContext`，并没有一个被显式命名和测试的
+`query analyzer` 子组件。这会带来三个问题：
+
+1. `domain_class`、`intent`、`entity`、`relation` 的提取步骤仍是隐含的
+2. 后续 Task 3.2 / 4.x 难以在统一入口上继续扩展
+3. analyzer 失败时缺少明确、可验证的回退语义
+
+Task 3.1 要求把 analyzer 收口成 `QueryMemory` 的内部组件。
+
+## Decision
+
+### 1. 在 `retrieve/` 模块下新增 `query_analyzer.rs`
+
+引入内部组件：
+
+- `QueryAnalyzer`
+- `QueryAnalysis`
+
+输入固定为：
+
+- `query_text`
+- `domain_class`
+- `session_id`
+
+输出固定为：
+
+- `domain_classes[]`
+- `entities[]`
+- `relation_types[]`
+- `intent_type`
+- `intent_aux[]`
+- `recall_target_type`
+
+### 2. 使用启发式规则冻结 V1 analyzer 输出骨架
+
+V1 不依赖额外模型调用，而是先用稳定的启发式规则完成：
+
+- `domain_class` 归一化
+- `intent_type` 粗分类
+- `entities` 的轻量提取
+- `relation_types` 的关键词识别
+- `recall_target_type` 的偏好/事实/通用识别
+- `intent_aux[]` 的有限增强标签
+
+这保证 Task 3.1 能先把 analyzer 组件边界收稳，再在后续任务中继续丰富语义。
+
+### 3. 把 analyzer 作为 `QueryMemory` 的显式前置步骤
+
+`QueryMemory` 在分派给 `DOMAIN_FIRST` / `SUMMARY_FIRST` 之前：
+
+1. 先调用 `QueryAnalyzer::analyze(...)`
+2. 再把分析结果灌入扩展后的 `RetrieveContext`
+3. 现有 retriever 暂时仍主要使用 `domain_class` / `query_text` / `session_id`
+
+这样 analyzer 不再是“未来要加的概念”，而是已经进入真实主路径的内部步骤。
+
+### 4. analyzer 失败时显式回退
+
+若 analyzer 返回错误：
+
+- 记录结构化 warning
+- 回退到 `QueryAnalysis::fallback(...)`
+- 保留原始 `domain_class + query_text + session_id` 路径
+
+这保证 analyzer 不会因为局部解析失败而阻塞主检索请求。
+
+## Consequences
+
+正面影响：
+
+1. `QueryMemory` 拥有了明确的 analyzer 子流程和结构化上下文载体。
+2. 后续 Task 3.2 / 4.x 可以在同一入口上继续演进，而不必重构主 RPC。
+3. analyzer 的失败语义被代码和测试显式冻结。
+
+代价与权衡：
+
+1. V1 analyzer 仍是启发式实现，召回语义增强有限。
+2. 当前 retriever 还没有完全消费 `entities[]` / `relation_types[]` / `intent_aux[]`，这些字段先作为稳定中间表示存在。
+
+## Compatibility Impact
+
+1. 不修改 `memory.v1` 对外契约。
+2. 不改变 `DOMAIN_FIRST` / `SUMMARY_FIRST` 的现有外部开关语义。
+3. analyzer 失败时回退到旧路径，因此不会破坏现有查询请求。
+
+## Alternatives Considered
+
+### Alternative A: 继续把 analyzer 保持为隐含步骤
+
+未采用。这样后续 intent / anchor path 的扩展入口仍然模糊。
+
+### Alternative B: 直接接入外部 LLM/分类服务
+
+未采用。Task 3.1 的目标是先建立内部组件边界，不是引入新的外部依赖。
+
+### Alternative C: 先不扩展 `RetrieveContext`，只在 `QueryMemory` 局部使用 analyzer 结果
+
+未采用。这样 analyzer 输出无法成为后续检索管线的稳定中间表示。

--- a/koduck-memory/src/capability/service.rs
+++ b/koduck-memory/src/capability/service.rs
@@ -19,7 +19,7 @@ use crate::memory_unit::{AppendedEntryUnit, MemoryUnitMaterializer};
 use crate::observe::{record_rpc_call, RpcMethod, RpcOutcome};
 use crate::observe::RpcGuard;
 use crate::observe::RpcMetrics;
-use crate::retrieve::{DomainFirstRetriever, RetrieveContext, SummaryFirstRetriever};
+use crate::retrieve::{DomainFirstRetriever, QueryAnalysis, QueryAnalyzer, RetrieveContext, SummaryFirstRetriever};
 use crate::summary::{SummaryJob, SummaryTaskRunner};
 use crate::session::{
     extra_to_jsonb, parse_optional_uuid, parse_uuid, SessionRepository, UpsertSession,
@@ -373,6 +373,28 @@ impl MemoryService for MemoryGrpcService {
         if !req.session_id.is_empty() {
             ctx = ctx.with_session_id(&req.session_id);
         }
+
+        // Explicit internal query analyzer for structured retrieval context.
+        let query_analysis = QueryAnalyzer::new()
+            .analyze(&req.query_text, &domain_class, &req.session_id)
+            .unwrap_or_else(|error| {
+                tracing::warn!(
+                    error = %error,
+                    tenant_id = %meta.tenant_id,
+                    session_id = req.session_id,
+                    domain_class = domain_class,
+                    "query analyzer failed, falling back to raw retrieval context"
+                );
+                QueryAnalysis::fallback(&domain_class, &req.query_text)
+            });
+        ctx = ctx.with_query_analysis(
+            query_analysis.domain_classes,
+            query_analysis.entities,
+            query_analysis.relation_types,
+            query_analysis.intent_type,
+            query_analysis.intent_aux,
+            query_analysis.recall_target_type,
+        );
 
         // Execute retrieval based on policy
         let results = match req.retrieve_policy {
@@ -2536,6 +2558,50 @@ mod tests {
         assert!(hit.match_reasons.contains(&"domain_class_hit".to_string()));
         assert!(hit.match_reasons.contains(&"summary_hit".to_string()));
         assert!(hit.match_reasons.contains(&"session_scope_hit".to_string()));
+    }
+
+    #[tokio::test]
+    async fn query_memory_falls_back_when_query_analyzer_fails() {
+        let config = test_config();
+        let runtime = RuntimeState::initialize(&config).await.unwrap();
+        let service = MemoryGrpcService::new(config, runtime.clone(), None, Arc::new(RpcMetrics::new()));
+
+        let session_id = Uuid::new_v4();
+        let sid_str = session_id.to_string();
+
+        let session_resp = service
+            .upsert_session_meta(Request::new(UpsertSessionMetaRequest {
+                meta: Some(write_meta_with_idempotency("t54-seed", &sid_str)),
+                session_id: sid_str.clone(),
+                title: "Analyzer fallback".to_string(),
+                status: "active".to_string(),
+                parent_session_id: String::new(),
+                forked_from_session_id: String::new(),
+                last_message_at: 1700000000000,
+                extra: HashMap::new(),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert!(session_resp.ok);
+
+        let query_resp = service
+            .query_memory(Request::new(QueryMemoryRequest {
+                meta: Some(write_meta_with_idempotency("t54-query", &sid_str)),
+                query_text: "remember what we discussed".to_string(),
+                session_id: "not-a-uuid".to_string(),
+                domain_class: "chat".to_string(),
+                top_k: 5,
+                retrieve_policy: RetrievePolicy::RetrievePolicyDomainFirst as i32,
+                page_token: String::new(),
+                page_size: 0,
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert!(query_resp.ok);
+        assert!(query_resp.error.is_none());
     }
 
     #[tokio::test]

--- a/koduck-memory/src/retrieve/mod.rs
+++ b/koduck-memory/src/retrieve/mod.rs
@@ -5,10 +5,12 @@
 //! - SUMMARY_FIRST: Use summary for filtering within domain_class candidates.
 
 pub mod domain_first;
+pub mod query_analyzer;
 pub mod summary_first;
 pub mod types;
 
 pub use domain_first::DomainFirstRetriever;
+pub use query_analyzer::{QueryAnalysis, QueryAnalyzer};
 pub use summary_first::SummaryFirstRetriever;
 pub use types::{
     domain_class, match_reason, RetrieveContext, RetrieveResult,

--- a/koduck-memory/src/retrieve/query_analyzer.rs
+++ b/koduck-memory/src/retrieve/query_analyzer.rs
@@ -1,0 +1,286 @@
+//! Internal query analyzer for `QueryMemory`.
+//!
+//! The analyzer converts raw request fields into a structured retrieval context
+//! while keeping a clear fallback path when analysis fails.
+
+use anyhow::{Result, bail};
+use std::collections::BTreeSet;
+
+use crate::retrieve::types::domain_class;
+
+const INTENT_RECALL: &str = "recall";
+const INTENT_COMPARE: &str = "compare";
+const INTENT_DISAMBIGUATE: &str = "disambiguate";
+const INTENT_CORRECT: &str = "correct";
+const INTENT_EXPLAIN: &str = "explain";
+const INTENT_DECIDE: &str = "decide";
+const INTENT_NONE: &str = "none";
+
+const TARGET_GENERAL: &str = "general";
+const TARGET_PREFERENCE: &str = "preference";
+const TARGET_FACT: &str = "fact";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QueryAnalysis {
+    pub domain_classes: Vec<String>,
+    pub entities: Vec<String>,
+    pub relation_types: Vec<String>,
+    pub intent_type: String,
+    pub intent_aux: Vec<String>,
+    pub recall_target_type: Option<String>,
+}
+
+impl QueryAnalysis {
+    pub fn fallback(domain_class_input: &str, query_text: &str) -> Self {
+        let normalized_domain_class = normalize_domain_class(domain_class_input);
+        let recall_target_type = detect_recall_target_type(query_text)
+            .map(str::to_string)
+            .or(Some(TARGET_GENERAL.to_string()));
+
+        Self {
+            domain_classes: vec![normalized_domain_class],
+            entities: Vec::new(),
+            relation_types: Vec::new(),
+            intent_type: INTENT_NONE.to_string(),
+            intent_aux: Vec::new(),
+            recall_target_type,
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct QueryAnalyzer;
+
+impl QueryAnalyzer {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub fn analyze(
+        &self,
+        query_text: &str,
+        domain_class_input: &str,
+        session_id: &str,
+    ) -> Result<QueryAnalysis> {
+        if !session_id.trim().is_empty() {
+            uuid::Uuid::parse_str(session_id)
+                .map_err(|e| anyhow::anyhow!("invalid session_id for query analyzer: {e}"))?;
+        }
+
+        let normalized_query = query_text.trim();
+        let normalized_domain_class = normalize_domain_class(domain_class_input);
+        let intent_type = detect_intent_type(normalized_query);
+        if !is_supported_intent(&intent_type) {
+            bail!("unsupported intent_type: {intent_type}");
+        }
+
+        let recall_target_type = if intent_type == INTENT_RECALL {
+            detect_recall_target_type(normalized_query).map(str::to_string)
+        } else {
+            detect_recall_target_type(normalized_query)
+                .filter(|target| *target != TARGET_GENERAL)
+                .map(str::to_string)
+        };
+
+        let mut domain_classes = BTreeSet::new();
+        domain_classes.insert(normalized_domain_class);
+
+        let entities = extract_entities(normalized_query);
+        let relation_types = detect_relation_types(normalized_query, &intent_type);
+        let intent_aux = detect_intent_aux(normalized_query, session_id, &intent_type, &relation_types);
+
+        Ok(QueryAnalysis {
+            domain_classes: domain_classes.into_iter().collect(),
+            entities,
+            relation_types,
+            intent_type,
+            intent_aux,
+            recall_target_type,
+        })
+    }
+}
+
+fn normalize_domain_class(input: &str) -> String {
+    let trimmed = input.trim();
+    if domain_class::is_valid(trimmed) {
+        trimmed.to_string()
+    } else {
+        domain_class::default().to_string()
+    }
+}
+
+fn detect_intent_type(query_text: &str) -> String {
+    let lower = query_text.to_lowercase();
+
+    if contains_any(&lower, &["remember", "recall", "previously", "before", "之前", "还记得", "聊过"]) {
+        return INTENT_RECALL.to_string();
+    }
+    if contains_any(&lower, &["compare", "difference", "versus", "vs", "区别", "比较"]) {
+        return INTENT_COMPARE.to_string();
+    }
+    if contains_any(&lower, &["which one", "还是", "到底是", "弄混", "disambiguate"]) {
+        return INTENT_DISAMBIGUATE.to_string();
+    }
+    if contains_any(&lower, &["correct", "wrong", "不对", "纠正", "更正"]) {
+        return INTENT_CORRECT.to_string();
+    }
+    if contains_any(&lower, &["explain", "why", "how", "解释", "说明"]) {
+        return INTENT_EXPLAIN.to_string();
+    }
+    if contains_any(&lower, &["decide", "choose", "option", "选择", "决定", "方案"]) {
+        return INTENT_DECIDE.to_string();
+    }
+
+    INTENT_NONE.to_string()
+}
+
+fn detect_recall_target_type(query_text: &str) -> Option<&'static str> {
+    let lower = query_text.to_lowercase();
+
+    if contains_any(&lower, &["preference", "prefer", "偏好", "倾向"]) {
+        return Some(TARGET_PREFERENCE);
+    }
+    if contains_any(&lower, &["fact", "事实", "约束", "constraint"]) {
+        return Some(TARGET_FACT);
+    }
+    if query_text.trim().is_empty() {
+        return None;
+    }
+
+    Some(TARGET_GENERAL)
+}
+
+fn detect_relation_types(query_text: &str, intent_type: &str) -> Vec<String> {
+    let lower = query_text.to_lowercase();
+    let mut relation_types = BTreeSet::new();
+
+    if intent_type == INTENT_COMPARE || contains_any(&lower, &["compare", "difference", "versus", "vs", "比较", "区别"]) {
+        relation_types.insert("comparison".to_string());
+    }
+    if intent_type == INTENT_DISAMBIGUATE || contains_any(&lower, &["还是", "到底是", "弄混", "disambiguate"]) {
+        relation_types.insert("disambiguation".to_string());
+    }
+    if intent_type == INTENT_CORRECT || contains_any(&lower, &["correct", "wrong", "不对", "纠正", "更正"]) {
+        relation_types.insert("correction".to_string());
+    }
+
+    relation_types.into_iter().collect()
+}
+
+fn detect_intent_aux(
+    query_text: &str,
+    session_id: &str,
+    intent_type: &str,
+    relation_types: &[String],
+) -> Vec<String> {
+    let lower = query_text.to_lowercase();
+    let mut aux = BTreeSet::new();
+
+    if intent_type == INTENT_RECALL && session_id.trim().is_empty() {
+        aux.insert("cross_session_scope".to_string());
+    }
+    if intent_type == INTENT_RECALL
+        && contains_any(&lower, &["latest", "recent", "最近", "刚才"])
+    {
+        aux.insert("recent_bias".to_string());
+    }
+    if intent_type == INTENT_DECIDE
+        && !relation_types.iter().any(|relation| relation == "comparison")
+    {
+        aux.insert("decision_context".to_string());
+    }
+
+    aux.into_iter().collect()
+}
+
+fn extract_entities(query_text: &str) -> Vec<String> {
+    let mut entities = BTreeSet::new();
+
+    for token in query_text.split(|c: char| !c.is_alphanumeric() && c != '_' && c != '-') {
+        if token.chars().count() < 2 {
+            continue;
+        }
+
+        let starts_uppercase = token.chars().next().is_some_and(|c| c.is_uppercase());
+        let is_ascii_word = token.chars().all(|c| c.is_alphanumeric() || c == '-' || c == '_');
+
+        if starts_uppercase && is_ascii_word {
+            entities.insert(token.to_string());
+        }
+    }
+
+    entities.into_iter().collect()
+}
+
+fn contains_any(haystack: &str, needles: &[&str]) -> bool {
+    needles.iter().any(|needle| haystack.contains(needle))
+}
+
+fn is_supported_intent(intent_type: &str) -> bool {
+    matches!(
+        intent_type,
+        INTENT_RECALL
+            | INTENT_COMPARE
+            | INTENT_DISAMBIGUATE
+            | INTENT_CORRECT
+            | INTENT_EXPLAIN
+            | INTENT_DECIDE
+            | INTENT_NONE
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn analyze_returns_structured_context() {
+        let analyzer = QueryAnalyzer::new();
+
+        let analysis = analyzer
+            .analyze(
+                "Do you remember whether Karl Marx or Friedrich Engels was mentioned before?",
+                "history",
+                "",
+            )
+            .unwrap();
+
+        assert_eq!(analysis.domain_classes, vec!["history".to_string()]);
+        assert_eq!(analysis.intent_type, "recall");
+        assert!(analysis.entities.contains(&"Karl".to_string()));
+        assert!(analysis.entities.contains(&"Marx".to_string()));
+        assert!(analysis.entities.contains(&"Friedrich".to_string()));
+        assert!(analysis.entities.contains(&"Engels".to_string()));
+        assert!(analysis.intent_aux.contains(&"cross_session_scope".to_string()));
+        assert_eq!(analysis.recall_target_type.as_deref(), Some("general"));
+    }
+
+    #[test]
+    fn analyze_detects_relation_without_dup_aux() {
+        let analyzer = QueryAnalyzer::new();
+
+        let analysis = analyzer
+            .analyze("Compare Rust vs Go for backend services", "technology", "")
+            .unwrap();
+
+        assert_eq!(analysis.intent_type, "compare");
+        assert_eq!(analysis.relation_types, vec!["comparison".to_string()]);
+        assert!(analysis.intent_aux.is_empty());
+    }
+
+    #[test]
+    fn analyze_rejects_invalid_session_id() {
+        let analyzer = QueryAnalyzer::new();
+
+        let result = analyzer.analyze("remember this", "chat", "not-a-uuid");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn fallback_normalizes_domain_class() {
+        let fallback = QueryAnalysis::fallback("not-real", "Need the latest preference");
+        assert_eq!(fallback.domain_classes, vec!["chat".to_string()]);
+        assert_eq!(fallback.intent_type, "none");
+        assert_eq!(fallback.recall_target_type.as_deref(), Some("preference"));
+    }
+}

--- a/koduck-memory/src/retrieve/types.rs
+++ b/koduck-memory/src/retrieve/types.rs
@@ -8,6 +8,12 @@ pub struct RetrieveContext {
     pub tenant_id: String,
     pub session_id: Option<String>,
     pub domain_class: String,
+    pub domain_classes: Vec<String>,
+    pub entities: Vec<String>,
+    pub relation_types: Vec<String>,
+    pub intent_type: String,
+    pub intent_aux: Vec<String>,
+    pub recall_target_type: Option<String>,
     pub query_text: String,
     pub top_k: i32,
 }
@@ -23,6 +29,12 @@ impl RetrieveContext {
             tenant_id: tenant_id.into(),
             session_id: None,
             domain_class: domain_class.into(),
+            domain_classes: Vec::new(),
+            entities: Vec::new(),
+            relation_types: Vec::new(),
+            intent_type: "none".to_string(),
+            intent_aux: Vec::new(),
+            recall_target_type: None,
             query_text: query_text.into(),
             top_k: top_k.max(1).min(100), // Clamp between 1 and 100
         }
@@ -30,6 +42,27 @@ impl RetrieveContext {
 
     pub fn with_session_id(mut self, session_id: impl Into<String>) -> Self {
         self.session_id = Some(session_id.into());
+        self
+    }
+
+    pub fn with_query_analysis(
+        mut self,
+        domain_classes: Vec<String>,
+        entities: Vec<String>,
+        relation_types: Vec<String>,
+        intent_type: impl Into<String>,
+        intent_aux: Vec<String>,
+        recall_target_type: Option<String>,
+    ) -> Self {
+        if let Some(primary_domain_class) = domain_classes.first() {
+            self.domain_class = primary_domain_class.clone();
+        }
+        self.domain_classes = domain_classes;
+        self.entities = entities;
+        self.relation_types = relation_types;
+        self.intent_type = intent_type.into();
+        self.intent_aux = intent_aux;
+        self.recall_target_type = recall_target_type;
         self
     }
 }
@@ -167,6 +200,12 @@ mod tests {
         assert_eq!(ctx.tenant_id, "tenant-1");
         assert_eq!(ctx.session_id, Some("session-1".to_string()));
         assert_eq!(ctx.domain_class, "chat");
+        assert!(ctx.domain_classes.is_empty());
+        assert!(ctx.entities.is_empty());
+        assert!(ctx.relation_types.is_empty());
+        assert_eq!(ctx.intent_type, "none");
+        assert!(ctx.intent_aux.is_empty());
+        assert!(ctx.recall_target_type.is_none());
         assert_eq!(ctx.query_text, "query");
         assert_eq!(ctx.top_k, 10);
     }
@@ -178,6 +217,26 @@ mod tests {
 
         let ctx_high = RetrieveContext::new("t", "c", "q", 200);
         assert_eq!(ctx_high.top_k, 100);
+    }
+
+    #[test]
+    fn retrieve_context_with_query_analysis_overrides_primary_domain() {
+        let ctx = RetrieveContext::new("tenant-1", "chat", "query", 10).with_query_analysis(
+            vec!["history".to_string()],
+            vec!["Karl".to_string()],
+            vec!["comparison".to_string()],
+            "compare",
+            vec!["recent_bias".to_string()],
+            Some("general".to_string()),
+        );
+
+        assert_eq!(ctx.domain_class, "history");
+        assert_eq!(ctx.domain_classes, vec!["history".to_string()]);
+        assert_eq!(ctx.entities, vec!["Karl".to_string()]);
+        assert_eq!(ctx.relation_types, vec!["comparison".to_string()]);
+        assert_eq!(ctx.intent_type, "compare");
+        assert_eq!(ctx.intent_aux, vec!["recent_bias".to_string()]);
+        assert_eq!(ctx.recall_target_type.as_deref(), Some("general"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add an explicit internal query analyzer for QueryMemory with structured query context output
- extend RetrieveContext to carry domain_classes, entities, relation_types, intent_type, intent_aux, and recall_target_type
- add ADR-0032 and complete Task 3.1 in the adr-0025 implementation checklist

## Verification
- docker build -t koduck-memory:dev ./koduck-memory
- docker build -t koduck-ai:dev ./koduck-ai

Closes #857