### PR TITLE
feat(memory): freeze intent and discourse action semantics

### DIFF
--- a/docs/implementation/adr-0025-anchor-based-memory-retrieval-tasks.md
+++ b/docs/implementation/adr-0025-anchor-based-memory-retrieval-tasks.md
@@ -247,11 +247,11 @@ kubectl rollout status deployment/dev-koduck-memory -n koduck-dev --timeout=180s
    - 不单独改变主召回路径
 
 **验收标准:**
-- [ ] 查询侧与存储侧语义不再混用
-- [ ] `intent_score` 具备稳定映射基础
-- [ ] `intent_aux[]` 不造成重复加权
-- [ ] `docker build -t koduck-memory:dev ./koduck-memory` 成功
-- [ ] `kubectl rollout status deployment/dev-koduck-memory -n koduck-dev --timeout=180s` 成功
+- [x] 查询侧与存储侧语义不再混用
+- [x] `intent_score` 具备稳定映射基础
+- [x] `intent_aux[]` 不造成重复加权
+- [x] `docker build -t koduck-memory:dev ./koduck-memory` 成功
+- [x] `kubectl rollout status deployment/dev-koduck-memory -n koduck-dev --timeout=180s` 成功
 
 ---
 

--- a/koduck-memory/docs/adr/0033-intent-and-discourse-action-governance.md
+++ b/koduck-memory/docs/adr/0033-intent-and-discourse-action-governance.md
@@ -1,0 +1,117 @@
+# ADR-0033: Freeze Query Intent and Storage Discourse Action Semantics
+
+- Status: Accepted
+- Date: 2026-04-14
+- Issue: #859
+
+## Context
+
+Task 3.1 已经把 `QueryMemory` 的 `query analyzer` 建立为显式内部组件，但 Task 3.2 仍有三个缺口：
+
+1. 查询侧 `intent_type` 仍主要以散落字符串参与判断，闭集边界没有独立固化。
+2. 存储侧 `discourse_action` 虽然在 anchor schema 中保留了类型位，但写路径没有稳定地产出这类锚点。
+3. `intent_aux[]` 的“只做弱增强、不重复表达 `relation_types[]`、不单独改变主召回路径”还没有被代码层显式冻结。
+
+如果继续维持这种状态，后续 Task 4.x 的 `intent_score` 和 anchor-first 重排会缺少稳定、可测试的语义基线。
+
+## Decision
+
+### 1. 把查询侧 `intent_type` 与存储侧 `discourse_action` 分成两个独立闭集
+
+在 `retrieve/semantics.rs` 中新增共享语义层，显式冻结：
+
+- 查询侧 `QueryIntentType`
+  - `recall`
+  - `compare`
+  - `disambiguate`
+  - `correct`
+  - `explain`
+  - `decide`
+  - `none`
+- 存储侧 `DiscourseAction`
+  - `recall_prompt`
+  - `comparison`
+  - `disambiguation`
+  - `correction`
+  - `explanation`
+  - `decision`
+  - `other`
+
+两者保持独立命名，避免把查询意图和记忆本身的话语动作混成一套标签。
+
+### 2. 固化 `intent -> discourse_action` 的稳定映射
+
+新增单一映射函数：
+
+- `recall -> recall_prompt`
+- `compare -> comparison`
+- `disambiguate -> disambiguation`
+- `correct -> correction`
+- `explain -> explanation`
+- `decide -> decision`
+- `none -> None`
+
+当前阶段这套映射先作为后续 `intent_score` 的稳定基线，不提前在重排器中做隐式扩散。
+
+### 3. 在 materializer 写路径中落 `discourse_action` anchors
+
+`MemoryUnitMaterializer` 在以下写路径中统一追加 `discourse_action` anchors：
+
+- 追加消息产生的 generic conversation unit
+- session summary unit
+- fact units
+
+写入规则：
+
+1. 先用闭集启发式规则从源文本推断 `discourse_action`
+2. 若没有命中任何显式动作，则落 `other`
+3. 不复用查询侧 `intent_type` 直接写库，保持 storage 语义独立
+
+这样可以保证未来无论是 entry 级还是 summary/fact 级命中，都有稳定的 storage-side `discourse_action` 可用于解释性打分。
+
+### 4. 显式收紧 `intent_aux[]` 的边界
+
+`intent_aux[]` 继续仅保留少量弱增强标签，例如：
+
+- `cross_session_scope`
+- `recent_bias`
+- `decision_context`
+
+并在 analyzer 中统一做归一化：
+
+1. 去重
+2. 移除与 `relation_types[]` 重复的语义值
+3. 保持其只作为排序增强信号，不承担主召回入口职责
+
+## Consequences
+
+正面影响：
+
+1. 查询侧与存储侧的语义边界被显式代码结构冻结。
+2. `memory_units` 写路径现在能稳定产出 `discourse_action` anchors。
+3. 后续实现 `intent_score` 时，不需要再回头补“语义来源到底是什么”的基础治理工作。
+
+代价与权衡：
+
+1. V1 的 `discourse_action` 仍然基于启发式关键词，不等于完整语义理解。
+2. 对 summary/fact unit 的默认兜底会写入 `other`，这会让部分记录先拥有保守而非高精度的 storage 标签。
+
+## Compatibility Impact
+
+1. 不修改对外 gRPC 契约。
+2. 不改变现有 `DOMAIN_FIRST` / `SUMMARY_FIRST` 的外部行为开关。
+3. 只新增内部语义类型和写路径 anchor，不破坏已有 `memory_units` / `memory_unit_anchors` schema 契约。
+
+## Alternatives Considered
+
+### Alternative A: 继续只在 query analyzer 中维护 intent 字符串
+
+未采用。这样 storage-side `discourse_action` 仍没有真正进入写路径，Task 3.2 无法闭环。
+
+### Alternative B: 直接把查询侧 `intent_type` 原样持久化到 anchor
+
+未采用。这会重新混淆“查询操作类型”和“记忆内容的话语动作模式”。
+
+### Alternative C: 等 Task 4.x 做重排时再补 discourse_action
+
+未采用。那样会把基础语义治理和排序实现耦合在一起，回归面更大，也更难验证。

--- a/koduck-memory/src/capability/service.rs
+++ b/koduck-memory/src/capability/service.rs
@@ -869,7 +869,7 @@ mod tests {
     };
     use crate::facts::MemoryFactRepository;
     use crate::index::MemoryIndexRepository;
-    use crate::memory_anchor::MemoryUnitAnchorRepository;
+    use crate::memory_anchor::{MemoryUnitAnchorRepository, MemoryUnitAnchorType};
     use crate::memory_unit::{MemoryUnitKind, MemoryUnitRepository};
     use crate::reliability::TaskAttemptRepository;
     use crate::summary::MemorySummaryRepository;
@@ -1933,6 +1933,7 @@ mod tests {
         let config = test_config();
         let runtime = RuntimeState::initialize(&config).await.unwrap();
         let unit_repo = MemoryUnitRepository::new(runtime.pool());
+        let anchor_repo = MemoryUnitAnchorRepository::new(runtime.pool());
         let (mut client, shutdown_tx, server) = start_test_server(config, runtime).await;
 
         let session_id = Uuid::new_v4();
@@ -1986,6 +1987,15 @@ mod tests {
         assert_eq!(units[1].entry_range_start, 2);
         assert_eq!(units[1].entry_range_end, 2);
         assert!(units[1].snippet.as_deref().is_some_and(|snippet| snippet.contains("concise checklist")));
+
+        let anchors = anchor_repo
+            .list_by_memory_unit("tenant-t33", units[0].memory_unit_id)
+            .await
+            .unwrap();
+        assert!(anchors.iter().any(|anchor| {
+            anchor.anchor_type == MemoryUnitAnchorType::DiscourseAction
+                && anchor.anchor_key == "other"
+        }));
 
         let _ = shutdown_tx.send(());
         server.await.unwrap();
@@ -2336,6 +2346,10 @@ mod tests {
             .await
             .unwrap();
         assert!(summary_anchors.iter().any(|anchor| anchor.anchor_key == stored_summary.domain_class));
+        assert!(summary_anchors.iter().any(|anchor| {
+            anchor.anchor_type == MemoryUnitAnchorType::DiscourseAction
+                && anchor.anchor_key == "other"
+        }));
 
         for fact in &facts {
             let anchors = anchor_repo
@@ -2344,7 +2358,69 @@ mod tests {
                 .unwrap();
             assert!(anchors.iter().any(|anchor| anchor.anchor_key == stored_summary.domain_class));
             assert!(anchors.iter().any(|anchor| anchor.anchor_key == fact.fact_type));
+            assert!(anchors.iter().any(|anchor| {
+                anchor.anchor_type == MemoryUnitAnchorType::DiscourseAction
+                    && anchor.anchor_key == "other"
+            }));
         }
+
+        let _ = shutdown_tx.send(());
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn append_memory_materializes_discourse_action_anchor_for_comparison_prompt() {
+        let config = test_config();
+        let runtime = RuntimeState::initialize(&config).await.unwrap();
+        let unit_repo = MemoryUnitRepository::new(runtime.pool());
+        let anchor_repo = MemoryUnitAnchorRepository::new(runtime.pool());
+        let (mut client, shutdown_tx, server) = start_test_server(config, runtime).await;
+
+        let session_id = Uuid::new_v4();
+        let sid_str = session_id.to_string();
+
+        client
+            .upsert_session_meta(UpsertSessionMetaRequest {
+                meta: Some(write_meta_with_idempotency("t53b-session", &sid_str)),
+                session_id: sid_str.clone(),
+                title: "Comparison units".to_string(),
+                status: "active".to_string(),
+                parent_session_id: String::new(),
+                forked_from_session_id: String::new(),
+                last_message_at: 1700000000000,
+                extra: [].into(),
+            })
+            .await
+            .unwrap();
+
+        client
+            .append_memory(AppendMemoryRequest {
+                meta: Some(write_meta_with_idempotency("t53b-append", &sid_str)),
+                session_id: sid_str.clone(),
+                entries: vec![MemoryEntry {
+                    role: "user".to_string(),
+                    content: "Compare Rust vs Go for backend services".to_string(),
+                    timestamp: 1700000000000,
+                    metadata: std::collections::HashMap::new(),
+                }],
+            })
+            .await
+            .unwrap();
+
+        let units = wait_for_memory_units(&unit_repo, "tenant-t33", session_id, 1).await;
+        let anchors = anchor_repo
+            .list_by_memory_unit("tenant-t33", units[0].memory_unit_id)
+            .await
+            .unwrap();
+
+        assert!(anchors.iter().any(|anchor| {
+            anchor.anchor_type == MemoryUnitAnchorType::DiscourseAction
+                && anchor.anchor_key == "comparison"
+        }));
+        assert!(!anchors.iter().any(|anchor| {
+            anchor.anchor_type == MemoryUnitAnchorType::DiscourseAction
+                && anchor.anchor_key == "other"
+        }));
 
         let _ = shutdown_tx.send(());
         server.await.unwrap();

--- a/koduck-memory/src/memory_unit/materializer.rs
+++ b/koduck-memory/src/memory_unit/materializer.rs
@@ -14,6 +14,7 @@ use crate::memory_unit::{
     MemoryUnitRepository,
     MemoryUnitSummaryState,
 };
+use crate::retrieve::infer_discourse_actions;
 
 const DEFAULT_SNIPPET_LIMIT: usize = 96;
 
@@ -79,7 +80,9 @@ impl MemoryUnitMaterializer {
             .with_snippet(truncate_text(&entry.content, DEFAULT_SNIPPET_LIMIT))
             .with_time_bucket(build_time_bucket(entry.message_ts));
 
-            let _ = self.unit_repo.insert(&insert).await?;
+            let unit = self.unit_repo.insert(&insert).await?;
+            self.insert_discourse_action_anchors(&entry.tenant_id, unit.memory_unit_id, &entry.content)
+                .await?;
         }
 
         Ok(())
@@ -112,6 +115,8 @@ impl MemoryUnitMaterializer {
                     input.domain_class.clone(),
                 )?,
             )
+            .await?;
+        self.insert_discourse_action_anchors(&input.tenant_id, input.session_id, &input.summary)
             .await?;
         self.unit_repo
             .sync_projected_domain_class_primary(&input.tenant_id, input.session_id)
@@ -175,8 +180,36 @@ impl MemoryUnitMaterializer {
                     .with_weight(input.fact.confidence)?,
                 )
                 .await?;
+            self.insert_discourse_action_anchors(
+                &input.tenant_id,
+                unit.memory_unit_id,
+                &input.fact.fact_text,
+            )
+            .await?;
             self.unit_repo
                 .sync_projected_domain_class_primary(&input.tenant_id, unit.memory_unit_id)
+                .await?;
+        }
+
+        Ok(())
+    }
+
+    async fn insert_discourse_action_anchors(
+        &self,
+        tenant_id: &str,
+        memory_unit_id: Uuid,
+        source_text: &str,
+    ) -> Result<()> {
+        for discourse_action in infer_discourse_actions(source_text) {
+            self.anchor_repo
+                .insert(
+                    &InsertMemoryUnitAnchor::new(
+                        tenant_id.to_string(),
+                        memory_unit_id,
+                        MemoryUnitAnchorType::DiscourseAction,
+                        discourse_action.as_str(),
+                    )?,
+                )
                 .await?;
         }
 

--- a/koduck-memory/src/retrieve/mod.rs
+++ b/koduck-memory/src/retrieve/mod.rs
@@ -6,11 +6,19 @@
 
 pub mod domain_first;
 pub mod query_analyzer;
+pub mod semantics;
 pub mod summary_first;
 pub mod types;
 
 pub use domain_first::DomainFirstRetriever;
 pub use query_analyzer::{QueryAnalysis, QueryAnalyzer};
+pub use semantics::{
+    DiscourseAction,
+    QueryIntentType,
+    infer_discourse_actions,
+    map_intent_to_discourse_action,
+    normalize_intent_aux,
+};
 pub use summary_first::SummaryFirstRetriever;
 pub use types::{
     domain_class, match_reason, RetrieveContext, RetrieveResult,

--- a/koduck-memory/src/retrieve/query_analyzer.rs
+++ b/koduck-memory/src/retrieve/query_analyzer.rs
@@ -3,18 +3,18 @@
 //! The analyzer converts raw request fields into a structured retrieval context
 //! while keeping a clear fallback path when analysis fails.
 
-use anyhow::{Result, bail};
+use anyhow::Result;
 use std::collections::BTreeSet;
 
+use crate::retrieve::semantics::{
+    QueryIntentType,
+    contains_any,
+    intent_aux_cross_session_scope,
+    intent_aux_decision_context,
+    intent_aux_recent_bias,
+    normalize_intent_aux,
+};
 use crate::retrieve::types::domain_class;
-
-const INTENT_RECALL: &str = "recall";
-const INTENT_COMPARE: &str = "compare";
-const INTENT_DISAMBIGUATE: &str = "disambiguate";
-const INTENT_CORRECT: &str = "correct";
-const INTENT_EXPLAIN: &str = "explain";
-const INTENT_DECIDE: &str = "decide";
-const INTENT_NONE: &str = "none";
 
 const TARGET_GENERAL: &str = "general";
 const TARGET_PREFERENCE: &str = "preference";
@@ -41,7 +41,7 @@ impl QueryAnalysis {
             domain_classes: vec![normalized_domain_class],
             entities: Vec::new(),
             relation_types: Vec::new(),
-            intent_type: INTENT_NONE.to_string(),
+            intent_type: QueryIntentType::None.as_str().to_string(),
             intent_aux: Vec::new(),
             recall_target_type,
         }
@@ -70,11 +70,8 @@ impl QueryAnalyzer {
         let normalized_query = query_text.trim();
         let normalized_domain_class = normalize_domain_class(domain_class_input);
         let intent_type = detect_intent_type(normalized_query);
-        if !is_supported_intent(&intent_type) {
-            bail!("unsupported intent_type: {intent_type}");
-        }
 
-        let recall_target_type = if intent_type == INTENT_RECALL {
+        let recall_target_type = if intent_type == QueryIntentType::Recall {
             detect_recall_target_type(normalized_query).map(str::to_string)
         } else {
             detect_recall_target_type(normalized_query)
@@ -86,14 +83,14 @@ impl QueryAnalyzer {
         domain_classes.insert(normalized_domain_class);
 
         let entities = extract_entities(normalized_query);
-        let relation_types = detect_relation_types(normalized_query, &intent_type);
+        let relation_types = detect_relation_types(normalized_query, intent_type);
         let intent_aux = detect_intent_aux(normalized_query, session_id, &intent_type, &relation_types);
 
         Ok(QueryAnalysis {
             domain_classes: domain_classes.into_iter().collect(),
             entities,
             relation_types,
-            intent_type,
+            intent_type: intent_type.as_str().to_string(),
             intent_aux,
             recall_target_type,
         })
@@ -109,29 +106,29 @@ fn normalize_domain_class(input: &str) -> String {
     }
 }
 
-fn detect_intent_type(query_text: &str) -> String {
+fn detect_intent_type(query_text: &str) -> QueryIntentType {
     let lower = query_text.to_lowercase();
 
     if contains_any(&lower, &["remember", "recall", "previously", "before", "之前", "还记得", "聊过"]) {
-        return INTENT_RECALL.to_string();
+        return QueryIntentType::Recall;
     }
     if contains_any(&lower, &["compare", "difference", "versus", "vs", "区别", "比较"]) {
-        return INTENT_COMPARE.to_string();
+        return QueryIntentType::Compare;
     }
     if contains_any(&lower, &["which one", "还是", "到底是", "弄混", "disambiguate"]) {
-        return INTENT_DISAMBIGUATE.to_string();
+        return QueryIntentType::Disambiguate;
     }
     if contains_any(&lower, &["correct", "wrong", "不对", "纠正", "更正"]) {
-        return INTENT_CORRECT.to_string();
+        return QueryIntentType::Correct;
     }
     if contains_any(&lower, &["explain", "why", "how", "解释", "说明"]) {
-        return INTENT_EXPLAIN.to_string();
+        return QueryIntentType::Explain;
     }
     if contains_any(&lower, &["decide", "choose", "option", "选择", "决定", "方案"]) {
-        return INTENT_DECIDE.to_string();
+        return QueryIntentType::Decide;
     }
 
-    INTENT_NONE.to_string()
+    QueryIntentType::None
 }
 
 fn detect_recall_target_type(query_text: &str) -> Option<&'static str> {
@@ -150,17 +147,23 @@ fn detect_recall_target_type(query_text: &str) -> Option<&'static str> {
     Some(TARGET_GENERAL)
 }
 
-fn detect_relation_types(query_text: &str, intent_type: &str) -> Vec<String> {
+fn detect_relation_types(query_text: &str, intent_type: QueryIntentType) -> Vec<String> {
     let lower = query_text.to_lowercase();
     let mut relation_types = BTreeSet::new();
 
-    if intent_type == INTENT_COMPARE || contains_any(&lower, &["compare", "difference", "versus", "vs", "比较", "区别"]) {
+    if intent_type == QueryIntentType::Compare
+        || contains_any(&lower, &["compare", "difference", "versus", "vs", "比较", "区别"])
+    {
         relation_types.insert("comparison".to_string());
     }
-    if intent_type == INTENT_DISAMBIGUATE || contains_any(&lower, &["还是", "到底是", "弄混", "disambiguate"]) {
+    if intent_type == QueryIntentType::Disambiguate
+        || contains_any(&lower, &["还是", "到底是", "弄混", "disambiguate"])
+    {
         relation_types.insert("disambiguation".to_string());
     }
-    if intent_type == INTENT_CORRECT || contains_any(&lower, &["correct", "wrong", "不对", "纠正", "更正"]) {
+    if intent_type == QueryIntentType::Correct
+        || contains_any(&lower, &["correct", "wrong", "不对", "纠正", "更正"])
+    {
         relation_types.insert("correction".to_string());
     }
 
@@ -170,27 +173,27 @@ fn detect_relation_types(query_text: &str, intent_type: &str) -> Vec<String> {
 fn detect_intent_aux(
     query_text: &str,
     session_id: &str,
-    intent_type: &str,
+    intent_type: &QueryIntentType,
     relation_types: &[String],
 ) -> Vec<String> {
     let lower = query_text.to_lowercase();
     let mut aux = BTreeSet::new();
 
-    if intent_type == INTENT_RECALL && session_id.trim().is_empty() {
-        aux.insert("cross_session_scope".to_string());
+    if *intent_type == QueryIntentType::Recall && session_id.trim().is_empty() {
+        aux.insert(intent_aux_cross_session_scope().to_string());
     }
-    if intent_type == INTENT_RECALL
+    if *intent_type == QueryIntentType::Recall
         && contains_any(&lower, &["latest", "recent", "最近", "刚才"])
     {
-        aux.insert("recent_bias".to_string());
+        aux.insert(intent_aux_recent_bias().to_string());
     }
-    if intent_type == INTENT_DECIDE
+    if *intent_type == QueryIntentType::Decide
         && !relation_types.iter().any(|relation| relation == "comparison")
     {
-        aux.insert("decision_context".to_string());
+        aux.insert(intent_aux_decision_context().to_string());
     }
 
-    aux.into_iter().collect()
+    normalize_intent_aux(aux.into_iter().collect(), relation_types)
 }
 
 fn extract_entities(query_text: &str) -> Vec<String> {
@@ -210,23 +213,6 @@ fn extract_entities(query_text: &str) -> Vec<String> {
     }
 
     entities.into_iter().collect()
-}
-
-fn contains_any(haystack: &str, needles: &[&str]) -> bool {
-    needles.iter().any(|needle| haystack.contains(needle))
-}
-
-fn is_supported_intent(intent_type: &str) -> bool {
-    matches!(
-        intent_type,
-        INTENT_RECALL
-            | INTENT_COMPARE
-            | INTENT_DISAMBIGUATE
-            | INTENT_CORRECT
-            | INTENT_EXPLAIN
-            | INTENT_DECIDE
-            | INTENT_NONE
-    )
 }
 
 #[cfg(test)]

--- a/koduck-memory/src/retrieve/semantics.rs
+++ b/koduck-memory/src/retrieve/semantics.rs
@@ -1,0 +1,219 @@
+//! Shared query/storage semantics for anchored retrieval.
+
+use std::collections::BTreeSet;
+
+const INTENT_AUX_CROSS_SESSION_SCOPE: &str = "cross_session_scope";
+const INTENT_AUX_RECENT_BIAS: &str = "recent_bias";
+const INTENT_AUX_DECISION_CONTEXT: &str = "decision_context";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum QueryIntentType {
+    Recall,
+    Compare,
+    Disambiguate,
+    Correct,
+    Explain,
+    Decide,
+    None,
+}
+
+impl QueryIntentType {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Recall => "recall",
+            Self::Compare => "compare",
+            Self::Disambiguate => "disambiguate",
+            Self::Correct => "correct",
+            Self::Explain => "explain",
+            Self::Decide => "decide",
+            Self::None => "none",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum DiscourseAction {
+    RecallPrompt,
+    Comparison,
+    Disambiguation,
+    Correction,
+    Explanation,
+    Decision,
+    Other,
+}
+
+impl DiscourseAction {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::RecallPrompt => "recall_prompt",
+            Self::Comparison => "comparison",
+            Self::Disambiguation => "disambiguation",
+            Self::Correction => "correction",
+            Self::Explanation => "explanation",
+            Self::Decision => "decision",
+            Self::Other => "other",
+        }
+    }
+}
+
+pub fn map_intent_to_discourse_action(intent: QueryIntentType) -> Option<DiscourseAction> {
+    match intent {
+        QueryIntentType::Recall => Some(DiscourseAction::RecallPrompt),
+        QueryIntentType::Compare => Some(DiscourseAction::Comparison),
+        QueryIntentType::Disambiguate => Some(DiscourseAction::Disambiguation),
+        QueryIntentType::Correct => Some(DiscourseAction::Correction),
+        QueryIntentType::Explain => Some(DiscourseAction::Explanation),
+        QueryIntentType::Decide => Some(DiscourseAction::Decision),
+        QueryIntentType::None => None,
+    }
+}
+
+pub fn infer_discourse_actions(text: &str) -> Vec<DiscourseAction> {
+    let lower = text.trim().to_lowercase();
+    if lower.is_empty() {
+        return vec![DiscourseAction::Other];
+    }
+
+    let mut actions = BTreeSet::new();
+
+    if contains_any(
+        &lower,
+        &["remember", "recall", "previously", "before", "之前", "还记得", "聊过"],
+    ) {
+        actions.insert(DiscourseAction::RecallPrompt);
+    }
+    if contains_any(
+        &lower,
+        &["compare", "difference", "versus", "vs", "区别", "比较"],
+    ) {
+        actions.insert(DiscourseAction::Comparison);
+    }
+    if contains_any(
+        &lower,
+        &["which one", "还是", "到底是", "弄混", "disambiguate"],
+    ) {
+        actions.insert(DiscourseAction::Disambiguation);
+    }
+    if contains_any(
+        &lower,
+        &["correct", "wrong", "不对", "纠正", "更正"],
+    ) {
+        actions.insert(DiscourseAction::Correction);
+    }
+    if contains_any(
+        &lower,
+        &["explain", "why", "how", "解释", "说明"],
+    ) {
+        actions.insert(DiscourseAction::Explanation);
+    }
+    if contains_any(
+        &lower,
+        &["decide", "choose", "option", "选择", "决定", "方案"],
+    ) {
+        actions.insert(DiscourseAction::Decision);
+    }
+
+    if actions.is_empty() {
+        vec![DiscourseAction::Other]
+    } else {
+        actions.into_iter().collect()
+    }
+}
+
+pub fn normalize_intent_aux(intent_aux: Vec<String>, relation_types: &[String]) -> Vec<String> {
+    let relation_set = relation_types
+        .iter()
+        .map(|value| value.trim().to_lowercase())
+        .collect::<BTreeSet<_>>();
+
+    intent_aux
+        .into_iter()
+        .filter_map(|value| {
+            let normalized = value.trim().to_lowercase();
+            (!normalized.is_empty() && !relation_set.contains(&normalized)).then_some(normalized)
+        })
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+pub fn contains_any(haystack: &str, needles: &[&str]) -> bool {
+    needles.iter().any(|needle| haystack.contains(needle))
+}
+
+pub const fn intent_aux_cross_session_scope() -> &'static str {
+    INTENT_AUX_CROSS_SESSION_SCOPE
+}
+
+pub const fn intent_aux_recent_bias() -> &'static str {
+    INTENT_AUX_RECENT_BIAS
+}
+
+pub const fn intent_aux_decision_context() -> &'static str {
+    INTENT_AUX_DECISION_CONTEXT
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn intent_to_discourse_mapping_is_stable() {
+        assert_eq!(
+            map_intent_to_discourse_action(QueryIntentType::Recall),
+            Some(DiscourseAction::RecallPrompt)
+        );
+        assert_eq!(
+            map_intent_to_discourse_action(QueryIntentType::Compare),
+            Some(DiscourseAction::Comparison)
+        );
+        assert_eq!(
+            map_intent_to_discourse_action(QueryIntentType::Disambiguate),
+            Some(DiscourseAction::Disambiguation)
+        );
+        assert_eq!(
+            map_intent_to_discourse_action(QueryIntentType::Correct),
+            Some(DiscourseAction::Correction)
+        );
+        assert_eq!(
+            map_intent_to_discourse_action(QueryIntentType::Explain),
+            Some(DiscourseAction::Explanation)
+        );
+        assert_eq!(
+            map_intent_to_discourse_action(QueryIntentType::Decide),
+            Some(DiscourseAction::Decision)
+        );
+        assert_eq!(map_intent_to_discourse_action(QueryIntentType::None), None);
+    }
+
+    #[test]
+    fn infer_discourse_actions_defaults_to_other() {
+        assert_eq!(infer_discourse_actions(""), vec![DiscourseAction::Other]);
+        assert_eq!(
+            infer_discourse_actions("Need a concise rollout checklist"),
+            vec![DiscourseAction::Other]
+        );
+    }
+
+    #[test]
+    fn infer_discourse_actions_collects_closed_set_values() {
+        assert_eq!(
+            infer_discourse_actions("Compare Rust vs Go and explain why"),
+            vec![DiscourseAction::Comparison, DiscourseAction::Explanation]
+        );
+    }
+
+    #[test]
+    fn normalize_intent_aux_deduplicates_relation_overlap() {
+        let normalized = normalize_intent_aux(
+            vec![
+                "comparison".to_string(),
+                "recent_bias".to_string(),
+                "recent_bias".to_string(),
+            ],
+            &["comparison".to_string()],
+        );
+
+        assert_eq!(normalized, vec!["recent_bias".to_string()]);
+    }
+}


### PR DESCRIPTION
## Summary
- freeze query-side intent and storage-side discourse_action as explicit closed sets
- materialize discourse_action anchors on memory unit write paths and normalize intent_aux boundaries
- document the governance decision in ADR-0033 and mark Task 3.2 complete

## Verification
- docker build -t koduck-memory:dev ./koduck-memory
- kubectl rollout status deployment/dev-koduck-memory -n koduck-dev --timeout=180s

Closes #859