### PR TITLE
feat(memory): freeze match reasons closed set

### DIFF
--- a/docs/implementation/adr-0025-anchor-based-memory-retrieval-tasks.md
+++ b/docs/implementation/adr-0025-anchor-based-memory-retrieval-tasks.md
@@ -292,11 +292,11 @@ kubectl rollout status deployment/dev-koduck-memory -n koduck-dev --timeout=180s
 3. `MemoryHit` 主路径不承载 recall 扩展的 batch 中间材料
 
 **验收标准:**
-- [ ] `match_reasons` 不出现开放集漂移
-- [ ] 输出形态与当前 `memory.v1` 主路径兼容
-- [ ] 不将 batch 中间材料塞入 `MemoryHit`
-- [ ] `docker build -t koduck-memory:dev ./koduck-memory` 成功
-- [ ] `kubectl rollout status deployment/dev-koduck-memory -n koduck-dev --timeout=180s` 成功
+- [x] `match_reasons` 不出现开放集漂移
+- [x] 输出形态与当前 `memory.v1` 主路径兼容
+- [x] 不将 batch 中间材料塞入 `MemoryHit`
+- [x] `docker build -t koduck-memory:dev ./koduck-memory` 成功
+- [x] `kubectl rollout status deployment/dev-koduck-memory -n koduck-dev --timeout=180s` 成功
 
 ---
 

--- a/koduck-memory/docs/adr/0035-match-reasons-closed-set-and-output-governance.md
+++ b/koduck-memory/docs/adr/0035-match-reasons-closed-set-and-output-governance.md
@@ -1,0 +1,85 @@
+# ADR-0035: Match Reasons Closed Set and Output Governance
+
+- Status: Accepted
+- Date: 2026-04-14
+- Issue: #863
+
+## Context
+
+Task 4.1 established internal `ANCHOR_FIRST` retrieval, but `match_reasons` values still had
+drift risk across retrievers and tests. We need a closed set for stable downstream behavior and
+explainability while keeping `QueryMemory` output contract unchanged.
+
+Task 4.2 requires:
+
+1. Freeze `match_reasons` to a closed set.
+2. Keep `QueryMemory` main path returning `MemoryHit`.
+3. Avoid attaching recall batch intermediate materials to `MemoryHit`.
+
+## Decision
+
+### 1) Freeze `match_reasons` closed set at retrieval output boundary
+
+`match_reasons` is governed by:
+
+- `domain_hit`
+- `entity_hit`
+- `relation_hit`
+- `discourse_action_hit`
+- `session_scope_hit`
+- `summary_hit`
+- `fact_hit`
+- `recency_boost`
+
+Any value outside this set is filtered out before `QueryMemory` returns `MemoryHit`.
+
+### 2) Add explicit normalization API
+
+In `retrieve/types.rs`:
+
+- add `match_reason::is_closed_set_value(...)`
+- add `match_reason::normalize_output(...)`
+
+`QueryMemory` applies `normalize_output` when converting internal `RetrieveResult` to external
+`MemoryHit`.
+
+### 3) Keep contract shape unchanged
+
+No `memory.v1` schema change. `QueryMemory` still returns `MemoryHit` list with existing fields:
+
+- `session_id`
+- `l0_uri`
+- `score`
+- `match_reasons`
+- `snippet`
+
+No batch intermediate recall materials are appended to the output payload.
+
+## Consequences
+
+Positive:
+
+1. Output reasons are deterministic and bounded.
+2. Downstream consumers can rely on stable reason taxonomy.
+3. Internal retriever evolution is safer because output has a normalization guardrail.
+
+Trade-offs:
+
+1. Unknown or experimental reasons are dropped unless explicitly added to the closed set.
+2. Future reason extensions require coordinated ADR/task updates.
+
+## Compatibility Impact
+
+1. gRPC schema remains unchanged.
+2. Output field set remains unchanged.
+3. Existing clients continue to parse `MemoryHit` as before; only reason vocabulary is stabilized.
+
+## Alternatives Considered
+
+### Alternative A: Let each retriever emit arbitrary reasons
+
+Rejected. This creates open-set drift and weakens explainability consistency.
+
+### Alternative B: Expose a new output field for raw internal reasons
+
+Rejected for Task 4.2 to keep `memory.v1` compatibility and avoid payload complexity.

--- a/koduck-memory/src/capability/service.rs
+++ b/koduck-memory/src/capability/service.rs
@@ -19,7 +19,14 @@ use crate::memory_unit::{AppendedEntryUnit, MemoryUnitMaterializer};
 use crate::observe::{record_rpc_call, RpcMethod, RpcOutcome};
 use crate::observe::RpcGuard;
 use crate::observe::RpcMetrics;
-use crate::retrieve::{AnchorFirstRetriever, QueryAnalysis, QueryAnalyzer, RetrieveContext, SummaryFirstRetriever};
+use crate::retrieve::{
+    AnchorFirstRetriever,
+    QueryAnalysis,
+    QueryAnalyzer,
+    RetrieveContext,
+    SummaryFirstRetriever,
+    match_reason,
+};
 use crate::summary::{SummaryJob, SummaryTaskRunner};
 use crate::session::{
     extra_to_jsonb, parse_optional_uuid, parse_uuid, SessionRepository, UpsertSession,
@@ -447,7 +454,7 @@ impl MemoryService for MemoryGrpcService {
                 session_id: r.session_id,
                 l0_uri: r.l0_uri,
                 score: r.score,
-                match_reasons: r.match_reasons,
+                match_reasons: match_reason::normalize_output(r.match_reasons),
                 snippet: r.snippet,
             })
             .collect();
@@ -872,6 +879,7 @@ mod tests {
     use crate::memory_anchor::{MemoryUnitAnchorRepository, MemoryUnitAnchorType};
     use crate::memory_unit::{MemoryUnitKind, MemoryUnitRepository};
     use crate::reliability::TaskAttemptRepository;
+    use crate::retrieve::match_reason;
     use crate::summary::MemorySummaryRepository;
     use crate::session::{SessionRepository, UpsertSession, extra_to_jsonb};
     use crate::store::RuntimeState;
@@ -932,6 +940,15 @@ mod tests {
                 mode: "domain-first".to_string(),
             },
         }
+    }
+
+    fn assert_match_reasons_are_closed_set(reasons: &[String]) {
+        assert!(
+            reasons
+                .iter()
+                .all(|reason| match_reason::is_closed_set_value(reason)),
+            "match_reasons must stay within closed set, got: {reasons:?}"
+        );
     }
 
     #[test]
@@ -1924,8 +1941,9 @@ mod tests {
         let hit = &query_resp.hits[0];
         assert_eq!(hit.l0_uri, record.source_uri);
         assert!(hit.snippet.contains("quarterly planning checklist"));
-        assert!(hit.match_reasons.contains(&"domain_class_hit".to_string()));
+        assert!(hit.match_reasons.contains(&"domain_hit".to_string()));
         assert!(hit.match_reasons.contains(&"session_scope_hit".to_string()));
+        assert_match_reasons_are_closed_set(&hit.match_reasons);
     }
 
     #[tokio::test]
@@ -2147,8 +2165,11 @@ mod tests {
             response
                 .hits
                 .iter()
-                .any(|hit| hit.match_reasons.contains(&"domain_class_hit".to_string()))
+                .any(|hit| hit.match_reasons.contains(&"domain_hit".to_string()))
         );
+        for hit in &response.hits {
+            assert_match_reasons_are_closed_set(&hit.match_reasons);
+        }
 
         let _ = shutdown_tx.send(());
         server.await.unwrap();
@@ -2631,9 +2652,10 @@ mod tests {
 
         let hit = &response.hits[0];
         assert!(hit.snippet.contains("release checklist"));
-        assert!(hit.match_reasons.contains(&"domain_class_hit".to_string()));
+        assert!(hit.match_reasons.contains(&"domain_hit".to_string()));
         assert!(hit.match_reasons.contains(&"summary_hit".to_string()));
         assert!(hit.match_reasons.contains(&"session_scope_hit".to_string()));
+        assert_match_reasons_are_closed_set(&hit.match_reasons);
     }
 
     #[tokio::test]

--- a/koduck-memory/src/retrieve/anchor_first.rs
+++ b/koduck-memory/src/retrieve/anchor_first.rs
@@ -17,7 +17,9 @@ use uuid::Uuid;
 
 use crate::Result;
 use crate::memory_anchor::{MemoryUnitAnchorRepository, MemoryUnitAnchorType};
+use crate::memory_unit::MemoryUnitKind;
 use crate::memory_unit::MemoryUnitRepository;
+use crate::retrieve::semantics::{QueryIntentType, map_intent_to_discourse_action};
 use crate::retrieve::types::{RetrieveContext, RetrieveResult, match_reason};
 
 const CANDIDATE_EXPANSION_FACTOR: i64 = 6;
@@ -77,7 +79,7 @@ impl AnchorFirstRetriever {
                 let candidate = candidates
                     .entry(anchor.memory_unit_id)
                     .or_insert_with(CandidateSignal::new);
-                candidate.reasons.insert(match_reason::DOMAIN_CLASS_HIT.to_string());
+                candidate.reasons.insert(match_reason::DOMAIN_HIT.to_string());
                 candidate.score_hint += 0.35 * anchor.weight as f32;
             }
         }
@@ -112,6 +114,28 @@ impl AnchorFirstRetriever {
                     .or_insert_with(CandidateSignal::new);
                 candidate.reasons.insert(match_reason::RELATION_HIT.to_string());
                 candidate.score_hint += 0.25 * anchor.weight as f32;
+            }
+        }
+
+        if let Some(discourse_action) = parse_intent_type(&ctx.intent_type)
+            .and_then(map_intent_to_discourse_action)
+        {
+            let anchors = self
+                .anchor_repo
+                .list_by_anchor(
+                    &ctx.tenant_id,
+                    MemoryUnitAnchorType::DiscourseAction,
+                    discourse_action.as_str(),
+                    channel_limit,
+                )
+                .await?;
+            for anchor in anchors {
+                if let Some(candidate) = candidates.get_mut(&anchor.memory_unit_id) {
+                    candidate
+                        .reasons
+                        .insert(match_reason::DISCOURSE_ACTION_HIT.to_string());
+                    candidate.score_hint += 0.05 * anchor.weight as f32;
+                }
             }
         }
 
@@ -170,6 +194,12 @@ impl AnchorFirstRetriever {
                 for reason in signal.reasons {
                     result = result.with_match_reason(reason);
                 }
+                if unit.memory_kind == MemoryUnitKind::Fact {
+                    result = result.with_match_reason(match_reason::FACT_HIT);
+                }
+                if recency_boost > 0.0 {
+                    result = result.with_match_reason(match_reason::RECENCY_BOOST);
+                }
                 results.push((result, unit.updated_at));
             }
         }
@@ -198,3 +228,15 @@ impl AnchorFirstRetriever {
     }
 }
 
+fn parse_intent_type(value: &str) -> Option<QueryIntentType> {
+    match value {
+        "recall" => Some(QueryIntentType::Recall),
+        "compare" => Some(QueryIntentType::Compare),
+        "disambiguate" => Some(QueryIntentType::Disambiguate),
+        "correct" => Some(QueryIntentType::Correct),
+        "explain" => Some(QueryIntentType::Explain),
+        "decide" => Some(QueryIntentType::Decide),
+        "none" => Some(QueryIntentType::None),
+        _ => None,
+    }
+}

--- a/koduck-memory/src/retrieve/domain_first.rs
+++ b/koduck-memory/src/retrieve/domain_first.rs
@@ -93,9 +93,9 @@ impl DomainFirstRetriever {
                     }),
                 );
 
-                // Add domain_class_hit reason
+                // Add domain_hit reason
                 if domain_filter.is_some() {
-                    result = result.with_match_reason(match_reason::DOMAIN_CLASS_HIT);
+                    result = result.with_match_reason(match_reason::DOMAIN_HIT);
                 }
 
                 // Add session_scope_hit if session filter was applied

--- a/koduck-memory/src/retrieve/summary_first.rs
+++ b/koduck-memory/src/retrieve/summary_first.rs
@@ -112,9 +112,9 @@ impl SummaryFirstRetriever {
                     && !result
                         .match_reasons
                         .iter()
-                        .any(|reason| reason == match_reason::DOMAIN_CLASS_HIT)
+                        .any(|reason| reason == match_reason::DOMAIN_HIT)
                 {
-                    result = result.with_match_reason(match_reason::DOMAIN_CLASS_HIT);
+                    result = result.with_match_reason(match_reason::DOMAIN_HIT);
                 }
                 result.with_match_reason(match_reason::SUMMARY_HIT)
             })

--- a/koduck-memory/src/retrieve/types.rs
+++ b/koduck-memory/src/retrieve/types.rs
@@ -182,12 +182,41 @@ pub mod domain_class {
 
 /// Match reasons for memory hits.
 pub mod match_reason {
-    pub const DOMAIN_CLASS_HIT: &str = "domain_class_hit";
+    use std::collections::BTreeSet;
+
+    pub const DOMAIN_HIT: &str = "domain_hit";
     pub const ENTITY_HIT: &str = "entity_hit";
     pub const RELATION_HIT: &str = "relation_hit";
+    pub const DISCOURSE_ACTION_HIT: &str = "discourse_action_hit";
     pub const SESSION_SCOPE_HIT: &str = "session_scope_hit";
     pub const SUMMARY_HIT: &str = "summary_hit";
-    pub const KEYWORD_HIT: &str = "keyword_hit";
+    pub const FACT_HIT: &str = "fact_hit";
+    pub const RECENCY_BOOST: &str = "recency_boost";
+
+    const CLOSED_SET: [&str; 8] = [
+        DOMAIN_HIT,
+        ENTITY_HIT,
+        RELATION_HIT,
+        DISCOURSE_ACTION_HIT,
+        SESSION_SCOPE_HIT,
+        SUMMARY_HIT,
+        FACT_HIT,
+        RECENCY_BOOST,
+    ];
+
+    pub fn is_closed_set_value(reason: &str) -> bool {
+        CLOSED_SET.contains(&reason)
+    }
+
+    pub fn normalize_output(reasons: Vec<String>) -> Vec<String> {
+        reasons
+            .into_iter()
+            .map(|reason| reason.trim().to_string())
+            .filter(|reason| !reason.is_empty() && is_closed_set_value(reason))
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect()
+    }
 }
 
 #[cfg(test)]
@@ -244,7 +273,7 @@ mod tests {
     #[test]
     fn retrieve_result_builder_works() {
         let result = RetrieveResult::new("session-1", "s3://bucket/obj", 0.85, "snippet")
-            .with_match_reason("domain_class_hit")
+            .with_match_reason("domain_hit")
             .with_match_reason("session_scope_hit");
 
         assert_eq!(result.session_id, "session-1");
@@ -252,7 +281,22 @@ mod tests {
         assert!((result.score - 0.85).abs() < f32::EPSILON);
         assert_eq!(result.snippet, "snippet");
         assert_eq!(result.match_reasons.len(), 2);
-        assert!(result.match_reasons.contains(&"domain_class_hit".to_string()));
+        assert!(result.match_reasons.contains(&"domain_hit".to_string()));
+    }
+
+    #[test]
+    fn match_reason_normalization_filters_open_set_values() {
+        let normalized = match_reason::normalize_output(vec![
+            "domain_hit".to_string(),
+            "domain_hit".to_string(),
+            "keyword_hit".to_string(),
+            " summary_hit ".to_string(),
+        ]);
+
+        assert_eq!(
+            normalized,
+            vec!["domain_hit".to_string(), "summary_hit".to_string()]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- freeze Task 4.2 match_reasons closed set and normalize output at QueryMemory boundary
- migrate retrieval reason labels to closed set values: domain_hit, entity_hit, relation_hit, discourse_action_hit, session_scope_hit, summary_hit, fact_hit, recency_boost
- keep QueryMemory output shape unchanged (MemoryHit only), without recall batch intermediate payloads
- add ADR-0035 and update Task 4.2 checklist

## Verification
- docker build -t koduck-memory:dev ./koduck-memory
- kubectl rollout status deployment/dev-koduck-memory -n koduck-dev --timeout=180s

Closes #863