### PR TITLE
feat(memory): gate summary filtering by ready and quality

### DIFF
--- a/docs/implementation/adr-0025-anchor-based-memory-retrieval-tasks.md
+++ b/docs/implementation/adr-0025-anchor-based-memory-retrieval-tasks.md
@@ -311,11 +311,11 @@ kubectl rollout status deployment/dev-koduck-memory -n koduck-dev --timeout=180s
 3. 低质量 `summary` 不进入 `summary gate`
 
 **验收标准:**
-- [ ] recent memory 在 `pending` 状态仍可被命中
-- [ ] `SUMMARY_FIRST` 仍保留负向过滤语义
-- [ ] 低质量 summary 不会污染检索结果
-- [ ] `docker build -t koduck-memory:dev ./koduck-memory` 成功
-- [ ] `kubectl rollout status deployment/dev-koduck-memory -n koduck-dev --timeout=180s` 成功
+- [x] recent memory 在 `pending` 状态仍可被命中
+- [x] `SUMMARY_FIRST` 仍保留负向过滤语义
+- [x] 低质量 summary 不会污染检索结果
+- [x] `docker build -t koduck-memory:dev ./koduck-memory` 成功
+- [x] `kubectl rollout status deployment/dev-koduck-memory -n koduck-dev --timeout=180s` 成功
 
 ---
 

--- a/koduck-memory/docs/adr/0036-summary-gate-ready-and-quality-governance.md
+++ b/koduck-memory/docs/adr/0036-summary-gate-ready-and-quality-governance.md
@@ -1,0 +1,81 @@
+# ADR-0036: Summary Gate Ready/Quality Governance
+
+- Status: Accepted
+- Date: 2026-04-14
+- Issue: #865
+
+## Context
+
+Task 5.1 requires tightening `SUMMARY_FIRST` behavior:
+
+1. Summary gate must apply only when `summary_status = ready`.
+2. When summary is not ready, candidates should continue through anchor path and remain retrievable.
+3. Low-quality summaries must not enter summary gate.
+
+Before this change, `SUMMARY_FIRST` always attempted summary filtering once query text existed, which
+could hide recent memory when summary material was pending or low quality.
+
+## Decision
+
+### 1) Gate eligibility becomes session-scoped and explicit
+
+For each candidate session from `ANCHOR_FIRST`, `SUMMARY_FIRST` checks whether that session has a
+latest summary unit that is:
+
+- `summary_status = ready`
+- quality-qualified by heuristic
+
+Only these sessions are `gate-eligible`.
+
+### 2) Non-eligible sessions bypass summary gate
+
+If a session is not gate-eligible (`pending`/`failed`/missing/low-quality), its anchor candidates
+stay in result set and are not hidden by summary filter.
+
+This preserves recent-memory recall under pending summary state.
+
+### 3) Negative filtering remains for eligible sessions
+
+For gate-eligible sessions, `SUMMARY_FIRST` preserves negative filtering semantics:
+
+- query summary index material
+- keep only candidates that survive summary match
+- add `summary_hit` reason for matched items
+
+### 4) Low-quality summary heuristic
+
+A summary is treated as low quality when it is too short or contains placeholder markers
+(e.g. accepted/pending/todo style artifacts). Such summaries are excluded from gate eligibility.
+
+## Consequences
+
+Positive:
+
+1. `pending` summaries no longer suppress recent anchor hits.
+2. `SUMMARY_FIRST` keeps semantic value where high-quality summary exists.
+3. Placeholder summaries cannot dominate retrieval behavior.
+
+Trade-offs:
+
+1. Quality detection is heuristic in V1 and may need iterative tuning.
+2. Session-level eligibility adds a small number of repository lookups.
+
+## Compatibility Impact
+
+1. No changes to `memory.v1` proto or `QueryMemory` output schema.
+2. Existing clients keep the same API contract.
+3. Behavior improves for pending/low-quality summary edge cases without requiring client migration.
+
+## Alternatives Considered
+
+### Alternative A: Always apply summary gate when query text is present
+
+Rejected because it can hide recent memory when summary is pending.
+
+### Alternative B: Fully disable negative filtering
+
+Rejected because Task 5.1 explicitly keeps `SUMMARY_FIRST` negative filtering semantics.
+
+### Alternative C: Treat all `ready` summaries as high quality
+
+Rejected because low-quality placeholders can still appear and would pollute gate behavior.

--- a/koduck-memory/src/capability/service.rs
+++ b/koduck-memory/src/capability/service.rs
@@ -875,9 +875,9 @@ mod tests {
         PostgresSection, RetrySection, ServerSection, SummarySection,
     };
     use crate::facts::MemoryFactRepository;
-    use crate::index::MemoryIndexRepository;
+    use crate::index::{InsertMemoryIndexRecord, MemoryIndexRepository};
     use crate::memory_anchor::{MemoryUnitAnchorRepository, MemoryUnitAnchorType};
-    use crate::memory_unit::{MemoryUnitKind, MemoryUnitRepository};
+    use crate::memory_unit::{InsertMemoryUnit, MemoryUnitKind, MemoryUnitRepository, MemoryUnitSummaryState};
     use crate::reliability::TaskAttemptRepository;
     use crate::retrieve::match_reason;
     use crate::summary::MemorySummaryRepository;
@@ -2656,6 +2656,173 @@ mod tests {
         assert!(hit.match_reasons.contains(&"summary_hit".to_string()));
         assert!(hit.match_reasons.contains(&"session_scope_hit".to_string()));
         assert_match_reasons_are_closed_set(&hit.match_reasons);
+    }
+
+    #[tokio::test]
+    async fn query_memory_summary_first_keeps_recent_hits_when_summary_pending() {
+        let config = test_config();
+        let runtime = RuntimeState::initialize(&config).await.unwrap();
+        let service = MemoryGrpcService::new(config, runtime, None, Arc::new(RpcMetrics::new()));
+
+        let session_id = Uuid::new_v4();
+        let sid_str = session_id.to_string();
+
+        let session_resp = service
+            .upsert_session_meta(Request::new(UpsertSessionMetaRequest {
+                meta: Some(write_meta_with_idempotency("t55-seed", &sid_str)),
+                session_id: sid_str.clone(),
+                title: "Pending summary session".to_string(),
+                status: "active".to_string(),
+                parent_session_id: String::new(),
+                forked_from_session_id: String::new(),
+                last_message_at: 1700000000000,
+                extra: HashMap::new(),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert!(session_resp.ok);
+
+        let append_resp = service
+            .append_memory(Request::new(AppendMemoryRequest {
+                meta: Some(write_meta_with_idempotency("t55-append", &sid_str)),
+                session_id: sid_str.clone(),
+                entries: vec![MemoryEntry {
+                    role: "user".to_string(),
+                    content: "Need release checklist for next deployment".to_string(),
+                    timestamp: 1700000001000,
+                    metadata: HashMap::new(),
+                }],
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert!(append_resp.ok);
+        assert_eq!(append_resp.appended_count, 1);
+
+        let response = service
+            .query_memory(Request::new(QueryMemoryRequest {
+                meta: Some(write_meta_with_idempotency("t55-query", &sid_str)),
+                query_text: "release checklist deployment".to_string(),
+                session_id: sid_str,
+                domain_class: "chat".to_string(),
+                top_k: 5,
+                retrieve_policy: RetrievePolicy::RetrievePolicySummaryFirst as i32,
+                page_token: String::new(),
+                page_size: 0,
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert!(response.ok);
+        assert!(!response.hits.is_empty());
+        assert!(response
+            .hits
+            .iter()
+            .any(|hit| hit.snippet.contains("release checklist")));
+        assert!(response
+            .hits
+            .iter()
+            .all(|hit| !hit.match_reasons.contains(&"summary_hit".to_string())));
+        for hit in &response.hits {
+            assert_match_reasons_are_closed_set(&hit.match_reasons);
+        }
+    }
+
+    #[tokio::test]
+    async fn query_memory_summary_first_ignores_low_quality_ready_summary() {
+        let config = test_config();
+        let runtime = RuntimeState::initialize(&config).await.unwrap();
+        let service = MemoryGrpcService::new(config, runtime.clone(), None, Arc::new(RpcMetrics::new()));
+        let unit_repo = MemoryUnitRepository::new(runtime.pool());
+        let index_repo = MemoryIndexRepository::new(runtime.pool());
+
+        let session_id = Uuid::new_v4();
+        let sid_str = session_id.to_string();
+        let tenant_id = "tenant-t33";
+
+        service
+            .upsert_session_meta(Request::new(UpsertSessionMetaRequest {
+                meta: Some(write_meta_with_idempotency("t56-seed", &sid_str)),
+                session_id: sid_str.clone(),
+                title: "Low quality summary session".to_string(),
+                status: "active".to_string(),
+                parent_session_id: String::new(),
+                forked_from_session_id: String::new(),
+                last_message_at: 1700000000000,
+                extra: HashMap::new(),
+            }))
+            .await
+            .unwrap();
+
+        service
+            .append_memory(Request::new(AppendMemoryRequest {
+                meta: Some(write_meta_with_idempotency("t56-append", &sid_str)),
+                session_id: sid_str.clone(),
+                entries: vec![MemoryEntry {
+                    role: "user".to_string(),
+                    content: "Need deployment checklist details".to_string(),
+                    timestamp: 1700000001000,
+                    metadata: HashMap::new(),
+                }],
+            }))
+            .await
+            .unwrap();
+
+        let low_quality_summary_uri =
+            format!("memory-summary://tenants/{tenant_id}/sessions/{session_id}/versions/1");
+        let summary_unit = InsertMemoryUnit::new(
+            tenant_id,
+            session_id,
+            1,
+            1,
+            low_quality_summary_uri.clone(),
+        )
+        .unwrap()
+        .with_memory_unit_id(session_id)
+        .with_memory_kind(MemoryUnitKind::Summary)
+        .with_summary_state(MemoryUnitSummaryState::ready("todo: summarize later").unwrap())
+        .with_snippet("todo")
+        .with_time_bucket("2026-04");
+        unit_repo.upsert(&summary_unit).await.unwrap();
+        index_repo
+            .insert(
+                &InsertMemoryIndexRecord::new(
+                    tenant_id,
+                    session_id,
+                    "summary",
+                    "chat",
+                    "deployment checklist summary",
+                    low_quality_summary_uri,
+                )
+                .with_memory_unit_id(session_id)
+                .with_snippet("deployment checklist summary"),
+            )
+            .await
+            .unwrap();
+
+        let response = service
+            .query_memory(Request::new(QueryMemoryRequest {
+                meta: Some(write_meta_with_idempotency("t56-query", &sid_str)),
+                query_text: "deployment checklist".to_string(),
+                session_id: sid_str,
+                domain_class: "chat".to_string(),
+                top_k: 5,
+                retrieve_policy: RetrievePolicy::RetrievePolicySummaryFirst as i32,
+                page_token: String::new(),
+                page_size: 0,
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert!(response.ok);
+        assert!(!response.hits.is_empty());
+        assert!(response
+            .hits
+            .iter()
+            .all(|hit| !hit.match_reasons.contains(&"summary_hit".to_string())));
     }
 
     #[tokio::test]

--- a/koduck-memory/src/retrieve/summary_first.rs
+++ b/koduck-memory/src/retrieve/summary_first.rs
@@ -5,10 +5,13 @@
 //! 2. Within candidates, match against summary using full-text search
 
 use sqlx::PgPool;
+use std::collections::HashSet;
 use tracing::{debug, info, instrument};
+use uuid::Uuid;
 
 use crate::index::MemoryIndexRepository;
 use crate::retrieve::anchor_first::AnchorFirstRetriever;
+use crate::memory_unit::{MemoryUnitKind, MemoryUnitRepository};
 use crate::retrieve::types::{
     match_reason, RetrieveContext, RetrieveResult,
 };
@@ -19,6 +22,7 @@ use crate::Result;
 pub struct SummaryFirstRetriever {
     anchor_retriever: AnchorFirstRetriever,
     index_repo: MemoryIndexRepository,
+    unit_repo: MemoryUnitRepository,
 }
 
 impl SummaryFirstRetriever {
@@ -27,6 +31,7 @@ impl SummaryFirstRetriever {
         Self {
             anchor_retriever: AnchorFirstRetriever::new(pool),
             index_repo: MemoryIndexRepository::new(pool),
+            unit_repo: MemoryUnitRepository::new(pool),
         }
     }
 
@@ -47,7 +52,7 @@ impl SummaryFirstRetriever {
             return self.anchor_retriever.retrieve(ctx).await;
         }
 
-        let limit = ctx.top_k as i64;
+        let limit = ctx.top_k.max(1) as usize;
         let session_uuid = ctx
             .session_id
             .as_ref()
@@ -59,6 +64,23 @@ impl SummaryFirstRetriever {
             return Ok(Vec::new());
         }
 
+        let mut gate_eligible_sessions = HashSet::new();
+        for session_id in unique_session_ids(&anchor_candidates) {
+            if self
+                .is_summary_gate_eligible_session(&ctx.tenant_id, session_id)
+                .await?
+            {
+                gate_eligible_sessions.insert(session_id);
+            }
+        }
+        if gate_eligible_sessions.is_empty() {
+            info!(
+                anchor_count = anchor_candidates.len(),
+                "no ready+quality summary found, bypassing summary gate"
+            );
+            return Ok(anchor_candidates.into_iter().take(limit).collect());
+        }
+
         // Perform summary search
         let summary_records = self
             .index_repo
@@ -67,7 +89,7 @@ impl SummaryFirstRetriever {
                 session_uuid,
                 domain_filter.unwrap_or(""),
                 &ctx.query_text,
-                limit * 2,
+                limit as i64 * 2,
             )
             .await?;
 
@@ -77,16 +99,6 @@ impl SummaryFirstRetriever {
             "summary search completed"
         );
 
-        // If no summary matches, return no hits rather than falling back to unrelated
-        // domain-only candidates. This keeps summary retrieval semantically meaningful.
-        if summary_records.is_empty() {
-            info!(
-                query_text = %ctx.query_text,
-                "no summary matches found for SUMMARY_FIRST"
-            );
-            return Ok(Vec::new());
-        }
-
         info!(
             anchor_count = anchor_candidates.len(),
             summary_match_count = summary_records.len(),
@@ -95,18 +107,24 @@ impl SummaryFirstRetriever {
         );
 
         // Build a set of record IDs that matched summary
-        let summary_match_sources: std::collections::HashSet<_> = summary_records
+        let summary_match_sources: HashSet<_> = summary_records
             .iter()
+            .filter(|record| gate_eligible_sessions.contains(&record.session_id))
             .map(|r| r.source_uri.clone())
             .collect();
 
-        // Summary acts as a negative filter inside the domain candidate set:
-        // only records that survive the summary check are returned.
+        // Summary gate applies only to sessions with ready+quality summary.
+        // Sessions without gate eligibility stay on anchor path and are never hidden.
         let results = anchor_candidates
             .into_iter()
-            .filter(|record| summary_match_sources.contains(&record.l0_uri))
-            .take(limit as usize)
-            .map(|record| {
+            .filter_map(|record| {
+                let is_gate_session = Uuid::parse_str(&record.session_id)
+                    .ok()
+                    .is_some_and(|session_id| gate_eligible_sessions.contains(&session_id));
+                if is_gate_session && !summary_match_sources.contains(&record.l0_uri) {
+                    return None;
+                }
+
                 let mut result = record;
                 if domain_filter.is_some()
                     && !result
@@ -116,12 +134,66 @@ impl SummaryFirstRetriever {
                 {
                     result = result.with_match_reason(match_reason::DOMAIN_HIT);
                 }
-                result.with_match_reason(match_reason::SUMMARY_HIT)
+                if is_gate_session {
+                    result = result.with_match_reason(match_reason::SUMMARY_HIT);
+                }
+                Some(result)
             })
+            .take(limit)
             .collect();
 
         Ok(results)
     }
+
+    async fn is_summary_gate_eligible_session(
+        &self,
+        tenant_id: &str,
+        session_id: Uuid,
+    ) -> Result<bool> {
+        let summary_units = self
+            .unit_repo
+            .list_by_session_and_kind(tenant_id, session_id, MemoryUnitKind::Summary)
+            .await?;
+        let Some(latest_summary_unit) = summary_units.first() else {
+            return Ok(false);
+        };
+        if latest_summary_unit.summary_state.summary_status != "ready" {
+            return Ok(false);
+        }
+
+        Ok(latest_summary_unit
+            .summary_state
+            .summary
+            .as_deref()
+            .is_some_and(is_quality_summary))
+    }
+}
+
+fn unique_session_ids(candidates: &[RetrieveResult]) -> Vec<Uuid> {
+    candidates
+        .iter()
+        .filter_map(|candidate| Uuid::parse_str(&candidate.session_id).ok())
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+fn is_quality_summary(summary: &str) -> bool {
+    let normalized = summary.trim();
+    if normalized.chars().count() < 24 {
+        return false;
+    }
+
+    let lower = normalized.to_lowercase();
+    ![
+        "summary task already accepted",
+        "accepted for session",
+        "pending",
+        "n/a",
+        "todo",
+    ]
+    .iter()
+    .any(|marker| lower.contains(marker))
 }
 
 #[cfg(test)]
@@ -135,5 +207,14 @@ mod tests {
     fn retriever_new_works() {
         // This is a compile-time check
         // Actual functionality requires a database connection
+    }
+
+    #[test]
+    fn quality_summary_heuristic_works() {
+        assert!(!is_quality_summary("summary task already accepted for session 123"));
+        assert!(!is_quality_summary("todo"));
+        assert!(is_quality_summary(
+            "The user asked for rollout checklist details and follow-up milestones."
+        ));
     }
 }


### PR DESCRIPTION
## Summary
- enforce SUMMARY_FIRST gate only for sessions with ready and quality summary units
- keep anchor-path candidates visible for pending/missing/low-quality summaries
- add ADR-0036 and Task 5.1 checklist updates

## Verification
- docker build -t koduck-memory:dev ./koduck-memory
- kubectl rollout status deployment/dev-koduck-memory -n koduck-dev --timeout=180s

Closes #865