### PR TITLE
feat(memory): add intent-aware query routing

### DIFF
--- a/docs/implementation/adr-0025-anchor-based-memory-retrieval-tasks.md
+++ b/docs/implementation/adr-0025-anchor-based-memory-retrieval-tasks.md
@@ -219,7 +219,7 @@ kubectl rollout status deployment/dev-koduck-memory -n koduck-dev --timeout=180s
 - [x] 输出字段与 ADR 定义一致
 - [x] analyzer 失败时存在明确回退路径
 - [x] `docker build -t koduck-memory:dev ./koduck-memory` 成功
-- [ ] `kubectl rollout restart deployment/dev-koduck-memory -n koduck-dev` 后可成功完成 rollout
+- [x] `kubectl rollout restart deployment/dev-koduck-memory -n koduck-dev` 后可成功完成 rollout
 
 ---
 

--- a/koduck-ai/docs/adr/0020-intent-aware-memory-query-routing.md
+++ b/koduck-ai/docs/adr/0020-intent-aware-memory-query-routing.md
@@ -1,0 +1,157 @@
+# ADR-0020: Intent-aware Memory Query Routing
+
+- Status: Accepted
+- Date: 2026-04-15
+- Issue: TBD
+
+## Context
+
+当前 `koduck-ai -> query_memory -> koduck-memory` 主链路已经打通，但在处理
+“我们之前聊过什么”“之前讨论过哪些内容”这类全局历史回顾问题时，暴露出一个
+边界错位问题：
+
+1. `koduck-ai` 当前只让 LLM 返回 `tool_call=query_memory`，没有要求 LLM 同时显式返回
+   本次 memory query 的主意图。
+2. `koduck-memory` 因此需要再次根据 `query_text` 进行内部意图猜测，并在统一检索路径中
+   把“全局回顾”“比较”“纠错”“辨析”等不同语义重新路由。
+3. 对于“之前我们聊过什么”这类 query，单靠 query text 做 anchor-style 检索时，
+   可能既没有明确 `domain`，也没有稳定 `entity/relation`，导致 `QueryMemory`
+   返回空命中，即使系统中实际上存在可用于汇总的全局 session summaries。
+4. 这会让 `koduck-ai` 的 northbound 编排语义与 `koduck-memory` 的 southbound
+   检索职责重新耦合：AI 编排层没有真正声明“这次想回顾历史”，memory 服务只能靠猜。
+
+本问题不应通过新增 fallback 解决。
+
+原因是：
+
+1. fallback 会把“检索意图不明确”的问题掩盖成“检索策略补丁”，继续放大服务边界漂移。
+2. “全局历史回顾”本身就是一种显式 retrieval intent，不是默认 anchor 检索失败后的兜底分支。
+3. `koduck-ai` 作为 orchestration 层，本来就应负责把用户请求映射为明确的 southbound
+   语义，而不是把这一步隐式下沉给 `koduck-memory`。
+
+## Decision
+
+我们决定引入 **intent-aware memory query routing**，并明确以下约束：
+
+### 1. LLM 对 `query_memory` 的工具调用必须同时输出主意图
+
+当 LLM 选择调用 `query_memory` 时，除了现有 query 参数外，必须显式返回一个封闭集合中的
+主意图字段，例如：
+
+- `recall`
+- `compare`
+- `disambiguate`
+- `correct`
+- `explain`
+- `decide`
+- `none`
+
+`koduck-ai` 不再只依赖 `tool_call=query_memory` 这一层语义，而是将
+`query_memory + intent` 作为完整的编排决策单元。
+
+### 2. `koduck-ai` 根据 `intent + tool_call` 决定 southbound 检索路径
+
+`koduck-ai` 负责把 LLM 返回的主意图转化为具体的 memory 检索模式：
+
+- `intent=recall`
+  - 语义：显式全局历史回顾
+  - 路径：全局 `session summaries` 检索
+- `intent=compare`
+  - 语义：比较/差异类历史检索
+  - 路径：优先查找 `anchor=compare` / `relation=comparison`
+- `intent=disambiguate`
+  - 语义：辨析/混淆消解
+  - 路径：优先查找 `anchor=disambiguation`
+- `intent=correct`
+  - 语义：纠正历史说法
+  - 路径：优先查找 `anchor=correction`
+- `intent=explain`
+  - 语义：解释型问题
+  - 路径：继续走 domain/entity 为主的常规 memory 检索
+- `intent=decide`
+  - 语义：决策上下文检索
+  - 路径：优先查找 decision-related anchors / facts
+- `intent=none`
+  - 语义：不做 intent-specific routing
+  - 路径：走默认 memory 查询路径
+
+### 3. `koduck-memory` 不再承担主意图猜测责任
+
+`koduck-memory` 仍可保留轻量 query normalization 或结构化辅助分析，但它不再负责根据
+`query_text` 独立决定“这是 recall 还是 compare”这种主语义分流。
+
+换句话说：
+
+- 主意图由 `koduck-ai` 显式下发
+- `koduck-memory` 按已声明意图执行相应检索路径
+
+### 4. “全局历史回顾”不是 fallback，而是一级检索模式
+
+`intent=recall` 时，不应先走 anchor-first 再在空结果后 fallback 到 summaries。
+
+正确语义是：
+
+- `recall` 本身就是一个一级 retrieval mode
+- 其主路径就是全局 `session summaries`
+
+这保证了“我们之前聊过什么”不会被误降级成宽泛、低信息量的 anchor 查询。
+
+## Consequences
+
+正面影响：
+
+1. `koduck-ai` 与 `koduck-memory` 的边界更清晰：
+   `koduck-ai` 负责语义编排，`koduck-memory` 负责检索执行。
+2. “全局回顾”“比较”“纠错”等不同 memory 需求可以走清晰、可观测、可测试的独立路径。
+3. 避免出现“本次 QueryMemory 结果为空，但回答看起来像命中了历史”的隐式语义漂移。
+4. 后续如果需要观测 recall/compare/correct 等命中率，可以直接按 intent 维度统计。
+
+代价与约束：
+
+1. `query_memory` 的工具 schema、`koduck-ai` 内部 tool resolution、`memory.v1` southbound
+   contract 都需要一起演进。
+2. 原有 `koduck-memory` 内部基于 `query_text` 猜 intent 的逻辑需要降级为辅助能力，
+   不再作为主路由依据。
+3. 需要为 intent-routing 建立明确的集成测试，确保 `intent=recall` 不会错误落回
+   anchor-first 主路径。
+
+## Compatibility Impact
+
+1. `koduck-ai` 的 northbound HTTP API 对前端保持兼容；
+   变化发生在 LLM tool schema 与 southbound memory contract。
+2. `memory.v1` 需要新增 intent-aware 查询字段或等价的 retrieval mode 表达；
+   这属于 southbound contract 的前向演进，不应复用原有“仅靠 query text 推断”的隐式语义。
+3. 历史调用方若仍只传 `query_text` 而不传 intent，应在迁移期被显式识别为旧路径，
+   而不是静默混入新语义。
+
+## Alternatives Considered
+
+### Alternative A: 保持现状，由 `koduck-memory` 继续从 `query_text` 猜主意图
+
+未采用。
+
+这会把编排责任错误地下沉到 memory 服务，继续模糊服务边界，也无法稳定支持
+`recall -> global session summaries` 这样的一级检索模式。
+
+### Alternative B: 在 anchor-first 空结果后增加 fallback 到全局 summaries
+
+未采用。
+
+这会把“显式 recall”伪装成“检索失败后的补丁分支”，掩盖问题根因。
+`recall` 应该是一级检索意图，而不是 fallback。
+
+### Alternative C: 让 `koduck-ai` 直接本地维护 recall / compare 的检索实现
+
+未采用。
+
+这会破坏 `koduck-memory` 作为 southbound first-class memory service 的定位，
+把检索执行重新带回 `koduck-ai`，与解耦架构方向相反。
+
+## Follow-up
+
+1. 更新 `query_memory` tool schema，使 LLM 必须返回 `intent`。
+2. 更新 `koduck-ai` tool resolution 逻辑，基于 `intent + tool_call` 构造 southbound 请求。
+3. 演进 `memory.v1 QueryMemoryRequest`，显式承载 intent-aware routing 信息。
+4. 在 `koduck-memory` 中将 `recall` 路径实现为全局 `session summaries` 查询主路径，
+   而非 anchor-first fallback。
+5. 为 `recall / compare / correct / disambiguate` 增加端到端测试和日志字段。

--- a/koduck-ai/proto/koduck/memory/v1/memory.proto
+++ b/koduck-ai/proto/koduck/memory/v1/memory.proto
@@ -76,6 +76,7 @@ message QueryMemoryRequest {
   RetrievePolicy retrieve_policy = 6;
   string page_token = 7;
   int32 page_size = 8;
+  QueryIntent query_intent = 20;
 
   reserved 9 to 19;
 }
@@ -169,4 +170,17 @@ enum RetrievePolicy {
   RETRIEVE_POLICY_HYBRID = 3;
 
   reserved 4 to 19;
+}
+
+enum QueryIntent {
+  QUERY_INTENT_UNSPECIFIED = 0;
+  QUERY_INTENT_RECALL = 1;
+  QUERY_INTENT_COMPARE = 2;
+  QUERY_INTENT_DISAMBIGUATE = 3;
+  QUERY_INTENT_CORRECT = 4;
+  QUERY_INTENT_EXPLAIN = 5;
+  QUERY_INTENT_DECIDE = 6;
+  QUERY_INTENT_NONE = 7;
+
+  reserved 8 to 19;
 }

--- a/koduck-ai/src/api/mod.rs
+++ b/koduck-ai/src/api/mod.rs
@@ -21,13 +21,14 @@ use crate::{
     app::AppState,
     auth::AuthContext,
     clients::memory::{
-        self, MemoryEntry, MemoryHit, MemoryRpcContext, QueryMemoryInput, RetrievePolicy,
-        SessionInfo, SessionUpsertInput,
+        self, MemoryEntry, MemoryHit, MemoryRpcContext, QueryIntent, QueryMemoryInput,
+        RetrievePolicy, SessionInfo, SessionUpsertInput,
     },
     config::LlmMode,
     llm::{
         ChatMessage as ProviderChatMessage, GenerateRequest as ProviderGenerateRequest,
-        RequestContext, StreamEvent as ProviderStreamEvent,
+        RequestContext, StreamEvent as ProviderStreamEvent, ToolCall as ProviderToolCall,
+        ToolDefinition as ProviderToolDefinition,
     },
     orchestrator::cancel::{run_abortable_with_cleanup, AbortReason, RequestGenerationGuard},
     reliability::{
@@ -105,6 +106,25 @@ pub struct ApiResponse<T> {
 struct MemoryContextSnapshot {
     session: Option<SessionInfo>,
     hits: Vec<MemoryHit>,
+}
+
+#[derive(Debug, Default)]
+struct ToolResolutionResult {
+    snapshot: MemoryContextSnapshot,
+    direct_response: Option<crate::llm::GenerateResponse>,
+}
+
+enum StreamLlmPlan {
+    Upstream(crate::llm::ProviderEventStream),
+    ReadyAnswer(String),
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct QueryMemoryToolArgs {
+    query: Option<String>,
+    intent: Option<String>,
+    memory_scope: Option<String>,
+    domain_class: Option<String>,
 }
 
 pub async fn chat(
@@ -360,7 +380,7 @@ pub async fn chat_stream(
                 "stub_enabled",
             );
         } else if state.config.llm.mode == LlmMode::Direct {
-            let upstream = match call_llm_stream(
+            let llm_plan = match call_llm_stream(
                 &state,
                 &request.chat,
                 memory_snapshot.as_ref(),
@@ -371,7 +391,7 @@ pub async fn chat_stream(
             )
             .await
             {
-                Ok(stream) => stream,
+                Ok(plan) => plan,
                 Err(err) => {
                     if let Some(decision) = state
                         .degrade_policy
@@ -400,151 +420,181 @@ pub async fn chat_stream(
                     return api_error_response(err, request_id);
                 }
             };
-
-            let stream_session = Arc::clone(&session);
-            let guard = generation_guard.clone();
-            let append_state = Arc::clone(&state);
-            let append_ctx = memory_ctx.clone();
-            let append_request = request.chat.clone();
-            tokio::spawn(async move {
-                let producer_guard = guard.clone();
-                let producer = async {
-                    let mut upstream = upstream;
-                    let mut full_answer = String::new();
-                    while let Some(next) = upstream.next().await {
-                        match next {
-                            Ok(ev) => {
-                                full_answer.push_str(&ev.delta);
-                                info!(
-                                    request_id = %stream_session.request_id(),
-                                    session_id = %stream_session.session_id(),
-                                    upstream_event_id = %ev.event_id,
-                                    upstream_sequence_num = ev.sequence_num,
-                                    delta_len = ev.delta.len(),
-                                    finish_reason = %ev.finish_reason,
-                                    "forwarding llm stream event to sse session"
-                                );
-                                for pending in build_stream_events(
-                                    &ev,
-                                    stream_session.request_id(),
-                                    stream_session.session_id(),
-                                ) {
-                                    if let Err(err) = stream_session
-                                        .enqueue_event_if_current(&producer_guard, pending)
-                                        .await
-                                    {
+            match llm_plan {
+                StreamLlmPlan::ReadyAnswer(answer) => {
+                    if let Err(err) = append_chat_turn(
+                        &state,
+                        &memory_ctx,
+                        &request.chat,
+                        &answer,
+                        request.chat.model.as_deref().unwrap_or_default(),
+                    )
+                    .await
+                    {
+                        log_memory_failure(
+                            &state,
+                            DegradeRoute::ChatStream,
+                            MemoryOperation::AppendMemory,
+                            &memory_ctx,
+                            &err,
+                            true,
+                            "append_memory failed after direct tool-free response; continuing with generated stream",
+                        );
+                    }
+                    spawn_generated_stream(
+                        Arc::clone(&session),
+                        generation_guard.clone(),
+                        stream_timeout,
+                        answer,
+                    );
+                }
+                StreamLlmPlan::Upstream(upstream) => {
+                    let stream_session = Arc::clone(&session);
+                    let guard = generation_guard.clone();
+                    let append_state = Arc::clone(&state);
+                    let append_ctx = memory_ctx.clone();
+                    let append_request = request.chat.clone();
+                    tokio::spawn(async move {
+                        let producer_guard = guard.clone();
+                        let producer = async {
+                            let mut upstream = upstream;
+                            let mut full_answer = String::new();
+                            while let Some(next) = upstream.next().await {
+                                match next {
+                                    Ok(ev) => {
+                                        full_answer.push_str(&ev.delta);
+                                        info!(
+                                            request_id = %stream_session.request_id(),
+                                            session_id = %stream_session.session_id(),
+                                            upstream_event_id = %ev.event_id,
+                                            upstream_sequence_num = ev.sequence_num,
+                                            delta_len = ev.delta.len(),
+                                            finish_reason = %ev.finish_reason,
+                                            "forwarding llm stream event to sse session"
+                                        );
+                                        for pending in build_stream_events(
+                                            &ev,
+                                            stream_session.request_id(),
+                                            stream_session.session_id(),
+                                        ) {
+                                            if let Err(err) = stream_session
+                                                .enqueue_event_if_current(&producer_guard, pending)
+                                                .await
+                                            {
+                                                info!(
+                                                    request_id = %stream_session.request_id(),
+                                                    session_id = %stream_session.session_id(),
+                                                    error = %err,
+                                                    generation = producer_guard.generation(),
+                                                    "stream queue rejected upstream event"
+                                                );
+                                                stream_session
+                                                    .force_shutdown_if_current(
+                                                        &producer_guard,
+                                                        ErrorCode::StreamTimeout.to_string(),
+                                                        "stream queue backpressure timeout",
+                                                    )
+                                                    .await;
+                                                return;
+                                            }
+                                        }
+                                        info!(
+                                            request_id = %stream_session.request_id(),
+                                            session_id = %stream_session.session_id(),
+                                            upstream_event_id = %ev.event_id,
+                                            "llm stream event enqueued"
+                                        );
+                                    }
+                                    Err(err) => {
                                         info!(
                                             request_id = %stream_session.request_id(),
                                             session_id = %stream_session.session_id(),
                                             error = %err,
                                             generation = producer_guard.generation(),
-                                            "stream queue rejected upstream event"
+                                            "llm stream item failed"
                                         );
-                                        stream_session
-                                            .force_shutdown_if_current(
+                                        let _ = stream_session
+                                            .enqueue_event_if_current(
                                                 &producer_guard,
-                                                ErrorCode::StreamTimeout.to_string(),
-                                                "stream queue backpressure timeout",
+                                                build_stream_error_event(
+                                                    &err,
+                                                    stream_session.request_id(),
+                                                    stream_session.session_id(),
+                                                ),
                                             )
                                             .await;
-                                        return;
+                                        break;
                                     }
                                 }
-                                info!(
-                                    request_id = %stream_session.request_id(),
-                                    session_id = %stream_session.session_id(),
-                                    upstream_event_id = %ev.event_id,
-                                    "llm stream event enqueued"
-                                );
                             }
-                            Err(err) => {
-                                info!(
-                                    request_id = %stream_session.request_id(),
-                                    session_id = %stream_session.session_id(),
-                                    error = %err,
-                                    generation = producer_guard.generation(),
-                                    "llm stream item failed"
-                                );
+
+                            let replay = stream_session.open_replay(0).await;
+                            let has_terminal_event = replay
+                                .replay_events
+                                .iter()
+                                .any(|event| matches!(event.event_type.as_str(), "done" | "error"));
+
+                            if !has_terminal_event {
                                 let _ = stream_session
                                     .enqueue_event_if_current(
                                         &producer_guard,
-                                        build_stream_error_event(
-                                            &err,
-                                            stream_session.request_id(),
-                                            stream_session.session_id(),
+                                        StreamEventData::done(
+                                            stream_session.request_id().to_string(),
+                                            stream_session.session_id().to_string(),
+                                            "stop",
                                         ),
                                     )
                                     .await;
-                                break;
                             }
-                        }
-                    }
 
-                    let replay = stream_session.open_replay(0).await;
-                    let has_terminal_event = replay
-                        .replay_events
-                        .iter()
-                        .any(|event| matches!(event.event_type.as_str(), "done" | "error"));
-
-                    if !has_terminal_event {
-                        let _ = stream_session
-                            .enqueue_event_if_current(
-                                &producer_guard,
-                                StreamEventData::done(
-                                    stream_session.request_id().to_string(),
-                                    stream_session.session_id().to_string(),
-                                    "stop",
-                                ),
+                            if let Err(err) = append_chat_turn(
+                                &append_state,
+                                &append_ctx,
+                                &append_request,
+                                &full_answer,
+                                append_request.model.as_deref().unwrap_or_default(),
                             )
-                            .await;
-                    }
+                            .await
+                            {
+                                log_memory_failure(
+                                    &append_state,
+                                    DegradeRoute::ChatStream,
+                                    MemoryOperation::AppendMemory,
+                                    &append_ctx,
+                                    &err,
+                                    true,
+                                    "failed to persist streamed conversation into memory",
+                                );
+                            }
+                        };
 
-                    if let Err(err) = append_chat_turn(
-                        &append_state,
-                        &append_ctx,
-                        &append_request,
-                        &full_answer,
-                        append_request.model.as_deref().unwrap_or_default(),
-                    )
-                    .await
-                    {
-                        log_memory_failure(
-                            &append_state,
-                            DegradeRoute::ChatStream,
-                            MemoryOperation::AppendMemory,
-                            &append_ctx,
-                            &err,
-                            true,
-                            "failed to persist streamed conversation into memory",
-                        );
-                    }
-                };
+                        let cleanup_session = Arc::clone(&stream_session);
+                        let cleanup_guard = guard.clone();
+                        let cleanup_guard_for_log = cleanup_guard.clone();
+                        let result = run_abortable_with_cleanup(
+                            guard,
+                            stream_timeout,
+                            producer,
+                            move |reason| async move {
+                                handle_stream_abort(&cleanup_session, &cleanup_guard, reason).await;
+                            },
+                        )
+                        .await;
 
-                let cleanup_session = Arc::clone(&stream_session);
-                let cleanup_guard = guard.clone();
-                let cleanup_guard_for_log = cleanup_guard.clone();
-                let result = run_abortable_with_cleanup(
-                    guard,
-                    stream_timeout,
-                    producer,
-                    move |reason| async move {
-                        handle_stream_abort(&cleanup_session, &cleanup_guard, reason).await;
-                    },
-                )
-                .await;
-
-                if let Err(reason) = result {
-                    info!(
-                        request_id = %stream_session.request_id(),
-                        session_id = %stream_session.session_id(),
-                        generation = cleanup_guard_for_log.generation(),
-                        abort_reason = ?reason,
-                        "upstream stream producer terminated early"
-                    );
+                        if let Err(reason) = result {
+                            info!(
+                                request_id = %stream_session.request_id(),
+                                session_id = %stream_session.session_id(),
+                                generation = cleanup_guard_for_log.generation(),
+                                abort_reason = ?reason,
+                                "upstream stream producer terminated early"
+                            );
+                        }
+                    });
                 }
-            });
+            }
         } else {
-            let upstream =
+            let llm_plan =
                 match call_llm_stream(
                     &state,
                     &request.chat,
@@ -556,7 +606,7 @@ pub async fn chat_stream(
                 )
                 .await
                 {
-                    Ok(stream) => stream,
+                    Ok(plan) => plan,
                     Err(err) => {
                         if let Some(decision) = state
                             .degrade_policy
@@ -585,133 +635,164 @@ pub async fn chat_stream(
                         return api_error_response(err, request_id);
                     }
                 };
-            let stream_session = Arc::clone(&session);
-            let guard = generation_guard.clone();
-            let append_state = Arc::clone(&state);
-            let append_ctx = memory_ctx.clone();
-            let append_request = request.chat.clone();
-            tokio::spawn(async move {
-                let producer_guard = guard.clone();
-                let producer = async {
-                    let mut upstream = upstream;
-                    let mut full_answer = String::new();
-                    while let Some(next) = upstream.next().await {
-                        match next {
-                            Ok(ev) => {
-                                full_answer.push_str(&ev.delta);
-                                for pending in build_stream_events(
-                                    &ev,
-                                    stream_session.request_id(),
-                                    stream_session.session_id(),
-                                ) {
-                                    if let Err(err) = stream_session
-                                        .enqueue_event_if_current(&producer_guard, pending)
-                                        .await
-                                    {
+            match llm_plan {
+                StreamLlmPlan::ReadyAnswer(answer) => {
+                    if let Err(err) = append_chat_turn(
+                        &state,
+                        &memory_ctx,
+                        &request.chat,
+                        &answer,
+                        request.chat.model.as_deref().unwrap_or_default(),
+                    )
+                    .await
+                    {
+                        log_memory_failure(
+                            &state,
+                            DegradeRoute::ChatStream,
+                            MemoryOperation::AppendMemory,
+                            &memory_ctx,
+                            &err,
+                            true,
+                            "append_memory failed after direct tool-free response; continuing with generated stream",
+                        );
+                    }
+                    spawn_generated_stream(
+                        Arc::clone(&session),
+                        generation_guard.clone(),
+                        stream_timeout,
+                        answer,
+                    );
+                }
+                StreamLlmPlan::Upstream(upstream) => {
+                    let stream_session = Arc::clone(&session);
+                    let guard = generation_guard.clone();
+                    let append_state = Arc::clone(&state);
+                    let append_ctx = memory_ctx.clone();
+                    let append_request = request.chat.clone();
+                    tokio::spawn(async move {
+                        let producer_guard = guard.clone();
+                        let producer = async {
+                            let mut upstream = upstream;
+                            let mut full_answer = String::new();
+                            while let Some(next) = upstream.next().await {
+                                match next {
+                                    Ok(ev) => {
+                                        full_answer.push_str(&ev.delta);
+                                        for pending in build_stream_events(
+                                            &ev,
+                                            stream_session.request_id(),
+                                            stream_session.session_id(),
+                                        ) {
+                                            if let Err(err) = stream_session
+                                                .enqueue_event_if_current(&producer_guard, pending)
+                                                .await
+                                            {
+                                                info!(
+                                                    request_id = %stream_session.request_id(),
+                                                    session_id = %stream_session.session_id(),
+                                                    error = %err,
+                                                    generation = producer_guard.generation(),
+                                                    "stream queue rejected upstream event"
+                                                );
+                                                stream_session
+                                                    .force_shutdown_if_current(
+                                                        &producer_guard,
+                                                        ErrorCode::StreamTimeout.to_string(),
+                                                        "stream queue backpressure timeout",
+                                                    )
+                                                    .await;
+                                                break;
+                                            }
+                                        }
+                                    }
+                                    Err(mapped_error) => {
                                         info!(
                                             request_id = %stream_session.request_id(),
                                             session_id = %stream_session.session_id(),
-                                            error = %err,
+                                            error = %mapped_error,
                                             generation = producer_guard.generation(),
-                                            "stream queue rejected upstream event"
+                                            "llm stream item failed"
                                         );
-                                        stream_session
-                                            .force_shutdown_if_current(
+                                        let _ = stream_session
+                                            .enqueue_event_if_current(
                                                 &producer_guard,
-                                                ErrorCode::StreamTimeout.to_string(),
-                                                "stream queue backpressure timeout",
+                                                build_stream_error_event(
+                                                    &mapped_error,
+                                                    stream_session.request_id(),
+                                                    stream_session.session_id(),
+                                                ),
                                             )
                                             .await;
                                         break;
                                     }
                                 }
                             }
-                            Err(mapped_error) => {
-                                info!(
-                                    request_id = %stream_session.request_id(),
-                                    session_id = %stream_session.session_id(),
-                                    error = %mapped_error,
-                                    generation = producer_guard.generation(),
-                                    "llm stream item failed"
-                                );
+
+                            let replay = stream_session.open_replay(0).await;
+                            let has_terminal_event = replay
+                                .replay_events
+                                .iter()
+                                .any(|event| matches!(event.event_type.as_str(), "done" | "error"));
+
+                            if !has_terminal_event {
                                 let _ = stream_session
                                     .enqueue_event_if_current(
                                         &producer_guard,
-                                        build_stream_error_event(
-                                            &mapped_error,
-                                            stream_session.request_id(),
-                                            stream_session.session_id(),
+                                        StreamEventData::done(
+                                            stream_session.request_id().to_string(),
+                                            stream_session.session_id().to_string(),
+                                            "stop",
                                         ),
                                     )
                                     .await;
-                                break;
                             }
-                        }
-                    }
 
-                    let replay = stream_session.open_replay(0).await;
-                    let has_terminal_event = replay
-                        .replay_events
-                        .iter()
-                        .any(|event| matches!(event.event_type.as_str(), "done" | "error"));
-
-                    if !has_terminal_event {
-                        let _ = stream_session
-                            .enqueue_event_if_current(
-                                &producer_guard,
-                                StreamEventData::done(
-                                    stream_session.request_id().to_string(),
-                                    stream_session.session_id().to_string(),
-                                    "stop",
-                                ),
+                            if let Err(err) = append_chat_turn(
+                                &append_state,
+                                &append_ctx,
+                                &append_request,
+                                &full_answer,
+                                append_request.model.as_deref().unwrap_or_default(),
                             )
-                            .await;
-                    }
+                            .await
+                            {
+                                log_memory_failure(
+                                    &append_state,
+                                    DegradeRoute::ChatStream,
+                                    MemoryOperation::AppendMemory,
+                                    &append_ctx,
+                                    &err,
+                                    true,
+                                    "failed to persist streamed conversation into memory",
+                                );
+                            }
+                        };
 
-                    if let Err(err) = append_chat_turn(
-                        &append_state,
-                        &append_ctx,
-                        &append_request,
-                        &full_answer,
-                        append_request.model.as_deref().unwrap_or_default(),
-                    )
-                    .await
-                    {
-                        log_memory_failure(
-                            &append_state,
-                            DegradeRoute::ChatStream,
-                            MemoryOperation::AppendMemory,
-                            &append_ctx,
-                            &err,
-                            true,
-                            "failed to persist streamed conversation into memory",
-                        );
-                    }
-                };
+                        let cleanup_session = Arc::clone(&stream_session);
+                        let cleanup_guard = guard.clone();
+                        let cleanup_guard_for_log = cleanup_guard.clone();
+                        let result = run_abortable_with_cleanup(
+                            guard,
+                            stream_timeout,
+                            producer,
+                            move |reason| async move {
+                                handle_stream_abort(&cleanup_session, &cleanup_guard, reason).await;
+                            },
+                        )
+                        .await;
 
-                let cleanup_session = Arc::clone(&stream_session);
-                let cleanup_guard = guard.clone();
-                let cleanup_guard_for_log = cleanup_guard.clone();
-                let result = run_abortable_with_cleanup(
-                    guard,
-                    stream_timeout,
-                    producer,
-                    move |reason| async move {
-                        handle_stream_abort(&cleanup_session, &cleanup_guard, reason).await;
-                    },
-                )
-                .await;
-
-                if let Err(reason) = result {
-                    info!(
-                        request_id = %stream_session.request_id(),
-                        session_id = %stream_session.session_id(),
-                        generation = cleanup_guard_for_log.generation(),
-                        abort_reason = ?reason,
-                        "upstream stream producer terminated early"
-                    );
+                        if let Err(reason) = result {
+                            info!(
+                                request_id = %stream_session.request_id(),
+                                session_id = %stream_session.session_id(),
+                                generation = cleanup_guard_for_log.generation(),
+                                abort_reason = ?reason,
+                                "upstream stream producer terminated early"
+                            );
+                        }
+                    });
                 }
-            });
+            }
         }
     }
 
@@ -818,33 +899,10 @@ async fn prepare_memory_context(
         );
     }
 
-    let hits = memory::query_memory(
-        state,
-        ctx,
-        QueryMemoryInput {
-            query_text: build_memory_query_text(&request.message),
-            session_id: memory_query_session_scope(request, ctx),
-            domain_class: metadata_string(request, "domain_class"),
-            retrieve_policy: retrieve_policy_from_request(request),
-            top_k: MEMORY_QUERY_TOP_K,
-            page_size: MEMORY_QUERY_PAGE_SIZE,
-        },
-    )
-    .await
-    .unwrap_or_else(|err| {
-        log_memory_failure(
-            state,
-            route,
-            MemoryOperation::QueryMemory,
-            ctx,
-            &err,
-            true,
-            "query_memory failed; continuing without retrieved memory hits",
-        );
-        Vec::new()
-    });
-
-    MemoryContextSnapshot { session, hits }
+    MemoryContextSnapshot {
+        session,
+        hits: Vec::new(),
+    }
 }
 
 async fn append_chat_turn(
@@ -1213,7 +1271,10 @@ fn build_degraded_stream_chunks(
     chunk_answer(&build_degraded_answer(user_message, snapshot, reason))
 }
 
-fn build_memory_prompt(snapshot: &MemoryContextSnapshot) -> Option<String> {
+fn build_memory_prompt(
+    snapshot: &MemoryContextSnapshot,
+    user_message: &str,
+) -> Option<String> {
     if snapshot.hits.is_empty() {
         return None;
     }
@@ -1235,10 +1296,209 @@ fn build_memory_prompt(snapshot: &MemoryContextSnapshot) -> Option<String> {
         .collect::<Vec<_>>()
         .join("\n");
 
+    let prompt_tail = if is_memory_recall_query(user_message) {
+        "这是一次“回顾历史/之前聊过什么”的请求。你必须优先做跨 session 汇总，不能只复述单个最近会话；请结合下面所有历史命中与当前问题，自行判断哪些会话相关、哪些不相关，再给出汇总后的最终答案。"
+    } else {
+        "请结合下面历史命中与当前问题，自行判断哪些内容相关，再决定是否在回答中引用这些历史记忆。"
+    };
+
     Some(format!(
-        "以下内容来自 koduck-memory 的历史摘要检索结果，可能跨多个旧会话。请先判断哪些历史记忆与当前问题相关，再基于相关命中进行总结回答；如果命中明显相关，应直接说明我们之前讨论过哪些内容，不要回答成“没有之前记录”。\n历史命中:\n{}",
-        snippets
+        "以下内容来自 koduck-memory 的历史摘要检索结果，可能跨多个旧会话。\n{}\n\n历史命中:\n{}\n\n当前用户问题（请把它作为最终相关性判断依据）:\n{}",
+        prompt_tail,
+        snippets,
+        user_message.trim()
     ))
+}
+
+fn build_memory_tool_definition() -> ProviderToolDefinition {
+    ProviderToolDefinition {
+        name: "query_memory".to_string(),
+        description: "检索当前用户与 koduck 的历史记忆会话，用于回答“之前聊过什么、之前是否聊过某个主题/人物/偏好/事实、具体聊到了哪些方面”等问题。".to_string(),
+        input_schema: json!({
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "用于检索历史记忆的查询文本，通常直接取当前用户问题或其中的主题/实体。"
+                },
+                "intent": {
+                    "type": "string",
+                    "enum": ["recall", "compare", "disambiguate", "correct", "explain", "decide", "none"],
+                    "description": "本次记忆检索的主意图。必须显式给出，禁止省略。"
+                },
+                "memory_scope": {
+                    "type": "string",
+                    "enum": ["global", "current_session"],
+                    "description": "可选；默认 global。仅当需要限制在当前 session 内检索时才传 current_session。"
+                },
+                "domain_class": {
+                    "type": "string",
+                    "description": "可选；当你非常确定某个 domain 更适合缩小检索范围时传入，例如 literature、history、food。"
+                }
+            },
+            "required": ["query", "intent"],
+            "additionalProperties": false
+        })
+        .to_string(),
+    }
+}
+
+fn build_memory_tool_instruction() -> &'static str {
+    "当用户询问“之前聊过什么 / 之前有没有聊过某个主题、人物、偏好、事实 / 具体聊到了哪些方面 / 回忆一下之前内容”时，优先调用 query_memory 工具；并且在工具参数中显式填写 intent。不要在没有调用工具的情况下臆测历史记录。"
+}
+
+fn parse_query_memory_tool_args(raw: &str) -> QueryMemoryToolArgs {
+    serde_json::from_str::<QueryMemoryToolArgs>(raw).unwrap_or_default()
+}
+
+fn parse_query_intent(intent: Option<&str>) -> QueryIntent {
+    match intent
+        .map(|value| value.trim().to_ascii_lowercase())
+        .as_deref()
+    {
+        Some("recall") => QueryIntent::Recall,
+        Some("compare") => QueryIntent::Compare,
+        Some("disambiguate") => QueryIntent::Disambiguate,
+        Some("correct") => QueryIntent::Correct,
+        Some("explain") => QueryIntent::Explain,
+        Some("decide") => QueryIntent::Decide,
+        Some("none") => QueryIntent::None,
+        _ => QueryIntent::Unspecified,
+    }
+}
+
+async fn execute_memory_tool_call(
+    state: &Arc<AppState>,
+    route: DegradeRoute,
+    request: &ChatRequest,
+    ctx: &MemoryRpcContext,
+    base_snapshot: &MemoryContextSnapshot,
+    tool_call: &ProviderToolCall,
+) -> MemoryContextSnapshot {
+    let args = parse_query_memory_tool_args(&tool_call.arguments);
+    info!(
+        request_id = %ctx.request_id,
+        session_id = %ctx.session_id,
+        tool_name = %tool_call.name,
+        tool_call_id = %tool_call.id,
+        tool_arguments = %tool_call.arguments,
+        "llm tool call resolved to memory query"
+    );
+
+    let query_text = args
+        .query
+        .as_deref()
+        .map(build_memory_query_text)
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| build_memory_query_text(&request.message));
+    let session_scope = match args.memory_scope.as_deref() {
+        Some("current_session") => Some(ctx.session_id.clone()),
+        _ => memory_query_session_scope(request, ctx),
+    };
+    let requested_domain_class = args.domain_class.clone();
+    let domain_class = requested_domain_class
+        .as_ref()
+        .filter(|value| !value.trim().is_empty())
+        .cloned()
+        .unwrap_or_else(|| metadata_string(request, "domain_class"));
+    let query_intent = parse_query_intent(args.intent.as_deref());
+
+    let hits = memory::query_memory(
+        state,
+        ctx,
+        QueryMemoryInput {
+            query_text,
+            session_id: session_scope,
+            domain_class,
+            query_intent,
+            retrieve_policy: retrieve_policy_from_request(request),
+            top_k: MEMORY_QUERY_TOP_K,
+            page_size: MEMORY_QUERY_PAGE_SIZE,
+        },
+    )
+    .await
+    .unwrap_or_else(|err| {
+        log_memory_failure(
+            state,
+            route,
+            MemoryOperation::QueryMemory,
+            ctx,
+            &err,
+            true,
+            "query_memory tool call failed; continuing without retrieved memory hits",
+        );
+        Vec::new()
+    });
+
+    info!(
+        request_id = %ctx.request_id,
+        session_id = %ctx.session_id,
+        tool_name = %tool_call.name,
+        hits_count = hits.len(),
+        query_intent = ?query_intent,
+        "memory tool call completed"
+    );
+
+    let mut snapshot = base_snapshot.clone();
+    snapshot.hits = hits;
+    snapshot
+}
+
+async fn resolve_memory_tool_call(
+    state: &Arc<AppState>,
+    route: DegradeRoute,
+    request: &ChatRequest,
+    base_snapshot: &MemoryContextSnapshot,
+    request_id: &str,
+    session_id: &str,
+    auth_ctx: &AuthContext,
+    trace_id: &str,
+) -> Result<ToolResolutionResult, AppError> {
+    let llm_request = build_provider_generate_request(
+        request,
+        Some(base_snapshot),
+        request_id,
+        session_id,
+        auth_ctx,
+        trace_id,
+        state.config.llm.timeout_ms,
+        vec![build_memory_tool_definition()],
+    );
+    let selection = state.llm_provider.generate(llm_request).await?;
+    info!(
+        request_id = %request_id,
+        session_id = %session_id,
+        tool_call_count = selection.tool_calls.len(),
+        finish_reason = %selection.finish_reason,
+        "llm tool-selection phase completed"
+    );
+
+    let maybe_memory_call = selection
+        .tool_calls
+        .iter()
+        .find(|tool_call| tool_call.name == "query_memory")
+        .cloned();
+
+    if let Some(tool_call) = maybe_memory_call {
+        let ctx = MemoryRpcContext::from_auth(
+            request_id.to_string(),
+            session_id.to_string(),
+            trace_id.to_string(),
+            state.config.llm.timeout_ms,
+            auth_ctx,
+        );
+        let snapshot =
+            execute_memory_tool_call(state, route, request, &ctx, base_snapshot, &tool_call).await;
+        return Ok(ToolResolutionResult {
+            snapshot,
+            direct_response: None,
+        });
+    }
+
+    Ok(ToolResolutionResult {
+        snapshot: base_snapshot.clone(),
+        direct_response: Some(selection),
+    })
 }
 
 fn build_memory_entry_metadata(
@@ -1268,6 +1528,11 @@ fn build_memory_entry_metadata(
         .and_then(json_value_as_string)
     {
         metadata.insert("domain_class".to_string(), domain_class);
+    }
+
+    if is_memory_recall_query(&request.message) {
+        metadata.insert("memory_recall_query".to_string(), "true".to_string());
+        metadata.insert("memory_skip_retrieval".to_string(), "true".to_string());
     }
 
     metadata
@@ -1421,6 +1686,35 @@ async fn call_llm_generate(
     auth_ctx: &AuthContext,
     trace_id: &str,
 ) -> Result<ChatResponse, AppError> {
+    let tool_resolution = resolve_memory_tool_call(
+        state,
+        DegradeRoute::Chat,
+        request,
+        memory_snapshot,
+        request_id,
+        session_id,
+        auth_ctx,
+        trace_id,
+    )
+    .await?;
+
+    if let Some(body) = tool_resolution.direct_response {
+        let answer = body.message.content.clone();
+        let usage = body.usage.as_ref();
+        return Ok(ChatResponse {
+            request_id: request_id.to_string(),
+            session_id: session_id.to_string(),
+            answer,
+            model: body.model,
+            usage: TokenUsage {
+                prompt_tokens: usage.map(|u| u.prompt_tokens).unwrap_or(0),
+                completion_tokens: usage.map(|u| u.completion_tokens).unwrap_or(0),
+                total_tokens: usage.map(|u| u.total_tokens).unwrap_or(0),
+            },
+            degraded: false,
+        });
+    }
+
     let policy = Arc::clone(&state.retry_budget_policy);
     let session = policy.begin_session();
     let mut attempt_index = 0;
@@ -1438,14 +1732,14 @@ async fn call_llm_generate(
             }
         };
         let llm_request = build_provider_generate_request(
-            state,
             request,
-            Some(memory_snapshot),
+            Some(&tool_resolution.snapshot),
             request_id,
             session_id,
             auth_ctx,
             trace_id,
             deadline_ms,
+            vec![],
         );
         match state.llm_provider.generate(llm_request).await {
             Ok(body) => break body,
@@ -1489,7 +1783,24 @@ async fn call_llm_stream(
     session_id: &str,
     auth_ctx: &AuthContext,
     trace_id: &str,
-) -> Result<crate::llm::ProviderEventStream, AppError> {
+) -> Result<StreamLlmPlan, AppError> {
+    let base_snapshot = memory_snapshot.cloned().unwrap_or_default();
+    let tool_resolution = resolve_memory_tool_call(
+        state,
+        DegradeRoute::ChatStream,
+        request,
+        &base_snapshot,
+        request_id,
+        session_id,
+        auth_ctx,
+        trace_id,
+    )
+    .await?;
+
+    if let Some(body) = tool_resolution.direct_response {
+        return Ok(StreamLlmPlan::ReadyAnswer(body.message.content));
+    }
+
     let policy = Arc::clone(&state.retry_budget_policy);
     let session = policy.begin_session();
     let mut attempt_index = 0;
@@ -1508,17 +1819,17 @@ async fn call_llm_stream(
             }
         };
         let llm_request = build_provider_generate_request(
-            state,
             request,
-            memory_snapshot,
+            Some(&tool_resolution.snapshot),
             request_id,
             session_id,
             auth_ctx,
             trace_id,
             deadline_ms,
+            vec![],
         );
         match state.llm_provider.stream_generate(llm_request).await {
-            Ok(stream) => return Ok(stream),
+            Ok(stream) => return Ok(StreamLlmPlan::Upstream(stream)),
             Err(err) => match policy.should_retry(&session, attempt_index, err) {
                 RetryDirective::RetryAfter { delay, err } => {
                     policy.log_retry(request_id, attempt_index, delay, &err);
@@ -1534,7 +1845,6 @@ async fn call_llm_stream(
 }
 
 fn build_provider_generate_request(
-    _state: &Arc<AppState>,
     request: &ChatRequest,
     memory_snapshot: Option<&MemoryContextSnapshot>,
     request_id: &str,
@@ -1542,6 +1852,7 @@ fn build_provider_generate_request(
     auth_ctx: &AuthContext,
     trace_id: &str,
     deadline_ms: u64,
+    tools: Vec<ProviderToolDefinition>,
 ) -> ProviderGenerateRequest {
     const KODUCK_V1_LITE_PROMPT: &str =
         include_str!("../../prompts/system/koduck-v1-lite.md");
@@ -1553,9 +1864,16 @@ fn build_provider_generate_request(
         KODUCK_BASE_LANGUAGE_PROMPT
     );
 
-    if let Some(memory_prompt) = memory_snapshot.and_then(build_memory_prompt) {
+    if let Some(memory_prompt) = memory_snapshot.and_then(|snapshot| {
+        build_memory_prompt(snapshot, &request.message)
+    }) {
         system_content.push_str("\n\n");
         system_content.push_str(&memory_prompt);
+    }
+
+    if !tools.is_empty() {
+        system_content.push_str("\n\n");
+        system_content.push_str(build_memory_tool_instruction());
     }
 
     let mut messages = vec![ProviderChatMessage {
@@ -1595,7 +1913,7 @@ fn build_provider_generate_request(
         temperature: request.temperature.unwrap_or(0.2),
         top_p: 1.0,
         max_tokens: request.max_tokens.unwrap_or(2048),
-        tools: vec![],
+        tools,
         response_format: String::new(),
     }
 }

--- a/koduck-ai/src/clients/memory/mod.rs
+++ b/koduck-ai/src/clients/memory/mod.rs
@@ -16,7 +16,7 @@ use crate::{
 pub use super::proto::{
     AppendMemoryRequest, AppendMemoryResponse, GetSessionRequest, GetSessionResponse, MemoryEntry,
     MemoryHit, MemoryService, MemoryServiceClient, MemoryServiceServer, QueryMemoryRequest,
-    QueryMemoryResponse, RetrievePolicy, SessionInfo, UpsertSessionMetaRequest,
+    QueryIntent, QueryMemoryResponse, RetrievePolicy, SessionInfo, UpsertSessionMetaRequest,
     UpsertSessionMetaResponse,
 };
 
@@ -80,6 +80,7 @@ pub struct QueryMemoryInput {
     pub query_text: String,
     pub session_id: Option<String>,
     pub domain_class: String,
+    pub query_intent: QueryIntent,
     pub retrieve_policy: RetrievePolicy,
     pub top_k: i32,
     pub page_size: i32,
@@ -140,6 +141,7 @@ pub async fn query_memory(
             retrieve_policy: input.retrieve_policy as i32,
             page_token: String::new(),
             page_size: input.page_size,
+            query_intent: input.query_intent as i32,
         }))
         .await
         .map_err(|status| map_grpc_status(UpstreamService::Memory, &ctx.request_id, &status))?;

--- a/koduck-ai/src/llm/compat.rs
+++ b/koduck-ai/src/llm/compat.rs
@@ -90,6 +90,7 @@ impl LlmProvider for AdapterLlmProvider {
             provider,
             model,
             message: proto_chat_message_to_unified(response.message.unwrap_or_default()),
+            tool_calls: vec![],
             finish_reason: response.finish_reason,
             usage: response.usage.map(proto_usage_to_unified),
         })

--- a/koduck-ai/src/llm/mod.rs
+++ b/koduck-ai/src/llm/mod.rs
@@ -19,5 +19,6 @@ pub use provider::{LlmProvider, ProviderEventStream};
 pub use router::{build_provider_router, LlmRouter};
 pub use types::{
     ChatMessage, CountTokensRequest, CountTokensResponse, GenerateRequest, GenerateResponse,
-    ListModelsRequest, ModelInfo, RequestContext, StreamEvent, TokenUsage, ToolDefinition,
+    ListModelsRequest, ModelInfo, RequestContext, StreamEvent, TokenUsage, ToolCall,
+    ToolDefinition,
 };

--- a/koduck-ai/src/llm/openai.rs
+++ b/koduck-ai/src/llm/openai.rs
@@ -16,7 +16,7 @@ use super::{
     provider::{LlmProvider, ProviderEventStream},
     types::{
         ChatMessage, CountTokensRequest, CountTokensResponse, GenerateRequest, GenerateResponse,
-        ListModelsRequest, ModelInfo, StreamEvent, TokenUsage, ToolDefinition,
+        ListModelsRequest, ModelInfo, StreamEvent, TokenUsage, ToolCall, ToolDefinition,
     },
 };
 
@@ -537,6 +537,13 @@ fn parse_generate_response(
             name: String::new(),
             metadata: Default::default(),
         },
+        tool_calls: choice
+            .message
+            .tool_calls
+            .unwrap_or_default()
+            .into_iter()
+            .map(tool_call_to_unified)
+            .collect(),
         finish_reason: choice.finish_reason.unwrap_or_default(),
         usage: payload.usage.map(usage_to_unified),
     })
@@ -596,6 +603,14 @@ fn usage_to_unified(usage: OpenAiUsage) -> TokenUsage {
         prompt_tokens: usage.prompt_tokens.max(0) as u32,
         completion_tokens: usage.completion_tokens.max(0) as u32,
         total_tokens: usage.total_tokens.max(0) as u32,
+    }
+}
+
+fn tool_call_to_unified(tool_call: OpenAiToolCall) -> ToolCall {
+    ToolCall {
+        id: tool_call.id.unwrap_or_default(),
+        name: tool_call.function.name,
+        arguments: tool_call.function.arguments,
     }
 }
 
@@ -695,6 +710,20 @@ struct OpenAiResponseMessage {
     role: Option<String>,
     #[serde(default)]
     content: Value,
+    tool_calls: Option<Vec<OpenAiToolCall>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAiToolCall {
+    id: Option<String>,
+    function: OpenAiFunctionCall,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAiFunctionCall {
+    name: String,
+    #[serde(default)]
+    arguments: String,
 }
 
 #[derive(Debug, Deserialize)]

--- a/koduck-ai/src/llm/provider.rs
+++ b/koduck-ai/src/llm/provider.rs
@@ -53,6 +53,7 @@ mod tests {
                 provider: req.provider,
                 model: req.model,
                 message: req.messages.into_iter().next().unwrap(),
+                tool_calls: vec![],
                 finish_reason: "stop".to_string(),
                 usage: Some(TokenUsage {
                     prompt_tokens: 1,

--- a/koduck-ai/src/llm/types.rs
+++ b/koduck-ai/src/llm/types.rs
@@ -29,6 +29,13 @@ pub struct ToolDefinition {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ToolCall {
+    pub id: String,
+    pub name: String,
+    pub arguments: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TokenUsage {
     pub prompt_tokens: u32,
     pub completion_tokens: u32,
@@ -53,6 +60,7 @@ pub struct GenerateResponse {
     pub provider: String,
     pub model: String,
     pub message: ChatMessage,
+    pub tool_calls: Vec<ToolCall>,
     pub finish_reason: String,
     pub usage: Option<TokenUsage>,
 }

--- a/koduck-memory/proto/koduck/memory/v1/memory.proto
+++ b/koduck-memory/proto/koduck/memory/v1/memory.proto
@@ -57,6 +57,7 @@ message QueryMemoryRequest {
   RetrievePolicy retrieve_policy = 6;
   string page_token = 7;
   int32 page_size = 8;
+  QueryIntent query_intent = 20;
 
   reserved 9 to 19;
 }
@@ -138,4 +139,17 @@ enum RetrievePolicy {
   RETRIEVE_POLICY_HYBRID = 3;
 
   reserved 4 to 19;
+}
+
+enum QueryIntent {
+  QUERY_INTENT_UNSPECIFIED = 0;
+  QUERY_INTENT_RECALL = 1;
+  QUERY_INTENT_COMPARE = 2;
+  QUERY_INTENT_DISAMBIGUATE = 3;
+  QUERY_INTENT_CORRECT = 4;
+  QUERY_INTENT_EXPLAIN = 5;
+  QUERY_INTENT_DECIDE = 6;
+  QUERY_INTENT_NONE = 7;
+
+  reserved 8 to 19;
 }

--- a/koduck-memory/src/capability/service.rs
+++ b/koduck-memory/src/capability/service.rs
@@ -10,6 +10,7 @@ use crate::api::{
     RequestMeta, SummarizeMemoryRequest, SummarizeMemoryResponse, UpsertSessionMetaRequest,
     UpsertSessionMetaResponse,
 };
+use crate::api::proto::memory::QueryIntent;
 use crate::config::AppConfig;
 use crate::index::MemoryIndexRepository;
 use crate::memory::{
@@ -23,6 +24,7 @@ use crate::retrieve::{
     AnchorFirstRetriever,
     QueryAnalysis,
     QueryAnalyzer,
+    QueryIntentType,
     RetrieveContext,
     SummaryFirstRetriever,
     match_reason,
@@ -202,6 +204,48 @@ impl MemoryGrpcService {
             "memory rpc failed"
         );
     }
+
+    fn explicit_query_intent(intent: i32) -> Option<QueryIntentType> {
+        match QueryIntent::try_from(intent).ok()? {
+            QueryIntent::Recall => Some(QueryIntentType::Recall),
+            QueryIntent::Compare => Some(QueryIntentType::Compare),
+            QueryIntent::Disambiguate => Some(QueryIntentType::Disambiguate),
+            QueryIntent::Correct => Some(QueryIntentType::Correct),
+            QueryIntent::Explain => Some(QueryIntentType::Explain),
+            QueryIntent::Decide => Some(QueryIntentType::Decide),
+            QueryIntent::None => Some(QueryIntentType::None),
+            QueryIntent::Unspecified => None,
+        }
+    }
+
+    async fn retrieve_global_session_summaries(
+        &self,
+        tenant_id: &str,
+        top_k: i32,
+    ) -> Result<Vec<crate::api::MemoryHit>, Status> {
+        let records = self
+            .index_repo()
+            .list_recent_summaries(tenant_id, top_k.max(1) as i64)
+            .await
+            .map_err(|e| Status::internal(format!("global summary retrieval failed: {e}")))?;
+
+        Ok(records
+            .into_iter()
+            .map(|record| crate::api::MemoryHit {
+                session_id: record.session_id.to_string(),
+                l0_uri: record.source_uri,
+                score: 1.0,
+                match_reasons: vec![
+                    match_reason::SUMMARY_HIT.to_string(),
+                    match_reason::RECENCY_BOOST.to_string(),
+                ],
+                snippet: record
+                    .snippet
+                    .filter(|snippet| !snippet.trim().is_empty())
+                    .unwrap_or(record.summary),
+            })
+            .collect())
+    }
 }
 
 #[tonic::async_trait]
@@ -367,6 +411,49 @@ impl MemoryService for MemoryGrpcService {
             .ok_or_else(|| { guard.error(); Status::invalid_argument("meta is required") })?;
         Self::validate_meta(meta).map_err(|e| { guard.error(); e })?;
 
+        let explicit_intent = Self::explicit_query_intent(req.query_intent);
+
+        if explicit_intent == Some(QueryIntentType::Recall) && req.session_id.trim().is_empty() {
+            let hits = self
+                .retrieve_global_session_summaries(
+                    &meta.tenant_id,
+                    if req.top_k > 0 { req.top_k } else { MAX_TOP_K },
+                )
+                .await
+                .map_err(|status| {
+                    guard.error();
+                    status
+                })?;
+
+            let result = Ok(Response::new(QueryMemoryResponse {
+                ok: true,
+                hits,
+                next_page_token: String::new(),
+                error: None,
+            }));
+
+            let elapsed = started_at.elapsed();
+            let duration_ms = elapsed.as_millis() as u64;
+            record_rpc_call(RpcMethod::QueryMemory, RpcOutcome::Success, elapsed);
+            let detail = format!(
+                "hits_count={},retrieve_policy={},domain_class={},query_intent=recall_global_summaries",
+                result.as_ref().map(|response| response.get_ref().hits.len()).unwrap_or(0),
+                req.retrieve_policy,
+                req.domain_class.trim()
+            );
+            Self::log_rpc_completion(
+                "QueryMemory",
+                &meta.request_id,
+                &req.session_id,
+                &meta.tenant_id,
+                &meta.trace_id,
+                "success",
+                duration_ms,
+                &detail,
+            );
+            return result;
+        }
+
         // Build retrieve context
         let domain_class = req.domain_class.trim().to_string();
 
@@ -394,11 +481,29 @@ impl MemoryService for MemoryGrpcService {
                 );
                 QueryAnalysis::fallback(&domain_class, &req.query_text)
             });
+        let resolved_intent = explicit_intent.unwrap_or_else(|| match query_analysis.intent_type.as_str() {
+            "recall" => QueryIntentType::Recall,
+            "compare" => QueryIntentType::Compare,
+            "disambiguate" => QueryIntentType::Disambiguate,
+            "correct" => QueryIntentType::Correct,
+            "explain" => QueryIntentType::Explain,
+            "decide" => QueryIntentType::Decide,
+            _ => QueryIntentType::None,
+        });
+        let mut relation_types = query_analysis.relation_types;
+        if relation_types.is_empty() {
+            match resolved_intent {
+                QueryIntentType::Compare => relation_types.push("comparison".to_string()),
+                QueryIntentType::Disambiguate => relation_types.push("disambiguation".to_string()),
+                QueryIntentType::Correct => relation_types.push("correction".to_string()),
+                _ => {}
+            }
+        }
         ctx = ctx.with_query_analysis(
             query_analysis.domain_classes,
             query_analysis.entities,
-            query_analysis.relation_types,
-            query_analysis.intent_type,
+            relation_types,
+            resolved_intent.as_str(),
             query_analysis.intent_aux,
             query_analysis.recall_target_type,
         );
@@ -1928,6 +2033,7 @@ mod tests {
                 session_id: sid_str,
                 domain_class: "chat".to_string(),
                 top_k: 5,
+                query_intent: QueryIntent::Unspecified as i32,
                 retrieve_policy: RetrievePolicy::RetrievePolicyDomainFirst as i32,
                 page_token: String::new(),
                 page_size: 0,
@@ -2147,8 +2253,10 @@ mod tests {
                 query_text: "task".to_string(),
                 domain_class: "task".to_string(),
                 top_k: 5,
+                query_intent: QueryIntent::Unspecified as i32,
                 retrieve_policy: 1,
                 page_token: String::new(),
+                page_size: 0,
             })
             .await
             .unwrap()
@@ -2253,8 +2361,10 @@ mod tests {
                 query_text: "rollout".to_string(),
                 domain_class: stored_summary.domain_class.clone(),
                 top_k: 5,
+                query_intent: QueryIntent::Unspecified as i32,
                 retrieve_policy: 1,
                 page_token: String::new(),
+                page_size: 0,
             })
             .await
             .unwrap()
@@ -2639,6 +2749,7 @@ mod tests {
                 session_id: sid_str,
                 domain_class: "chat".to_string(),
                 top_k: 5,
+                query_intent: QueryIntent::Unspecified as i32,
                 retrieve_policy: RetrievePolicy::RetrievePolicySummaryFirst as i32,
                 page_token: String::new(),
                 page_size: 0,
@@ -2707,6 +2818,7 @@ mod tests {
                 session_id: sid_str,
                 domain_class: "chat".to_string(),
                 top_k: 5,
+                query_intent: QueryIntent::Unspecified as i32,
                 retrieve_policy: RetrievePolicy::RetrievePolicySummaryFirst as i32,
                 page_token: String::new(),
                 page_size: 0,
@@ -2809,6 +2921,7 @@ mod tests {
                 session_id: sid_str,
                 domain_class: "chat".to_string(),
                 top_k: 5,
+                query_intent: QueryIntent::Unspecified as i32,
                 retrieve_policy: RetrievePolicy::RetrievePolicySummaryFirst as i32,
                 page_token: String::new(),
                 page_size: 0,
@@ -2823,6 +2936,100 @@ mod tests {
             .hits
             .iter()
             .all(|hit| !hit.match_reasons.contains(&"summary_hit".to_string())));
+    }
+
+    #[tokio::test]
+    async fn query_memory_explicit_recall_returns_global_session_summaries() {
+        let config = test_config();
+        let runtime = RuntimeState::initialize(&config).await.unwrap();
+        let service = MemoryGrpcService::new(config, runtime.clone(), None, Arc::new(RpcMetrics::new()));
+        let index_repo = MemoryIndexRepository::new(runtime.pool());
+
+        let first_session_id = Uuid::new_v4();
+        let first_sid = first_session_id.to_string();
+        let second_session_id = Uuid::new_v4();
+        let second_sid = second_session_id.to_string();
+
+        for (request_id, session_id, title) in [
+            ("t57-seed-1", first_sid.clone(), "Recall session one"),
+            ("t57-seed-2", second_sid.clone(), "Recall session two"),
+        ] {
+            let response = service
+                .upsert_session_meta(Request::new(UpsertSessionMetaRequest {
+                    meta: Some(write_meta_with_idempotency(request_id, &session_id)),
+                    session_id,
+                    title: title.to_string(),
+                    status: "active".to_string(),
+                    parent_session_id: String::new(),
+                    forked_from_session_id: String::new(),
+                    last_message_at: 1700000000000,
+                    extra: HashMap::new(),
+                }))
+                .await
+                .unwrap()
+                .into_inner();
+            assert!(response.ok);
+        }
+
+        for (request_id, session_id, content) in [
+            ("t57-append-1", first_sid.clone(), "We talked about Lu Xun and his essays."),
+            ("t57-append-2", second_sid.clone(), "We compared Rust rollout plans with Go services."),
+        ] {
+            let response = service
+                .append_memory(Request::new(AppendMemoryRequest {
+                    meta: Some(write_meta_with_idempotency(request_id, &session_id)),
+                    session_id,
+                    entries: vec![MemoryEntry {
+                        role: "user".to_string(),
+                        content: content.to_string(),
+                        timestamp: 1700000001000,
+                        metadata: HashMap::new(),
+                    }],
+                }))
+                .await
+                .unwrap()
+                .into_inner();
+            assert!(response.ok);
+        }
+
+        let first_projection =
+            wait_for_summary_projection(&index_repo, "tenant-t33", first_session_id).await;
+        let second_projection =
+            wait_for_summary_projection(&index_repo, "tenant-t33", second_session_id).await;
+        assert!(!first_projection.is_empty());
+        assert!(!second_projection.is_empty());
+
+        let response = service
+            .query_memory(Request::new(QueryMemoryRequest {
+                meta: Some(write_meta_with_idempotency("t57-query", &first_sid)),
+                query_text: "我们之前聊过什么".to_string(),
+                session_id: String::new(),
+                domain_class: "chat".to_string(),
+                top_k: 10,
+                query_intent: QueryIntent::Recall as i32,
+                retrieve_policy: RetrievePolicy::RetrievePolicyDomainFirst as i32,
+                page_token: String::new(),
+                page_size: 0,
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert!(response.ok);
+        assert_eq!(response.hits.len(), 2);
+        assert!(response
+            .hits
+            .iter()
+            .any(|hit| hit.session_id == first_sid && hit.snippet.contains("Lu Xun")));
+        assert!(response
+            .hits
+            .iter()
+            .any(|hit| hit.session_id == second_sid && hit.snippet.contains("Rust")));
+        for hit in &response.hits {
+            assert!(hit.match_reasons.contains(&"summary_hit".to_string()));
+            assert!(hit.match_reasons.contains(&"recency_boost".to_string()));
+            assert_match_reasons_are_closed_set(&hit.match_reasons);
+        }
     }
 
     #[tokio::test]
@@ -2857,6 +3064,7 @@ mod tests {
                 session_id: "not-a-uuid".to_string(),
                 domain_class: "chat".to_string(),
                 top_k: 5,
+                query_intent: QueryIntent::Unspecified as i32,
                 retrieve_policy: RetrievePolicy::RetrievePolicyDomainFirst as i32,
                 page_token: String::new(),
                 page_size: 0,

--- a/koduck-memory/src/index/repository.rs
+++ b/koduck-memory/src/index/repository.rs
@@ -157,6 +157,37 @@ impl MemoryIndexRepository {
         Ok(rows)
     }
 
+    /// List recent summary index records across all sessions for a tenant.
+    ///
+    /// Used by explicit recall-intent queries that should review global session summaries
+    /// instead of running anchor-based retrieval.
+    pub async fn list_recent_summaries(
+        &self,
+        tenant_id: &str,
+        limit: i64,
+    ) -> Result<Vec<MemoryIndexRecord>> {
+        let rows = sqlx::query_as::<_, MemoryIndexRecord>(
+            r#"
+            SELECT
+                id, tenant_id, session_id, memory_unit_id, entry_id,
+                memory_kind, domain_class, summary, snippet,
+                source_uri, score_hint::text AS score_hint,
+                created_at, updated_at
+            FROM memory_index_records
+            WHERE tenant_id = $1
+              AND memory_kind = 'summary'
+            ORDER BY updated_at DESC
+            LIMIT $2
+            "#,
+        )
+        .bind(tenant_id)
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows)
+    }
+
     /// Search index records by tenant_id + domain_class + summary text match.
     ///
     /// Used for SUMMARY_FIRST retrieval strategy.


### PR DESCRIPTION
Closes #869

## Summary
- require explicit memory query intent in koduck-ai tool routing
- add query_intent to ai-memory proto contract
- route recall intent without session scope to global session summaries in koduck-memory
- document the decision in ADR 0020

## Validation
- docker build -t koduck-ai:dev ./koduck-ai
- docker build -t koduck-memory:dev ./koduck-memory