### PR TITLE
feat(memory): implement internal anchor-first retrieval path

### DIFF
--- a/docs/implementation/adr-0025-anchor-based-memory-retrieval-tasks.md
+++ b/docs/implementation/adr-0025-anchor-based-memory-retrieval-tasks.md
@@ -269,11 +269,11 @@ kubectl rollout status deployment/dev-koduck-memory -n koduck-dev --timeout=180s
 4. 候选集合合并、去重并保留来源
 
 **验收标准:**
-- [ ] 支持 `memory_unit` 粒度召回
-- [ ] 时间维度仅参与排序，不作为候选入口
-- [ ] `ANCHOR_FIRST` 不暴露为外部 retrieve policy
-- [ ] `docker build -t koduck-memory:dev ./koduck-memory` 成功
-- [ ] `kubectl rollout status deployment/dev-koduck-memory -n koduck-dev --timeout=180s` 成功
+- [x] 支持 `memory_unit` 粒度召回
+- [x] 时间维度仅参与排序，不作为候选入口
+- [x] `ANCHOR_FIRST` 不暴露为外部 retrieve policy
+- [x] `docker build -t koduck-memory:dev ./koduck-memory` 成功
+- [x] `kubectl rollout status deployment/dev-koduck-memory -n koduck-dev --timeout=180s` 成功
 
 ---
 

--- a/koduck-memory/docs/adr/0034-internal-anchor-first-retrieval-path.md
+++ b/koduck-memory/docs/adr/0034-internal-anchor-first-retrieval-path.md
@@ -1,0 +1,87 @@
+# ADR-0034: Internal `ANCHOR_FIRST` Retrieval Path
+
+- Status: Accepted
+- Date: 2026-04-14
+- Issue: #861
+
+## Context
+
+Task 4.1 requires moving retrieval to an anchor-based internal main path while keeping the external gRPC `RetrievePolicy` contract unchanged.
+
+Before this change:
+
+1. `QueryMemory` used `DOMAIN_FIRST` / `SUMMARY_FIRST` implementations centered on `memory_index_records`.
+2. Anchor-based units (`memory_units` + `memory_unit_anchors`) existed, but were not the default retrieval backbone.
+3. `ANCHOR_FIRST` did not exist as a dedicated service-internal retriever.
+
+This made it hard to guarantee channel governance (`domain/entity/relation/session scope`) and memory-unit granularity behavior.
+
+## Decision
+
+### 1. Introduce internal `AnchorFirstRetriever`
+
+Add `retrieve/anchor_first.rs` and implement an internal retriever that:
+
+- recalls candidates only through four channels:
+  - `domain`
+  - `entity`
+  - `relation`
+  - `session scope`
+- merges and deduplicates candidate `memory_unit_id`s
+- preserves source channels as `match_reasons`
+- materializes `MemoryHit` from `memory_units`
+
+`time_bucket` is explicitly not used as an inverted candidate channel.
+
+### 2. Keep external retrieve policy unchanged
+
+Do **not** add new proto enum values.
+
+- `RETRIEVE_POLICY_DOMAIN_FIRST` and `UNSPECIFIED` now route internally to `ANCHOR_FIRST`.
+- `RETRIEVE_POLICY_HYBRID` still falls back, now to `ANCHOR_FIRST`.
+- `RETRIEVE_POLICY_SUMMARY_FIRST` keeps summary gate behavior, but candidate collection starts from `ANCHOR_FIRST`.
+
+So `ANCHOR_FIRST` is service-internal and not exposed as a new external retrieve policy.
+
+### 3. Ensure generic conversation units participate in domain channel
+
+For appended generic conversation units, materializer now writes:
+
+- `domain` anchor with default `chat`
+- `discourse_action` anchor (existing logic)
+- projection sync to `domain_class_primary`
+
+This prevents domain channel starvation for non-summary/non-fact units.
+
+## Consequences
+
+Positive:
+
+1. Retrieval backbone is now memory-unit + anchor based.
+2. Candidate channels are explicitly governed and testable.
+3. `SUMMARY_FIRST` remains backward-compatible at API level while inheriting anchor candidate behavior.
+
+Trade-offs:
+
+1. Scoring is still heuristic and will be further tightened in later tasks.
+2. Match-reason closed-set cleanup is deferred to Task 4.2.
+
+## Compatibility Impact
+
+1. No gRPC contract change (`memory.v1` unchanged).
+2. No new external retrieve policy value.
+3. Existing clients continue to call the same API and enum values.
+
+## Alternatives Considered
+
+### Alternative A: Add `ANCHOR_FIRST` as a new proto `RetrievePolicy`
+
+Rejected in Task 4.1 because requirement explicitly says internal-only.
+
+### Alternative B: Keep `DOMAIN_FIRST` as the main path and add anchor path as optional
+
+Rejected because Phase 4 requires anchor-based retrieval as main internal route.
+
+### Alternative C: Use `time_bucket` as an inverted candidate channel
+
+Rejected because Task 4.1 requires time dimension not to be used as candidate entry.

--- a/koduck-memory/src/capability/service.rs
+++ b/koduck-memory/src/capability/service.rs
@@ -19,7 +19,7 @@ use crate::memory_unit::{AppendedEntryUnit, MemoryUnitMaterializer};
 use crate::observe::{record_rpc_call, RpcMethod, RpcOutcome};
 use crate::observe::RpcGuard;
 use crate::observe::RpcMetrics;
-use crate::retrieve::{DomainFirstRetriever, QueryAnalysis, QueryAnalyzer, RetrieveContext, SummaryFirstRetriever};
+use crate::retrieve::{AnchorFirstRetriever, QueryAnalysis, QueryAnalyzer, RetrieveContext, SummaryFirstRetriever};
 use crate::summary::{SummaryJob, SummaryTaskRunner};
 use crate::session::{
     extra_to_jsonb, parse_optional_uuid, parse_uuid, SessionRepository, UpsertSession,
@@ -399,8 +399,8 @@ impl MemoryService for MemoryGrpcService {
         // Execute retrieval based on policy
         let results = match req.retrieve_policy {
             1 | 0 => {
-                // DOMAIN_FIRST (1) or UNSPECIFIED (0, default to DOMAIN_FIRST)
-                let retriever = DomainFirstRetriever::new(self.runtime.pool());
+                // DOMAIN_FIRST (1) or UNSPECIFIED (0) routes to internal ANCHOR_FIRST.
+                let retriever = AnchorFirstRetriever::new(self.runtime.pool());
                 retriever
                     .retrieve(&ctx)
                     .await
@@ -415,24 +415,24 @@ impl MemoryService for MemoryGrpcService {
                     .map_err(|e| { guard.error(); Status::internal(format!("retrieval failed: {e}")) })?
             }
             3 => {
-                // HYBRID (3) - reserved for V2, fall back to DOMAIN_FIRST
+                // HYBRID (3) - reserved for V2, fall back to internal ANCHOR_FIRST
                 tracing::warn!(
                     policy = req.retrieve_policy,
-                    "HYBRID retrieval policy requested but not implemented in V1, falling back to DOMAIN_FIRST"
+                    "HYBRID retrieval policy requested but not implemented in V1, falling back to ANCHOR_FIRST"
                 );
-                let retriever = DomainFirstRetriever::new(self.runtime.pool());
+                let retriever = AnchorFirstRetriever::new(self.runtime.pool());
                 retriever
                     .retrieve(&ctx)
                     .await
                     .map_err(|e| { guard.error(); Status::internal(format!("retrieval failed: {e}")) })?
             }
             _ => {
-                // Other policies not yet implemented, fall back to DOMAIN_FIRST
+                // Other policies not yet implemented, fall back to internal ANCHOR_FIRST
                 tracing::warn!(
                     policy = req.retrieve_policy,
-                    "Unknown retrieval policy requested, falling back to DOMAIN_FIRST"
+                    "Unknown retrieval policy requested, falling back to ANCHOR_FIRST"
                 );
-                let retriever = DomainFirstRetriever::new(self.runtime.pool());
+                let retriever = AnchorFirstRetriever::new(self.runtime.pool());
                 retriever
                     .retrieve(&ctx)
                     .await

--- a/koduck-memory/src/memory_unit/materializer.rs
+++ b/koduck-memory/src/memory_unit/materializer.rs
@@ -15,6 +15,7 @@ use crate::memory_unit::{
     MemoryUnitSummaryState,
 };
 use crate::retrieve::infer_discourse_actions;
+use crate::retrieve::types::domain_class;
 
 const DEFAULT_SNIPPET_LIMIT: usize = 96;
 
@@ -81,7 +82,20 @@ impl MemoryUnitMaterializer {
             .with_time_bucket(build_time_bucket(entry.message_ts));
 
             let unit = self.unit_repo.insert(&insert).await?;
+            self.anchor_repo
+                .insert(
+                    &InsertMemoryUnitAnchor::new(
+                        entry.tenant_id.clone(),
+                        unit.memory_unit_id,
+                        MemoryUnitAnchorType::Domain,
+                        domain_class::default(),
+                    )?,
+                )
+                .await?;
             self.insert_discourse_action_anchors(&entry.tenant_id, unit.memory_unit_id, &entry.content)
+                .await?;
+            self.unit_repo
+                .sync_projected_domain_class_primary(&entry.tenant_id, unit.memory_unit_id)
                 .await?;
         }
 

--- a/koduck-memory/src/retrieve/anchor_first.rs
+++ b/koduck-memory/src/retrieve/anchor_first.rs
@@ -1,0 +1,200 @@
+//! ANCHOR_FIRST retrieval strategy implementation.
+//!
+//! Candidate channels are fixed to:
+//! - domain
+//! - entity
+//! - relation
+//! - session scope
+//!
+//! `time_bucket` is intentionally excluded from inverted retrieval in V1.
+
+use std::cmp::Ordering;
+use std::collections::{BTreeSet, HashMap};
+
+use sqlx::PgPool;
+use tracing::{debug, info, instrument};
+use uuid::Uuid;
+
+use crate::Result;
+use crate::memory_anchor::{MemoryUnitAnchorRepository, MemoryUnitAnchorType};
+use crate::memory_unit::MemoryUnitRepository;
+use crate::retrieve::types::{RetrieveContext, RetrieveResult, match_reason};
+
+const CANDIDATE_EXPANSION_FACTOR: i64 = 6;
+const CHANNEL_LIMIT_FLOOR: i64 = 24;
+
+#[derive(Clone)]
+pub struct AnchorFirstRetriever {
+    anchor_repo: MemoryUnitAnchorRepository,
+    unit_repo: MemoryUnitRepository,
+}
+
+#[derive(Debug, Clone)]
+struct CandidateSignal {
+    reasons: BTreeSet<String>,
+    score_hint: f32,
+}
+
+impl CandidateSignal {
+    fn new() -> Self {
+        Self {
+            reasons: BTreeSet::new(),
+            score_hint: 0.0,
+        }
+    }
+}
+
+impl AnchorFirstRetriever {
+    pub fn new(pool: &PgPool) -> Self {
+        Self {
+            anchor_repo: MemoryUnitAnchorRepository::new(pool),
+            unit_repo: MemoryUnitRepository::new(pool),
+        }
+    }
+
+    #[instrument(skip(self, ctx), fields(tenant_id = %ctx.tenant_id, domain_class = %ctx.domain_class))]
+    pub async fn retrieve(&self, ctx: &RetrieveContext) -> Result<Vec<RetrieveResult>> {
+        let limit = ctx.top_k.max(1) as usize;
+        let channel_limit = (ctx.top_k.max(1) as i64 * CANDIDATE_EXPANSION_FACTOR)
+            .max(CHANNEL_LIMIT_FLOOR);
+
+        let mut candidates: HashMap<Uuid, CandidateSignal> = HashMap::new();
+
+        let mut domain_keys = if ctx.domain_classes.is_empty() {
+            Vec::new()
+        } else {
+            ctx.domain_classes.clone()
+        };
+        if domain_keys.is_empty() && !ctx.domain_class.trim().is_empty() {
+            domain_keys.push(ctx.domain_class.clone());
+        }
+        for domain_key in domain_keys {
+            let anchors = self
+                .anchor_repo
+                .list_by_anchor(&ctx.tenant_id, MemoryUnitAnchorType::Domain, &domain_key, channel_limit)
+                .await?;
+            for anchor in anchors {
+                let candidate = candidates
+                    .entry(anchor.memory_unit_id)
+                    .or_insert_with(CandidateSignal::new);
+                candidate.reasons.insert(match_reason::DOMAIN_CLASS_HIT.to_string());
+                candidate.score_hint += 0.35 * anchor.weight as f32;
+            }
+        }
+
+        for entity in &ctx.entities {
+            let anchors = self
+                .anchor_repo
+                .list_by_anchor(&ctx.tenant_id, MemoryUnitAnchorType::Entity, entity, channel_limit)
+                .await?;
+            for anchor in anchors {
+                let candidate = candidates
+                    .entry(anchor.memory_unit_id)
+                    .or_insert_with(CandidateSignal::new);
+                candidate.reasons.insert(match_reason::ENTITY_HIT.to_string());
+                candidate.score_hint += 0.30 * anchor.weight as f32;
+            }
+        }
+
+        for relation in &ctx.relation_types {
+            let anchors = self
+                .anchor_repo
+                .list_by_anchor(
+                    &ctx.tenant_id,
+                    MemoryUnitAnchorType::Relation,
+                    relation,
+                    channel_limit,
+                )
+                .await?;
+            for anchor in anchors {
+                let candidate = candidates
+                    .entry(anchor.memory_unit_id)
+                    .or_insert_with(CandidateSignal::new);
+                candidate.reasons.insert(match_reason::RELATION_HIT.to_string());
+                candidate.score_hint += 0.25 * anchor.weight as f32;
+            }
+        }
+
+        if let Some(session_id) = ctx
+            .session_id
+            .as_ref()
+            .and_then(|value| Uuid::parse_str(value).ok())
+        {
+            let units = self
+                .unit_repo
+                .list_by_session(&ctx.tenant_id, session_id, channel_limit)
+                .await?;
+            for unit in units {
+                let candidate = candidates
+                    .entry(unit.memory_unit_id)
+                    .or_insert_with(CandidateSignal::new);
+                candidate
+                    .reasons
+                    .insert(match_reason::SESSION_SCOPE_HIT.to_string());
+                candidate.score_hint += 0.20;
+            }
+        }
+
+        if candidates.is_empty() {
+            debug!("ANCHOR_FIRST found no candidates");
+            return Ok(Vec::new());
+        }
+
+        let mut results = Vec::new();
+        for (memory_unit_id, signal) in candidates {
+            if let Some(unit) = self
+                .unit_repo
+                .get_by_id(&ctx.tenant_id, memory_unit_id)
+                .await?
+            {
+                let recency_boost = if unit.updated_at > chrono::Utc::now() - chrono::Duration::days(3)
+                {
+                    0.12
+                } else {
+                    0.0
+                };
+                let salience = unit.salience_score.unwrap_or(0.0) as f32 * 0.08;
+                let final_score = (signal.score_hint + recency_boost + salience).clamp(0.0, 1.0);
+                let snippet = unit
+                    .snippet
+                    .clone()
+                    .or_else(|| unit.summary_state.summary.clone())
+                    .unwrap_or_else(|| unit.source_uri.clone());
+
+                let mut result = RetrieveResult::new(
+                    unit.session_id.to_string(),
+                    unit.source_uri,
+                    final_score,
+                    snippet,
+                );
+                for reason in signal.reasons {
+                    result = result.with_match_reason(reason);
+                }
+                results.push((result, unit.updated_at));
+            }
+        }
+
+        results.sort_by(|(left, left_time), (right, right_time)| {
+            right
+                .score
+                .partial_cmp(&left.score)
+                .unwrap_or(Ordering::Equal)
+                .then_with(|| right_time.cmp(left_time))
+        });
+
+        let merged = results
+            .into_iter()
+            .take(limit)
+            .map(|(result, _)| result)
+            .collect::<Vec<_>>();
+
+        info!(
+            result_count = merged.len(),
+            tenant_id = %ctx.tenant_id,
+            "ANCHOR_FIRST retrieval completed"
+        );
+
+        Ok(merged)
+    }
+}
+

--- a/koduck-memory/src/retrieve/mod.rs
+++ b/koduck-memory/src/retrieve/mod.rs
@@ -4,12 +4,14 @@
 //! - DOMAIN_FIRST: Filter by domain_class first, then by session scope.
 //! - SUMMARY_FIRST: Use summary for filtering within domain_class candidates.
 
+pub mod anchor_first;
 pub mod domain_first;
 pub mod query_analyzer;
 pub mod semantics;
 pub mod summary_first;
 pub mod types;
 
+pub use anchor_first::AnchorFirstRetriever;
 pub use domain_first::DomainFirstRetriever;
 pub use query_analyzer::{QueryAnalysis, QueryAnalyzer};
 pub use semantics::{

--- a/koduck-memory/src/retrieve/summary_first.rs
+++ b/koduck-memory/src/retrieve/summary_first.rs
@@ -8,7 +8,7 @@ use sqlx::PgPool;
 use tracing::{debug, info, instrument};
 
 use crate::index::MemoryIndexRepository;
-use crate::retrieve::domain_first::DomainFirstRetriever;
+use crate::retrieve::anchor_first::AnchorFirstRetriever;
 use crate::retrieve::types::{
     match_reason, RetrieveContext, RetrieveResult,
 };
@@ -17,7 +17,7 @@ use crate::Result;
 /// Retriever implementing the SUMMARY_FIRST strategy.
 #[derive(Clone)]
 pub struct SummaryFirstRetriever {
-    domain_retriever: DomainFirstRetriever,
+    anchor_retriever: AnchorFirstRetriever,
     index_repo: MemoryIndexRepository,
 }
 
@@ -25,7 +25,7 @@ impl SummaryFirstRetriever {
     /// Create a new SummaryFirstRetriever.
     pub fn new(pool: &PgPool) -> Self {
         Self {
-            domain_retriever: DomainFirstRetriever::new(pool),
+            anchor_retriever: AnchorFirstRetriever::new(pool),
             index_repo: MemoryIndexRepository::new(pool),
         }
     }
@@ -33,7 +33,7 @@ impl SummaryFirstRetriever {
     /// Retrieve memories using SUMMARY_FIRST strategy.
     ///
     /// # Strategy
-    /// 1. First, get candidates using DOMAIN_FIRST strategy.
+    /// 1. First, get candidates using ANCHOR_FIRST strategy.
     /// 2. If query_text is provided, perform full-text search on summary.
     /// 3. Mark records with summary_hit if they match the query.
     /// 4. Return combined results with appropriate match_reasons.
@@ -41,10 +41,10 @@ impl SummaryFirstRetriever {
     pub async fn retrieve(&self, ctx: &RetrieveContext) -> Result<Vec<RetrieveResult>> {
         let domain_filter = (!ctx.domain_class.trim().is_empty()).then_some(ctx.domain_class.as_str());
 
-        // If no query text, fall back to DOMAIN_FIRST
+        // If no query text, fall back to ANCHOR_FIRST
         if ctx.query_text.trim().is_empty() {
-            debug!("empty query_text, falling back to DOMAIN_FIRST");
-            return self.domain_retriever.retrieve(ctx).await;
+            debug!("empty query_text, falling back to ANCHOR_FIRST");
+            return self.anchor_retriever.retrieve(ctx).await;
         }
 
         let limit = ctx.top_k as i64;
@@ -53,26 +53,9 @@ impl SummaryFirstRetriever {
             .as_ref()
             .and_then(|session_id| uuid::Uuid::parse_str(session_id).ok());
 
-        // First collect the structural candidate set. When no explicit session scope is
-        // provided, SUMMARY_FIRST should search across all historical summaries in the same
-        // domain rather than silently collapsing back to the current session.
-        let domain_records = if let Some(session_id) = session_uuid {
-            self.index_repo
-                .list_by_session(&ctx.tenant_id, session_id, domain_filter, limit * 4)
-                .await?
-        } else {
-            match domain_filter {
-                Some(domain_class) => {
-                    self.index_repo
-                        .list_by_domain(&ctx.tenant_id, domain_class, limit * 4)
-                        .await?
-                }
-                None => Vec::new(),
-            }
-        };
-
-        if domain_records.is_empty() {
-            debug!("no domain candidates found for SUMMARY_FIRST");
+        let anchor_candidates = self.anchor_retriever.retrieve(ctx).await?;
+        if anchor_candidates.is_empty() {
+            debug!("no anchor candidates found for SUMMARY_FIRST");
             return Ok(Vec::new());
         }
 
@@ -105,57 +88,35 @@ impl SummaryFirstRetriever {
         }
 
         info!(
-            domain_count = domain_records.len(),
+            anchor_count = anchor_candidates.len(),
             summary_match_count = summary_records.len(),
             tenant_id = %ctx.tenant_id,
             "SUMMARY_FIRST retrieval completed"
         );
 
         // Build a set of record IDs that matched summary
-        let summary_match_ids: std::collections::HashSet<_> = summary_records
+        let summary_match_sources: std::collections::HashSet<_> = summary_records
             .iter()
-            .map(|r| r.id)
+            .map(|r| r.source_uri.clone())
             .collect();
 
         // Summary acts as a negative filter inside the domain candidate set:
         // only records that survive the summary check are returned.
-        let results = domain_records
+        let results = anchor_candidates
             .into_iter()
-            .filter(|record| summary_match_ids.contains(&record.id))
+            .filter(|record| summary_match_sources.contains(&record.l0_uri))
             .take(limit as usize)
             .map(|record| {
-                let mut result = RetrieveResult::new(
-                    record.session_id.to_string(),
-                    record.source_uri,
-                    record
-                        .score_hint
-                        .as_deref()
-                        .and_then(|score| score.parse().ok())
-                        .unwrap_or(0.5),
-                    record.snippet.unwrap_or_else(|| {
-                        let summary = record.summary;
-                        if summary.len() > 200 {
-                            format!("{}...", &summary[..200])
-                        } else {
-                            summary
-                        }
-                    }),
-                );
-
-                // Add domain_class_hit reason
-                if domain_filter.is_some() {
+                let mut result = record;
+                if domain_filter.is_some()
+                    && !result
+                        .match_reasons
+                        .iter()
+                        .any(|reason| reason == match_reason::DOMAIN_CLASS_HIT)
+                {
                     result = result.with_match_reason(match_reason::DOMAIN_CLASS_HIT);
                 }
-
-                // Add summary_hit because the record survived summary filtering.
-                result = result.with_match_reason(match_reason::SUMMARY_HIT);
-
-                // Add session_scope_hit if session filter was applied
-                if ctx.session_id.is_some() {
-                    result = result.with_match_reason(match_reason::SESSION_SCOPE_HIT);
-                }
-
-                result
+                result.with_match_reason(match_reason::SUMMARY_HIT)
             })
             .collect();
 

--- a/koduck-memory/src/retrieve/types.rs
+++ b/koduck-memory/src/retrieve/types.rs
@@ -183,6 +183,8 @@ pub mod domain_class {
 /// Match reasons for memory hits.
 pub mod match_reason {
     pub const DOMAIN_CLASS_HIT: &str = "domain_class_hit";
+    pub const ENTITY_HIT: &str = "entity_hit";
+    pub const RELATION_HIT: &str = "relation_hit";
     pub const SESSION_SCOPE_HIT: &str = "session_scope_hit";
     pub const SUMMARY_HIT: &str = "summary_hit";
     pub const KEYWORD_HIT: &str = "keyword_hit";


### PR DESCRIPTION
## Summary
- add internal ANCHOR_FIRST retriever using fixed candidate channels: domain/entity/relation/session scope
- route service-internal main retrieval path to ANCHOR_FIRST without adding new external retrieve policy enum
- keep time_bucket out of inverted recall; merge and dedupe candidates with source-preserving match reasons
- update materializer generic unit path to persist default domain=chat anchor for anchor recall coverage
- add ADR-0034 and mark Task 4.1 checklist complete

## Verification
- docker build -t koduck-memory:dev ./koduck-memory
- kubectl rollout status deployment/dev-koduck-memory -n koduck-dev --timeout=180s

Closes #861